### PR TITLE
Dark Willow changes

### DIFF
--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -9468,17 +9468,31 @@
 		"AbilityManaCost"				"80 100 120 140 160"
 		"AbilityValues"
 		{
+			"placement_count"       
+            {
+                "value"             "12"	// 8
+            }
+			"placement_duration"        "12 13 14 15 16"	// 12
 			"latch_duration"		"1.5 2.0 2.5 3.0 3.5"	// 1.0 1.5 2.0 2.5
 			"latch_range"
 			{
 				"value"		"120"							// 90
 				"affected_by_aoe_increase"	"1"
 			}
-			"damage_per_tick"		"50 60 70 80 90"		// 50 55 60 65
+			"damage_per_tick"		"60 70 80 90 100"		// 50 55 60 65
+			"spell_amp"
+            {
+                "value"                 "10 15 20 25 30"          
+            }
 			"AbilityCooldown"
 			{
 				"value"					"20"	// 22	减少CD
 				"special_bonus_unique_dark_willow_3"			"-6"	// -7
+			}
+			"SpellImmunityType"
+			{
+				"value"		"SPELL_IMMUNITY_ENEMIES_NO"
+				"special_bonus_mireska_bkb_pierce"	"=SPELL_IMMUNITY_ENEMIES_YES"
 			}
 		}
 	}
@@ -9493,9 +9507,25 @@
 			{
 				"value"						"105 180 255 330"	// x1.5
 			}
+			"attack_interval"       "0.25 0.2 0.15 0.1"
+			"target_count"
+            {
+                "value"     "1 2 2 3"
+            }
 			"attack_radius"
 			{
 				"value"		"450"		// 300
+			}
+			"roaming_seconds_per_rotation"              "1.5 1.25 1.0 0.75"
+			"roaming_duration"  
+            {
+                "value"                                         "5.5 6.0 6.5 7.0"
+            }
+			"damage_reduction_pct"	"15 20 25 30"
+			"SpellImmunityType"
+			{
+				"value"		"SPELL_IMMUNITY_ENEMIES_NO"
+				"special_bonus_mireska_bkb_pierce"	"=SPELL_IMMUNITY_ENEMIES_YES"
 			}
 		}
 	}
@@ -9503,6 +9533,7 @@
 	"dark_willow_terrorize"
 	{
 		"MaxLevel" "4"
+		"AbilityCastPoint"              "0.4"
 		"AbilityCooldown"				"60"	// 100 90 80
 		"AbilityValues"
 		{
@@ -9510,7 +9541,19 @@
 				{
 					"value"		"400 450 500 550"
 				}
+				"impact_damage"
+				{
+					"value"			"200 300 400 500"
+					"DamageTypeTooltip"			"DAMAGE_TYPE_MAGICAL"
+					"CalculateSpellDamageTooltip"		"1"
+				}
 				"destination_status_duration"	"2.8 3.0 3.2 3.4"
+				"return_travel_speed"   "1800"
+				"SpellImmunityType"
+				{
+					"value"		"SPELL_IMMUNITY_ENEMIES_NO"
+					"special_bonus_mireska_bkb_pierce"	"=SPELL_IMMUNITY_ENEMIES_YES"
+				}
 		}
 	}
 	// 暗影之境
@@ -9522,9 +9565,25 @@
 		{
 			"AbilityCooldown"
 			{
-				"value"					"20 19 18 17 16"
+				"value"					"19 18 17 16 15"
 			}
+			"fade_time"                 "0.3 0.25 0.2 0.15 0.1"
 			"damage"						"120 200 280 360 440"
+			"SpellImmunityType"
+			{
+				"value"		"SPELL_IMMUNITY_ENEMIES_NO"
+				"special_bonus_mireska_bkb_pierce"	"=SPELL_IMMUNITY_ENEMIES_YES"
+			}
+			"aura_radius"
+            {
+                "special_bonus_facet_dark_willow_throwing_shade"            "=1500"
+                "affected_by_aoe_increase"  "1"
+            }
+            "aura_damage_pct"
+            {
+                "value"                 "0"
+                "special_bonus_facet_dark_willow_throwing_shade"            "=30 =40 =50 =60 =70"
+            }
 		}
 	}
 	// 诅咒王冠
@@ -9533,18 +9592,52 @@
 		"MaxLevel" "5"
 		"AbilityCastRange"				"900"		// 600 625 650 675 增强
 		"AbilityManaCost"				"80 90 100 110 120"
+		"SpellDispellableType"          "SPELL_DISPELLABLE_NO"
 		"AbilityValues"
 		{
 				"stun_duration"
 				{
 					"value"			"1.4 1.8 2.2 2.6 3.0"	// 1.2 1.6 2.0 2.4
 				}
+				"shard_bramble_amount"          
+                {
+                    "special_bonus_shard"           "8"
+                }
+				"accumulated_damage_pct"
+                {
+                    "special_bonus_facet_dark_willow_shattering_crown"  "=35 =45 =55 =65 =75"
+                }
+                "accumulated_damage_pct_ally"
+                {
+                    "special_bonus_facet_dark_willow_shattering_crown"  "=15 =20 =25 =30 =35"
+                }
 				"AbilityCooldown"
 				{
 					"value"				"17 15 13 11 9"
 					"special_bonus_shard"				"-2.0"		// -1.5
 				}
+				"SpellImmunityType"
+				{
+					"value"		"SPELL_IMMUNITY_ENEMIES_NO"
+					"special_bonus_mireska_bkb_pierce"	"=SPELL_IMMUNITY_ENEMIES_YES"
+				}
 		}
+	}
+	"dark_willow_pixie_dust"
+    {
+       	"AbilityValues"
+       	{
+       	    "hp_regen" 
+			{
+				"value"		"150"
+				"special_bonus_mireska_pixie_dust_bonus"	"+100"
+			}
+        	"mana_regen_amp"
+			{
+				"value"		"150"
+				"special_bonus_mireska_pixie_dust_bonus"	"+100"
+			}
+       	}
 	}
 	//=================================================================================================================
 	// Ability: Dazzle 戴泽/暗牧


### PR DESCRIPTION
Dark Willow, while in a fairly decent spot, still seems to suffer from a rather from a lack of utility, crowd control, and most importantly, the ability to stay relevant once enemy bots get upgraded BKBs, after which none of her abilities can do anything. This aims to fix that, although unlike Marci, she will not get access to doing this right away.

General:
-Added an experimental talent that enables all of Dark Willow's abilities to ignore debuff immunity on enemies. Since I've not seen this done before in such a way, this may or may not consistently work. My tests so far, unfortunately, have been inconclusive, so more testing should be done.

Bramble Maze:
-Increased bramble count to 12.
-Increased placement duration.
-Added the removed/unused incoming spell damage for rooted targets.

Shadow Realm:
-Fade time now decreases with level.
-Damage increase aura from Throwing Shade facet has been greatly increased.
-Damage increase aura from Throw Shade facet now becomes more potent with more levels.

Cursed Crown:
-Can no longer be dispelled at all.
-Shard bramble count increased.
-Shattering Crown's damage accumulation from both allies and Dark Willow herself now increases the more it is leveled.

Bedlam:
-Duration and number of targets will both increase with more levels.
-Bedlam will also attack and roam faster with more levels.

Terrorize:
-Improved cast point and projectile return speed.
-Now deals damage by default. (Talent which added the damage is replaced by the experimental BKB-piercing talent.)

Pixie Dust (Innate):
-Added a talent which increases the HP/Mana regen. (Replaces +10 Intelligence talent.)