### PR TITLE
Localization Pass

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -693,9 +693,11 @@
 		"DOTA_Tooltip_ability_ancient_apparition_freezing_aura_duration"		"ACTIVE DURATION:"
 
 		"DOTA_Tooltip_modifier_ancient_apparition_freezing_damage"				"Bonechill Aura"
-		"DOTA_Tooltip_modifier_ancient_apparition_freezing_damage_Description"	"Damaging and slowing the movement speed of nearby enemies. Closer enemies suffer stronger effects."
+		"DOTA_Tooltip_modifier_ancient_apparition_freezing_damage_Description"	"Taking damage over time and movement speed reduced by %dMODIFER_PROPERTY_MOVESPEED_PERCENTAGE%%%. The effects are stronger the closer you are to the aura's source."
 		"DOTA_Tooltip_modifier_ancient_apparition_freezing_aura2"				"Bonechill Aura (Passive)"
 		"DOTA_Tooltip_modifier_ancient_apparition_freezing_aura2_Description"	"Health Restoration and Incoming Heals reduced by %dMODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE%%%. Health regeneration also reduced by %dMODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT%."
+		"DOTA_Tooltip_modifier_ancient_apparition_freezing_damage_aura"			"Bonechill Aura (Active)"
+		"DOTA_Tooltip_modifier_ancient_apparition_freezing_damage_aura_Description"	"Damaging and slowing nearby enemies. Closer enemies are subjected to stronger effects."
 		//冰霜封印
 		"DOTA_Tooltip_ability_ancient_apparition_frost_seal"				"Seal of Frost"
 		"DOTA_Tooltip_ability_ancient_apparition_frost_seal_Description"			"Freeze yourself in place for %stun_duration% seconds, but during that time, gain %damage_reduction%%% damage reduction and heal yourself. Additionally, enemy units are slowed and pulled towards you. After the self-stun expires, deal damage and stun all nearby enemy units"
@@ -1011,8 +1013,12 @@
 		"DOTA_Tooltip_ability_treant_overgrowth_scepter_description"					"Increases Overgrowth Range."
 
 		// 邪影芳灵
-		"DOTA_Tooltip_ability_dark_willow_bedlam_damage_reduction_pct"					"%Damage Reduction:"
-		"DOTA_Tooltip_ability_dark_willow_terrorize_impact_damage"						"DAMAGE:"
+		"DOTA_Tooltip_ability_dark_willow_cursed_crown_shard_description" 				"Cursed Crown creates %shard_bramble_amount% brambles in a %shard_spawn_radius% radius around the target after the counter ends. Cursed Crown cooldown reduced by 2 seconds."
+		"DOTA_Tooltip_ability_dark_willow_bedlam_Description"							"Dark Willow sends her pet wisp to roam around herself for the duration, rapidly attacking nearby enemies and providing her with incoming damage reduction. Bedlam cannot be used while Terrorize is active.
+		"DOTA_Tooltip_ability_dark_willow_bedlam_damage_reduction_pct"					"%INCOMING DAMAGE REDUCTION:"
+		"DOTA_Tooltip_ability_dark_willow_terrorize_Description"						"Dark Willow releases her pet wisp to terrorize her enemies. After a short delay, all enemies in the target area take impact damage, become fearful, and run toward their home fountain. Terrorize cannot be used while Bedlam is active."
+		"DOTA_Tooltip_ability_dark_willow_terrorize_impact_damage"						"IMPACT DAMAGE:"
+		"DOTA_Tooltip_ability_special_bonus_unique_dark_willow_2"           			"+{s:bonus_impact_damage} Terrorize Impact Damage"
 
 		///////////////////////////////////////////////////
 		//
@@ -1469,7 +1475,7 @@
 		"DOTA_Tooltip_ability_yukari_tentacles_root"	"%MOVEMENT SPEED SLOW:"
 
 		"DOTA_Tooltip_modifier_yukari_tentacles"	"Tentacle Portal"
-		"DOTA_Tooltip_modifier_yukari_tentacles_Description"	"Taking damage over time, vision reduced to 600, and movement speed reduced by %dMODIFIER_MOVESPEED_BONUS_PERCENTAGE%%%."
+		"DOTA_Tooltip_modifier_yukari_tentacles_Description"	"Taking damage over time, vision reduced to 600, and movement speed reduced by %dMODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE%%%."
 
 		"DOTA_Tooltip_ability_yukari_morph"							"Moon Phase"
 		"DOTA_Tooltip_ability_yukari_morph_Description" 			"Uses her hidden potential to unleash true power."
@@ -1477,9 +1483,9 @@
 		"DOTA_Tooltip_ability_yukari_morph_bonus_movespeed"						"MOVEMENT SPEED:"
 		"DOTA_Tooltip_ability_yukari_morph_fixed_duration"			"DURATION:"
 		"DOTA_Tooltip_modifier_yukari_morph"						"Moon Phase"
-		"DOTA_Tooltip_modifier_yukari_morph"					"Gaining %dMODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE%%% spell damage and %dMODIFIER_MOVESPEED_BONUS_CONSTANT% movement speed."
+		"DOTA_Tooltip_modifier_yukari_morph_Description"					"Gaining %dMODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE%%% spell damage and %dMODIFIER_MOVESPEED_BONUS_CONSTANT% movement speed."
 		"DOTA_Tooltip_modifier_yukari_morph_real"					"Moon Phase"
-		"DOTA_Tooltip_modifier_yukari_morph_real"					"Gaining %dMODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE%%% spell damage and %dMODIFIER_MOVESPEED_BONUS_CONSTANT% movement speed."
+		"DOTA_Tooltip_modifier_yukari_morph_real_Description"					"Gaining %dMODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE%%% spell damage and %dMODIFIER_MOVESPEED_BONUS_CONSTANT% movement speed."
 
 		// "DOTA_Tooltip_ability_yukari_train" "Yukari's special: Train"
 		// "DOTA_Tooltip_ability_yukari_train_Description" "Summons the train from portal that rides to selected direction. Deals enormous damage to all enemies in the train cars collide."
@@ -1651,7 +1657,6 @@
 		// item_excalibur 咖喱棒
 		"DOTA_Tooltip_Ability_item_excalibur"				"Excalibur"
 		"DOTA_Tooltip_Ability_item_excalibur_Description"							"<h1>Passive: <font color='#a74abd'>Eternal</font></h1>Grants <font color='#f15b47'>%bonus_damage_percent%%%</font> Base Attack Damage. This item cannot be sold or destroyed.\n<h1>Passive: True Strike</h1>Attacks will never miss due to evasion or other effects, unless you attack structures."
-		"DOTA_Tooltip_Ability_item_excalibur_Note0"									"The first hero to pick up a dropped Excalibur and have it in their main inventory becomes the new owner of that Excalibur, and may upgrade it."
 		"DOTA_Tooltip_Ability_item_excalibur_Lore"									"Excalibur serves the chosen king."
 		"DOTA_Tooltip_Ability_item_excalibur_bonus_damage"							"+$damage"
 		"DOTA_Tooltip_Ability_item_excalibur_bonus_spell_amp"						"%+$spell_amp"
@@ -2121,9 +2126,9 @@
 
 		// 圣女白莲
 		"DOTA_Tooltip_Ability_item_saint_orb"										"Saint White Lotus"
-		"DOTA_Tooltip_ability_item_saint_orb_Description"							"<h1>Active: <font color='#FFFF00'>White Lotus</font></h1>Gives a shield to the target, block and reflect most targeted spells back to their caster once, and upon blocking the spell, the target will heal for %heal_percent%% of their max HP. The shield lasts for %duration% seconds.\n<h1>Passive: Lotus Shield</h1>Block and reflect most targeted spells back to their caster, and will heal %heal_percent%% of self max HP. <br><br>Immune to slow effects."
+		"DOTA_Tooltip_ability_item_saint_orb_Description"							"<h1>Active: <font color='#FFFF00'>White Lotus</font></h1>Bestows a shield to the target allied unit. The shield will block and reflect the next targeted spell back to its caster, and upon blocking the spell, the shield then restores %heal_percent%%% of the targets max HP. The shield lasts for up to %duration% seconds or until it is expended.\n<h1>Passive: Lotus Shield</h1>Blocks and reflects most targeted spells back to their caster, and heals the owner for %heal_percent%%% of their max HP upon blocking and reflecting a spell. <br><br>Passively grants complete immunity to movement speed slows."
 		"DOTA_Tooltip_Ability_item_saint_orb_Lore"									"A glowing yellow orb that shines brightly in the darkest of days."
-		"DOTA_Tooltip_Ability_item_saint_orb_Note0"									"It's like a Linken's Sphere and Lotus Orb, but with a more powerful shield."
+		"DOTA_Tooltip_Ability_item_saint_orb_Note0"									"In layman's terms, it's a poor man's Mirror Shield, which also heals whenever it goes off."
 		"DOTA_Tooltip_Ability_item_saint_orb_bonus_all_stats_tooltip"				"+$all"
 		"DOTA_Tooltip_Ability_item_saint_orb_bonus_mana_tooltip"					"+$mana"
 		"DOTA_Tooltip_Ability_item_saint_orb_hp_regen_tooltip"						"+$hp_regen"
@@ -2131,7 +2136,7 @@
 		"DOTA_Tooltip_ability_item_saint_orb_bonus_armor_tooltip"					"+$armor"
 
 		"DOTA_Tooltip_modifier_item_saint_orb_buff"									"White Lotus"
-		"DOTA_Tooltip_modifier_item_saint_orb_buff_Description"						"Block and reflect most targeted spells back to their caster, and will heal 5% of your max health."
+		"DOTA_Tooltip_modifier_item_saint_orb_buff_Description"						"The next targeted spell will be blocked and reflected back to its caster, and will heal you for 8%% of your max health."
 
 		// 嘉心糖
 		"DOTA_Tooltip_Ability_item_candy_candy"							"Diana Candy"
@@ -2145,6 +2150,8 @@
 	    "DOTA_Tooltip_ability_item_hand_of_group_attack_speed"			                "+$attack"
 	    "DOTA_Tooltip_ability_item_hand_of_group_Lore" 									"A wise choice and scientific investment."
 	    "DOTA_Tooltip_ability_item_hand_of_group_Note0"  								"The gold and experience obtained will respect the Gold/XP multipliers set in the game rules."
+
+		"DOTA_Tooltip_ability_item_hand_of_midas_Note2"									"The gold and experience obtained will respect the Gold/XP multipliers set in the game rules."
 
 		// item_bloodstone_v2 血精神石
 		"DOTA_Tooltip_ability_item_bloodstone"										"Godly Bloodstone"
@@ -2175,12 +2182,12 @@
 
 		// item_rapier_ultra 诅咒圣剑
 		"DOTA_Tooltip_ability_item_rapier_ultra"                        "<font color='#e03e2e'>Cursed</font> Rapier"
-		"DOTA_Tooltip_Ability_item_rapier_ultra_Description"            "<h1>Passive: <font color='#a74abd'>Eternal</font></h1>Protected by Mars. Grants <font color='#f15b47'>%bonus_damage_percent%%%</font> bonus base attack damage. Cannot be sold or destroyed.\n<h1>Passive: True Strike</h1>Attacks will never miss due to evasion or other effects, unless you attack structures.\n<h1>Passive: <font color='#e03e2e'>Price of power</font></h1>Great power always comes with a price. <font color='#e03e2e'>This item has a %ruin_chance_tooltip%%% to be completely destroyed on death.</font>"
+		"DOTA_Tooltip_Ability_item_rapier_ultra_Description"            "<h1>Passive: <font color='#a74abd'>Eternal</font></h1>Grants <font color='#f15b47'>%bonus_damage_percent%%%</font> bonus base attack damage. Cannot be sold or destroyed.\n<h1>Passive: True Strike</h1>Attacks will never miss due to evasion or other effects, unless you attack structures.\n<h1>Passive: <font color='#e03e2e'>Price of power</font></h1>Great power always comes with a price. <font color='#e03e2e'>This item has a %ruin_chance_tooltip%%% to be completely destroyed on death.</font>"
 		"DOTA_Tooltip_ability_item_rapier_ultra_Lore"					"Not covered by warranty."
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bonus_damage"			"+$damage"
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bonus_spell_amp"           "%+$spell_amp"
-		"DOTA_Tooltip_Ability_item_rapier_ultra_Note0"					"You've got to ask yourself one question: do you feel lucky?"
-		"DOTA_Tooltip_Ability_item_rapier_ultra_Note1"					"Cursed Rapiers can never be destroyed, sold, or moved into the backpack."
+		"DOTA_Tooltip_Ability_item_rapier_ultra_Note0"					"Cursed Rapiers can never be destroyed, sold, or moved into the backpack."
+		"DOTA_Tooltip_Ability_item_rapier_ultra_Note2"				"If a Cursed Rapier is built in your stash and you cannot collect it, right-click and select 'Drop from Stash'."
 
 		// item_rapier_ultra_bot 解放的诅咒圣剑
 		"DOTA_Tooltip_ability_item_rapier_ultra_bot"                        "<font color='#CC7A00'>Liberated</font> Rapier"
@@ -2190,6 +2197,7 @@
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_bonus_spell_amp"           "%+$spell_amp"
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_Note0"					"A cursed rapier liberated by fusing the power of light and darkness."
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_Note1"					"Liberated Rapiers can never be destroyed, sold, or moved into the backpack."
+		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_Note2"				"If a Liberated Rapier is built in your stash and you cannot collect it, right-click and select 'Drop from Stash'."
 
 		// item_rapier_ultra_bot_1 解放的诅咒圣剑
 		"DOTA_Tooltip_ability_item_rapier_ultra_bot_1"                        "<font color='#CC7A00'>Liberated</font> Rapier"
@@ -2197,8 +2205,9 @@
 		"DOTA_Tooltip_ability_item_rapier_ultra_bot_1_Lore"					"You're silly! My cursed rapier is now permanent!"
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_bonus_damage"			"+$damage"
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_bonus_spell_amp"           "%+$spell_amp"
-		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1Note0"					"A cursed rapier liberated by fusing the power of light and darkness."
+		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_Note0"					"A cursed rapier liberated by fusing the power of light and darkness."
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_Note1"					"Liberated Rapiers can never be destroyed, sold, or moved into the backpack."
+		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_Note2"				"If a Liberated Rapier is built in your stash and you cannot collect it, right-click and select 'Drop from Stash'."
 
 		// item_bfury_ultra 救世狂战
 		"DOTA_Tooltip_ability_item_bfury_ultra"                         "<font color='#F24332'>Worldcleaver</font>"

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -588,12 +588,13 @@
 
 		//普通一拳
 		"DOTA_Tooltip_ability_dark_seer_normal_punch2"									"Normal Punch"
-		"DOTA_Tooltip_ability_dark_seer_normal_punch2_Description"						"Passively causes your next attack to damage and stun the target, while knocking an illusion out of them. Knockback distance is relative to how much you have moved prior to the attack."
-		"DOTA_Tooltip_ability_dark_seer_normal_punch2_Note0"							"Not affected by spell amplification, spell lifesteal."
-		"DOTA_Tooltip_ability_dark_seer_normal_punch2_max_stun"							"STUN DURATION:"
+		"DOTA_Tooltip_ability_dark_seer_normal_punch2_Description"						"Passively causes your next attack to damage and stun the target, while knocking an illusion out of them. Base damage, knockback distance, and stun duration are relative to how much you have moved prior to the attack."
+		"DOTA_Tooltip_ability_dark_seer_normal_punch2_Note0"							"Not affected by spell amplification nor spell lifesteal."
+		"DOTA_Tooltip_ability_dark_seer_normal_punch2_Lore"								"As a young soldier, long before he became a leader of his people, Ish'Kafel was known amongst his fellow recruits as quite the pugilist."
+		"DOTA_Tooltip_ability_dark_seer_normal_punch2_max_stun"							"MAX STUN DURATION:"
 		"DOTA_Tooltip_ability_dark_seer_normal_punch2_knockback_distance"				"MAX KNOCKBACK DISTANCE:"
 		"DOTA_Tooltip_ability_dark_seer_normal_punch2_illusion_duration"				"ILLUSION DURATION:"
-		"DOTA_Tooltip_ability_dark_seer_normal_punch2_max_damage"						"BASE DAMAGE:"
+		"DOTA_Tooltip_ability_dark_seer_normal_punch2_max_damage"						"MAX BASE DAMAGE:"
 		"DOTA_Tooltip_ability_dark_seer_normal_punch2_ad"								"BONUS DAMAGE PER ATTACK DAMAGE:"
 		//妙手空空
 		"DOTA_Tooltip_ability_bounty_hunter_cutpurse2"										"Cutpurse"
@@ -602,6 +603,7 @@
 
 		//神龙之血
 		"DOTA_Tooltip_ability_dragon_knight_inherited_vigor2"								"Dragon Blood"
+		"DOTA_Tooltip_ability_dragon_knight_inherited_vigor2_Lore"							"Slyrak's blood still courses through Davion's veins, giving him twice the vitality of an ordinary knight."
 		"DOTA_Tooltip_ability_dragon_knight_inherited_vigor2_Description"					"Passively grants increased health regeneration and armor."
 		"DOTA_Tooltip_ability_dragon_knight_inherited_vigor2_base_health_regen"				"HP REGEN:"
 		"DOTA_Tooltip_ability_dragon_knight_inherited_vigor2_base_armor"					"ARMOR:"
@@ -620,9 +622,10 @@
 		"DOTA_Tooltip_ability_clinkz_burning_barrage2_damage_pct"								"%DAMAGE PER ARROW:"
 		//冰爆
 		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion"				"Ice Explosion"
-		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_Description"	"Each attack has a 35% chance to summon an icy blast to strike a random area around you, dealing damage and slowing enemies for 1 second. Passively grants attack speed"
+		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_Description"	"Each attack has a 35% chance to summon an icy blast to strike a random area around you, dealing damage and slowing enemies for 1 second. Passively grants attack speed."
 		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_damage"		"BASE DAMAGE:"
 		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_ad"			"BONUS DAMAGE PER ATTACK DAMAGE:"
+		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_attack_speed"		"BONUS ATTACK SPEED:"
 		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_random_radius"		"ICE BLAST SPAWN RADIUS:"
 		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_explosion_radius"	"ICE BLAST EXPLOSION RADIUS:"
 		//诅咒之雨
@@ -658,10 +661,11 @@
 		"DOTA_Tooltip_ability_axe_one_man_army2_Description"			"Gain Strength based on armor."
 		"DOTA_Tooltip_ability_axe_one_man_army2_armor_pct_as_strength"	"%ARMOR TO STRENGTH:"
 		//人工神符
-		"DOTA_Tooltip_ability_arc_warden_scepter2"	"Manufacture Rune"
-		"DOTA_Tooltip_ability_arc_warden_scepter2_Description"	"Creates a random rune in front of you."
+		"DOTA_Tooltip_ability_arc_warden_scepter2"	"Rune Forge"
+		"DOTA_Tooltip_ability_arc_warden_scepter2_Description"	"Creates a random rune in front of you. Runes created this way will despawn in 20 seconds if not activated."
 		"DOTA_Tooltip_ability_arc_warden_scepter2_Note0"	"Resulting Rune be any Power Rune, as well as a Bounty Rune, Water Rune, or Rune of Wisdom."
 		"DOTA_Tooltip_ability_arc_warden_scepter2_Note1"	"Runes of Wisdom function as if a Shrine of Wisdom was captured, but if activated before 7:00, no XP is given."
+		"DOTA_Tooltip_ability_arc_warden_scepter2_Note2"	"All runes have an equal chance of spawning from this ability, and the same rune can appear twice or more in a row."
 		//魔法扰动
 		"DOTA_Tooltip_ability_antimage_mana_turbulence"	"Mana Turbulence"
 		"DOTA_Tooltip_ability_antimage_mana_turbulence_Description"	"Deals damage to enemy units in a fan-shaped area of effect while reducing their skill damage, increasing their mana costs and cooldowns, and slowing them."
@@ -693,7 +697,7 @@
 		"DOTA_Tooltip_ability_ancient_apparition_freezing_aura_duration"		"ACTIVE DURATION:"
 
 		"DOTA_Tooltip_modifier_ancient_apparition_freezing_damage"				"Bonechill Aura"
-		"DOTA_Tooltip_modifier_ancient_apparition_freezing_damage_Description"	"Taking damage over time and movement speed reduced by %dMODIFER_PROPERTY_MOVESPEED_PERCENTAGE%%%. The effects are stronger the closer you are to the aura's source."
+		"DOTA_Tooltip_modifier_ancient_apparition_freezing_damage_Description"	"Taking damage over time and movement speed reduced by %dMODIFIER_PROPERTY_MOVESPEED_PERCENTAGE%%%. The effects are stronger the closer you are to the aura's source."
 		"DOTA_Tooltip_modifier_ancient_apparition_freezing_aura2"				"Bonechill Aura (Passive)"
 		"DOTA_Tooltip_modifier_ancient_apparition_freezing_aura2_Description"	"Health Restoration and Incoming Heals reduced by %dMODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE%%%. Health regeneration also reduced by %dMODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT%."
 		"DOTA_Tooltip_modifier_ancient_apparition_freezing_damage_aura"			"Bonechill Aura (Active)"
@@ -1013,10 +1017,7 @@
 		"DOTA_Tooltip_ability_treant_overgrowth_scepter_description"					"Increases Overgrowth Range."
 
 		// 邪影芳灵
-		"DOTA_Tooltip_ability_dark_willow_cursed_crown_shard_description" 				"Cursed Crown creates %shard_bramble_amount% brambles in a %shard_spawn_radius% radius around the target after the counter ends. Cursed Crown cooldown reduced by 2 seconds."
-		"DOTA_Tooltip_ability_dark_willow_bedlam_Description"							"Dark Willow sends her pet wisp to roam around herself for the duration, rapidly attacking nearby enemies and providing her with incoming damage reduction. Bedlam cannot be used while Terrorize is active.
 		"DOTA_Tooltip_ability_dark_willow_bedlam_damage_reduction_pct"					"%INCOMING DAMAGE REDUCTION:"
-		"DOTA_Tooltip_ability_dark_willow_terrorize_Description"						"Dark Willow releases her pet wisp to terrorize her enemies. After a short delay, all enemies in the target area take impact damage, become fearful, and run toward their home fountain. Terrorize cannot be used while Bedlam is active."
 		"DOTA_Tooltip_ability_dark_willow_terrorize_impact_damage"						"IMPACT DAMAGE:"
 		"DOTA_Tooltip_ability_special_bonus_unique_dark_willow_2"           			"+{s:bonus_impact_damage} Terrorize Impact Damage"
 

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -588,13 +588,12 @@
 
 		//普通一拳
 		"DOTA_Tooltip_ability_dark_seer_normal_punch2"									"Normal Punch"
-		"DOTA_Tooltip_ability_dark_seer_normal_punch2_Description"						"Passively causes your next attack to damage and stun the target, while knocking an illusion out of them. Base damage, knockback distance, and stun duration are relative to how much you have moved prior to the attack."
+		"DOTA_Tooltip_ability_dark_seer_normal_punch2_Description"						"Passively causes your next attack to damage and stun the target, while knocking an illusion out of them."
 		"DOTA_Tooltip_ability_dark_seer_normal_punch2_Note0"							"Not affected by spell amplification nor spell lifesteal."
-		"DOTA_Tooltip_ability_dark_seer_normal_punch2_Lore"								"As a young soldier, long before he became a leader of his people, Ish'Kafel was known amongst his fellow recruits as quite the pugilist."
-		"DOTA_Tooltip_ability_dark_seer_normal_punch2_max_stun"							"MAX STUN DURATION:"
+		"DOTA_Tooltip_ability_dark_seer_normal_punch2_max_stun"							"STUN DURATION:"
 		"DOTA_Tooltip_ability_dark_seer_normal_punch2_knockback_distance"				"MAX KNOCKBACK DISTANCE:"
 		"DOTA_Tooltip_ability_dark_seer_normal_punch2_illusion_duration"				"ILLUSION DURATION:"
-		"DOTA_Tooltip_ability_dark_seer_normal_punch2_max_damage"						"MAX BASE DAMAGE:"
+		"DOTA_Tooltip_ability_dark_seer_normal_punch2_max_damage"						"BASE DAMAGE:"
 		"DOTA_Tooltip_ability_dark_seer_normal_punch2_ad"								"BONUS DAMAGE PER ATTACK DAMAGE:"
 		//妙手空空
 		"DOTA_Tooltip_ability_bounty_hunter_cutpurse2"										"Cutpurse"
@@ -665,7 +664,6 @@
 		"DOTA_Tooltip_ability_arc_warden_scepter2_Description"	"Creates a random rune in front of you. Runes created this way will despawn in 20 seconds if not activated."
 		"DOTA_Tooltip_ability_arc_warden_scepter2_Note0"	"Resulting Rune be any Power Rune, as well as a Bounty Rune, Water Rune, or Rune of Wisdom."
 		"DOTA_Tooltip_ability_arc_warden_scepter2_Note1"	"Runes of Wisdom function as if a Shrine of Wisdom was captured, but if activated before 7:00, no XP is given."
-		"DOTA_Tooltip_ability_arc_warden_scepter2_Note2"	"All runes have an equal chance of spawning from this ability, and the same rune can appear twice or more in a row."
 		//魔法扰动
 		"DOTA_Tooltip_ability_antimage_mana_turbulence"	"Mana Turbulence"
 		"DOTA_Tooltip_ability_antimage_mana_turbulence_Description"	"Deals damage to enemy units in a fan-shaped area of effect while reducing their skill damage, increasing their mana costs and cooldowns, and slowing them."
@@ -697,11 +695,9 @@
 		"DOTA_Tooltip_ability_ancient_apparition_freezing_aura_duration"		"ACTIVE DURATION:"
 
 		"DOTA_Tooltip_modifier_ancient_apparition_freezing_damage"				"Bonechill Aura"
-		"DOTA_Tooltip_modifier_ancient_apparition_freezing_damage_Description"	"Taking damage over time and movement speed reduced by %dMODIFIER_PROPERTY_MOVESPEED_PERCENTAGE%%%. The effects are stronger the closer you are to the aura's source."
+		"DOTA_Tooltip_modifier_ancient_apparition_freezing_damage_Description"	"Damaging and slowing the movement speed of nearby enemies. Closer enemies suffer stronger effects."
 		"DOTA_Tooltip_modifier_ancient_apparition_freezing_aura2"				"Bonechill Aura (Passive)"
 		"DOTA_Tooltip_modifier_ancient_apparition_freezing_aura2_Description"	"Health Restoration and Incoming Heals reduced by %dMODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE%%%. Health regeneration also reduced by %dMODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT%."
-		"DOTA_Tooltip_modifier_ancient_apparition_freezing_damage_aura"			"Bonechill Aura (Active)"
-		"DOTA_Tooltip_modifier_ancient_apparition_freezing_damage_aura_Description"	"Damaging and slowing nearby enemies. Closer enemies are subjected to stronger effects."
 		//冰霜封印
 		"DOTA_Tooltip_ability_ancient_apparition_frost_seal"				"Seal of Frost"
 		"DOTA_Tooltip_ability_ancient_apparition_frost_seal_Description"			"Freeze yourself in place for %stun_duration% seconds, but during that time, gain %damage_reduction%%% damage reduction and heal yourself. Additionally, enemy units are slowed and pulled towards you. After the self-stun expires, deal damage and stun all nearby enemy units"
@@ -1019,7 +1015,7 @@
 		// 邪影芳灵
 		"DOTA_Tooltip_ability_dark_willow_bedlam_damage_reduction_pct"					"%INCOMING DAMAGE REDUCTION:"
 		"DOTA_Tooltip_ability_dark_willow_terrorize_impact_damage"						"IMPACT DAMAGE:"
-		"DOTA_Tooltip_ability_special_bonus_unique_dark_willow_2"           			"+{s:bonus_impact_damage} Terrorize Impact Damage"
+		"DOTA_Tooltip_ability_special_bonus_unique_dark_willow_2"						"+{s:bonus_impact_damage} Terrorize Impact Damage"
 
 		///////////////////////////////////////////////////
 		//
@@ -1484,9 +1480,9 @@
 		"DOTA_Tooltip_ability_yukari_morph_bonus_movespeed"						"MOVEMENT SPEED:"
 		"DOTA_Tooltip_ability_yukari_morph_fixed_duration"			"DURATION:"
 		"DOTA_Tooltip_modifier_yukari_morph"						"Moon Phase"
-		"DOTA_Tooltip_modifier_yukari_morph_Description"					"Gaining %dMODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE%%% spell damage and %dMODIFIER_MOVESPEED_BONUS_CONSTANT% movement speed."
+		"DOTA_Tooltip_modifier_yukari_morph_Description"			"Gaining %dMODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE%%% spell damage and %dMODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT% movement speed."
 		"DOTA_Tooltip_modifier_yukari_morph_real"					"Moon Phase"
-		"DOTA_Tooltip_modifier_yukari_morph_real_Description"					"Gaining %dMODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE%%% spell damage and %dMODIFIER_MOVESPEED_BONUS_CONSTANT% movement speed."
+		"DOTA_Tooltip_modifier_yukari_morph_real_Description"		"Gaining %dMODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE%%% spell damage and %dMODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT% movement speed."
 
 		// "DOTA_Tooltip_ability_yukari_train" "Yukari's special: Train"
 		// "DOTA_Tooltip_ability_yukari_train_Description" "Summons the train from portal that rides to selected direction. Deals enormous damage to all enemies in the train cars collide."
@@ -2152,8 +2148,6 @@
 	    "DOTA_Tooltip_ability_item_hand_of_group_Lore" 									"A wise choice and scientific investment."
 	    "DOTA_Tooltip_ability_item_hand_of_group_Note0"  								"The gold and experience obtained will respect the Gold/XP multipliers set in the game rules."
 
-		"DOTA_Tooltip_ability_item_hand_of_midas_Note2"									"The gold and experience obtained will respect the Gold/XP multipliers set in the game rules."
-
 		// item_bloodstone_v2 血精神石
 		"DOTA_Tooltip_ability_item_bloodstone"										"Godly Bloodstone"
 		"DOTA_Tooltip_ability_item_bloodstone_bonus_aoe"							"+$aoe_bonus"
@@ -2187,8 +2181,8 @@
 		"DOTA_Tooltip_ability_item_rapier_ultra_Lore"					"Not covered by warranty."
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bonus_damage"			"+$damage"
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bonus_spell_amp"           "%+$spell_amp"
-		"DOTA_Tooltip_Ability_item_rapier_ultra_Note0"					"Cursed Rapiers can never be destroyed, sold, or moved into the backpack."
-		"DOTA_Tooltip_Ability_item_rapier_ultra_Note2"				"If a Cursed Rapier is built in your stash and you cannot collect it, right-click and select 'Drop from Stash'."
+		"DOTA_Tooltip_Ability_item_rapier_ultra_Note0"					"You've got to ask yourself one question: do you feel lucky?"
+		"DOTA_Tooltip_Ability_item_rapier_ultra_Note1"					"Cursed Rapiers can never be destroyed, sold, or moved into the backpack."
 
 		// item_rapier_ultra_bot 解放的诅咒圣剑
 		"DOTA_Tooltip_ability_item_rapier_ultra_bot"                        "<font color='#CC7A00'>Liberated</font> Rapier"
@@ -2198,7 +2192,6 @@
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_bonus_spell_amp"           "%+$spell_amp"
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_Note0"					"A cursed rapier liberated by fusing the power of light and darkness."
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_Note1"					"Liberated Rapiers can never be destroyed, sold, or moved into the backpack."
-		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_Note2"				"If a Liberated Rapier is built in your stash and you cannot collect it, right-click and select 'Drop from Stash'."
 
 		// item_rapier_ultra_bot_1 解放的诅咒圣剑
 		"DOTA_Tooltip_ability_item_rapier_ultra_bot_1"                        "<font color='#CC7A00'>Liberated</font> Rapier"
@@ -2206,9 +2199,8 @@
 		"DOTA_Tooltip_ability_item_rapier_ultra_bot_1_Lore"					"You're silly! My cursed rapier is now permanent!"
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_bonus_damage"			"+$damage"
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_bonus_spell_amp"           "%+$spell_amp"
-		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_Note0"					"A cursed rapier liberated by fusing the power of light and darkness."
+		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1Note0"					"A cursed rapier liberated by fusing the power of light and darkness."
 		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_Note1"					"Liberated Rapiers can never be destroyed, sold, or moved into the backpack."
-		"DOTA_Tooltip_Ability_item_rapier_ultra_bot_1_Note2"				"If a Liberated Rapier is built in your stash and you cannot collect it, right-click and select 'Drop from Stash'."
 
 		// item_bfury_ultra 救世狂战
 		"DOTA_Tooltip_ability_item_bfury_ultra"                         "<font color='#F24332'>Worldcleaver</font>"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -605,6 +605,7 @@
 
 		//神龙之血
 		"DOTA_Tooltip_ability_dragon_knight_inherited_vigor2"						"神龙之血"
+		"DOTA_Tooltip_ability_dragon_knight_inherited_vigor2_Lore"					"斯莱克萨的血仍流淌在达维安的血管中，使他拥有普通骑士两倍的生命恢复和护甲。"
 		"DOTA_Tooltip_ability_dragon_knight_inherited_vigor2_Description"			"神龙的生命之血提升了龙骑士的生命恢复和护甲。每升一级，两个数值都将提升%level_mult%，在古龙形态下还有倍数加成。"
 		"DOTA_Tooltip_ability_dragon_knight_inherited_vigor2_base_health_regen"		"生命恢复："
 		"DOTA_Tooltip_ability_dragon_knight_inherited_vigor2_base_armor"				"护甲："
@@ -623,10 +624,11 @@
 		"DOTA_Tooltip_ability_clinkz_burning_barrage2_damage_pct"								"%每支箭矢伤害："
 		//冰爆
 		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion"				"冰爆"
-		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_Description"	"增加%attack_speed%攻速，攻击有35%概率召唤一个冰爆打击随机区域，造成伤害和1秒减速"
+		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_Description"	"增加额外攻击速度，攻击有35%概率召唤一个冰爆打击随机区域，造成伤害和1秒减速"
 		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_damage"		"伤害："
 		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_ad"			"攻击力伤害加成倍率："
-		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_random_radius"		"随机范围："
+		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_attack_speed"		"额外攻击速度："
+		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_random_radius"		"冰爆发射范围："
 		"DOTA_Tooltip_ability_crystal_maiden_ice_explosion_explosion_radius"	"冰爆伤害范围："
 		//诅咒之雨
 		"DOTA_Tooltip_ability_dazzle_rain_of_vermin"				"诅咒之雨"
@@ -660,10 +662,12 @@
 		"DOTA_Tooltip_ability_axe_one_man_army2"			"一人之军"
 		"DOTA_Tooltip_ability_axe_one_man_army2_Description"		"获得护甲一定百分比的力量"
 		"DOTA_Tooltip_ability_axe_one_man_army2_armor_pct_as_strength"	"%护甲力量加成："
-
+		//人工神符
 		"DOTA_Tooltip_ability_arc_warden_scepter2"	"人工神符"
-		"DOTA_Tooltip_ability_arc_warden_scepter2_Description"	"创建一个随机神符"
-
+		"DOTA_Tooltip_ability_arc_warden_scepter2_Description"	"创建一个随机神符，神符创建后20秒后会消失"
+		"DOTA_Tooltip_ability_arc_warden_scepter2_Note0"	"创建的神符可以是力量神符，赏金神符，水神符，或者智慧神符。"
+		"DOTA_Tooltip_ability_arc_warden_scepter2_Note1"	"智慧神符的效果类似于智慧神殿，但如果激活时间早于7:00，则不会获得经验。"
+		//魔法扰动
 		"DOTA_Tooltip_ability_antimage_mana_turbulence"	"魔法扰动"
 		"DOTA_Tooltip_ability_antimage_mana_turbulence_Description"	"对扇形区域的敌方单位造成伤害，并施加debuff，降低其技能伤害，增加其魔法消耗,增加其技能cd,并造成%slow_duration%秒减速"
 		"DOTA_Tooltip_ability_antimage_mana_turbulence_damage"	"基础伤害："
@@ -1000,6 +1004,7 @@
 		// 邪影芳灵
 		"DOTA_Tooltip_ability_dark_willow_bedlam_damage_reduction_pct"					"%伤害减免："
 		"DOTA_Tooltip_ability_dark_willow_terrorize_impact_damage"						"伤害："
+		"DOTA_Tooltip_ability_special_bonus_unique_dark_willow_2"						"+{s:bonus_impact_damage} 恐吓击中伤害"
 
 		///////////////////////////////////////////////////
 		//
@@ -1282,13 +1287,18 @@
 		"DOTA_Tooltip_ability_yukari_tentacles_duration"	"间隙持续时间:"
 		"DOTA_Tooltip_ability_yukari_tentacles_root"	"%移动速度降低:"
 
+		"DOTA_Tooltip_modifier_yukari_tentacles"	"静观其变之眼"
+		"DOTA_Tooltip_modifier_yukari_tentacles_Description"	"持续受到伤害，视野范围降低为600，移动速度降低%dMODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE%%%"
+
 		"DOTA_Tooltip_ability_yukari_morph"							"月相"
 		"DOTA_Tooltip_ability_yukari_morph_Description"				"使用隐藏潜能释放真正的力量"
 		"DOTA_Tooltip_ability_yukari_morph_amp"					"%技能增强:"
 		"DOTA_Tooltip_ability_yukari_morph_bonus_movespeed"						"移速增加:"
 		"DOTA_Tooltip_ability_yukari_morph_fixed_duration"			"持续时间:"
 		"DOTA_Tooltip_modifier_yukari_morph"						"月相"
+		"DOTA_Tooltip_modifier_yukari_morph_Description"			"获得%dMODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE%%%技能增强和%dMODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT%移速增加"
 		"DOTA_Tooltip_modifier_yukari_morph_real"					"月相"
+		"DOTA_Tooltip_modifier_yukari_morph_real_Description"		"获得%dMODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE%%%技能增强和%dMODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT%移速增加"
 
 		// "DOTA_Tooltip_ability_yukari_train"	"废线「废弃车站下车之旅」"
 		// "DOTA_Tooltip_ability_yukari_train_Description"	"召唤从入口驶向选定方向的列车,对路线上的敌人造成大量伤害."
@@ -1642,7 +1652,6 @@
 		// item_excalibur 咖喱棒
 		"DOTA_Tooltip_Ability_item_excalibur"				"EX咖喱棒"
 		"DOTA_Tooltip_Ability_item_excalibur_Description"							"<h1>被动：<font color='#a74abd'>永恒之力</font></h1>受到来自战争之神的神秘力量庇护，获得<font color='#f15b47'>%bonus_damage_percent%%%</font>基础攻击力加成，不能出售或销毁。\n<h1>被动：克敌机先</h1>攻击不会因闪避或其他效果而落空。</font> \n<h1>被动：可塑性</h1>能够使用暗影组件进行诅咒强化"
-		"DOTA_Tooltip_Ability_item_excalibur_Note0"									"第一个捡起掉落的EX咖喱棒并将其放入主物品栏的英雄将成为EX咖喱棒的新主人。"
 		"DOTA_Tooltip_Ability_item_excalibur_Lore"									"咖喱棒效忠于被选中的王者。"
 		"DOTA_Tooltip_Ability_item_excalibur_bonus_damage"							"+$damage"
 		"DOTA_Tooltip_Ability_item_excalibur_bonus_spell_amp"						"%+$spell_amp"

--- a/game/scripts/vscripts/abilities/ancient_apparition_freezing_aura.lua
+++ b/game/scripts/vscripts/abilities/ancient_apparition_freezing_aura.lua
@@ -1,4 +1,4 @@
-ancient_apparition_freezing_aura = class( {} )
+ancient_apparition_freezing_aura = class({})
 
 function ancient_apparition_freezing_aura:GetIntrinsicModifierName()
 	return "modifier_ancient_apparition_freezing_aura"
@@ -8,22 +8,31 @@ end
 function ancient_apparition_freezing_aura:OnSpellStart()
 	--声音
 	-- EmitSoundOn( "Hero_EarthSpirit.Magnetize.Cast", self:GetCaster() )
-	self:GetCaster():AddNewModifier(self:GetCaster(),self,"modifier_ancient_apparition_freezing_damage_aura",{duration=8})
+	self:GetCaster():AddNewModifier(self:GetCaster(), self, "modifier_ancient_apparition_freezing_damage_aura",
+		{ duration = 8 })
 end
+
 ---------------------------------------------------------------------------------------
 modifier_ancient_apparition_freezing_damage_aura = class({})
-LinkLuaModifier("modifier_ancient_apparition_freezing_damage_aura", "abilities/ancient_apparition_freezing_aura", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_ancient_apparition_freezing_damage_aura", "abilities/ancient_apparition_freezing_aura",
+	LUA_MODIFIER_MOTION_NONE)
 --无法驱散
-function  modifier_ancient_apparition_freezing_damage_aura:IsPurgable() return false end
+function modifier_ancient_apparition_freezing_damage_aura:IsPurgable() return false end
+
+-- 隐藏
+function modifier_ancient_apparition_freezing_damage_aura:IsHidden() return true end
+
 --特效
 function modifier_ancient_apparition_freezing_damage_aura:GetEffectName()
 	return "particles/econ/items/crystal_maiden/crystal_maiden_maiden_of_icewrack/maiden_freezing_field_snow_arcana1.vpcf"
 end
+
 --当创建
 function modifier_ancient_apparition_freezing_damage_aura:OnCreated(keys)
 	if not IsServer() then return end
-	EmitSoundOn( "Hero_Lich.ChainFrostLoop", self:GetCaster() )
+	EmitSoundOn("Hero_Lich.ChainFrostLoop", self:GetCaster())
 end
+
 --当销毁
 function modifier_ancient_apparition_freezing_damage_aura:OnDestroy(keys)
 	if not IsServer() then return end
@@ -31,78 +40,100 @@ function modifier_ancient_apparition_freezing_damage_aura:OnDestroy(keys)
 end
 
 --残留时间
-function  modifier_ancient_apparition_freezing_damage_aura:GetAuraDuration() return 0 end
+function modifier_ancient_apparition_freezing_damage_aura:GetAuraDuration() return 0 end
+
 --光环范围
-function  modifier_ancient_apparition_freezing_damage_aura:GetAuraRadius() return 800 end
+function modifier_ancient_apparition_freezing_damage_aura:GetAuraRadius() return 800 end
+
 --是光环
-function  modifier_ancient_apparition_freezing_damage_aura:IsAura() return true end
+function modifier_ancient_apparition_freezing_damage_aura:IsAura() return true end
+
 --光环buff
-function  modifier_ancient_apparition_freezing_damage_aura:GetModifierAura() return "modifier_ancient_apparition_freezing_damage" end
+function modifier_ancient_apparition_freezing_damage_aura:GetModifierAura() return
+	"modifier_ancient_apparition_freezing_damage" end
+
 --光环对象
-function  modifier_ancient_apparition_freezing_damage_aura:GetAuraSearchTeam() return DOTA_UNIT_TARGET_TEAM_ENEMY end
-function  modifier_ancient_apparition_freezing_damage_aura:GetAuraSearchType() return DOTA_UNIT_TARGET_BASIC+1 end
-function  modifier_ancient_apparition_freezing_damage_aura:GetAuraSearchFlags() return 48 end
+function modifier_ancient_apparition_freezing_damage_aura:GetAuraSearchTeam() return DOTA_UNIT_TARGET_TEAM_ENEMY end
+
+function modifier_ancient_apparition_freezing_damage_aura:GetAuraSearchType() return DOTA_UNIT_TARGET_BASIC + 1 end
+
+function modifier_ancient_apparition_freezing_damage_aura:GetAuraSearchFlags() return 48 end
+
 ---------------------------------------------------------------------------------------------------------
 modifier_ancient_apparition_freezing_damage = class({})
-LinkLuaModifier("modifier_ancient_apparition_freezing_damage", "abilities/ancient_apparition_freezing_aura", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_ancient_apparition_freezing_damage", "abilities/ancient_apparition_freezing_aura",
+	LUA_MODIFIER_MOTION_NONE)
 --无法驱散
-function  modifier_ancient_apparition_freezing_damage:IsPurgable() return false end
+function modifier_ancient_apparition_freezing_damage:IsPurgable() return false end
+
 --函数声明
 function modifier_ancient_apparition_freezing_damage:DeclareFunctions()
-	local funcs = 
+	local funcs =
 	{
 		MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE,
 	}
 	return funcs
 end
+
 --当创建
 function modifier_ancient_apparition_freezing_damage:OnCreated(keys)
 	-- if not IsServer() then return end
 	self:OnIntervalThink()
 	self:StartIntervalThink(1)
 end
+
 --think
-function  modifier_ancient_apparition_freezing_damage:OnIntervalThink()
-	self.percentage = 1 - math.max((CalcDistanceBetweenEntityOBB(self:GetParent(),self:GetCaster())-100),0) /800
+function modifier_ancient_apparition_freezing_damage:OnIntervalThink()
+	self.percentage = 1 - math.max((CalcDistanceBetweenEntityOBB(self:GetParent(), self:GetCaster()) - 100), 0) / 800
 	if not IsServer() then return end
 	--造成伤害
-	local damage = self:GetAbility():GetSpecialValueFor("damage")+self:GetCaster():GetAverageTrueAttackDamage(nil)*self:GetAbility():GetSpecialValueFor("ad")
-	local damageInfo ={victim = self:GetParent(),attacker = self:GetCaster(),damage = damage*self.percentage,damage_type = DAMAGE_TYPE_MAGICAL,ability = self:GetAbility()}
-	ApplyDamage( damageInfo )
-end
---移速
-function modifier_ancient_apparition_freezing_damage:GetModifierMoveSpeedBonus_Percentage()
-	return -50*(1 - math.max((CalcDistanceBetweenEntityOBB(self:GetParent(),self:GetCaster())-100),0) /800)
+	local damage = self:GetAbility():GetSpecialValueFor("damage") +
+	self:GetCaster():GetAverageTrueAttackDamage(nil) * self:GetAbility():GetSpecialValueFor("ad")
+	local damageInfo = { victim = self:GetParent(), attacker = self:GetCaster(), damage = damage * self.percentage, damage_type =
+	DAMAGE_TYPE_MAGICAL, ability = self:GetAbility() }
+	ApplyDamage(damageInfo)
 end
 
+--移速
+function modifier_ancient_apparition_freezing_damage:GetModifierMoveSpeedBonus_Percentage()
+	return -50 * (1 - math.max((CalcDistanceBetweenEntityOBB(self:GetParent(), self:GetCaster()) - 100), 0) / 800)
+end
 
 ---------------------------------------------------------------------------------------------------------
 modifier_ancient_apparition_freezing_aura = class({})
-LinkLuaModifier("modifier_ancient_apparition_freezing_aura", "abilities/ancient_apparition_freezing_aura", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_ancient_apparition_freezing_aura", "abilities/ancient_apparition_freezing_aura",
+	LUA_MODIFIER_MOTION_NONE)
 
 --隐藏
-function  modifier_ancient_apparition_freezing_aura:IsHidden()return true end
---无法驱散
-function  modifier_ancient_apparition_freezing_aura:IsPurgable() return false end
---光环范围
-function  modifier_ancient_apparition_freezing_aura:GetAuraRadius() return 1200 end
---是光环
-function  modifier_ancient_apparition_freezing_aura:IsAura() return true end
---光环buff
-function  modifier_ancient_apparition_freezing_aura:GetModifierAura() return "modifier_ancient_apparition_freezing_aura2" end
---光环对象
-function  modifier_ancient_apparition_freezing_aura:GetAuraSearchTeam() return DOTA_UNIT_TARGET_TEAM_ENEMY end
-function  modifier_ancient_apparition_freezing_aura:GetAuraSearchType() return DOTA_UNIT_TARGET_BASIC+1 end
-function  modifier_ancient_apparition_freezing_aura:GetAuraSearchFlags() return 48 end
+function modifier_ancient_apparition_freezing_aura:IsHidden() return true end
 
+--无法驱散
+function modifier_ancient_apparition_freezing_aura:IsPurgable() return false end
+
+--光环范围
+function modifier_ancient_apparition_freezing_aura:GetAuraRadius() return 1200 end
+
+--是光环
+function modifier_ancient_apparition_freezing_aura:IsAura() return true end
+
+--光环buff
+function modifier_ancient_apparition_freezing_aura:GetModifierAura() return "modifier_ancient_apparition_freezing_aura2" end
+
+--光环对象
+function modifier_ancient_apparition_freezing_aura:GetAuraSearchTeam() return DOTA_UNIT_TARGET_TEAM_ENEMY end
+
+function modifier_ancient_apparition_freezing_aura:GetAuraSearchType() return DOTA_UNIT_TARGET_BASIC + 1 end
+
+function modifier_ancient_apparition_freezing_aura:GetAuraSearchFlags() return 48 end
 
 --光环生效buff
 modifier_ancient_apparition_freezing_aura2 = class({})
-LinkLuaModifier("modifier_ancient_apparition_freezing_aura2", "abilities/ancient_apparition_freezing_aura", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_ancient_apparition_freezing_aura2", "abilities/ancient_apparition_freezing_aura",
+	LUA_MODIFIER_MOTION_NONE)
 --------------------------------------------------------------------------------
 
 function modifier_ancient_apparition_freezing_aura2:DeclareFunctions()
-	local funcs = 
+	local funcs =
 	{
 		MODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE,
 		MODIFIER_PROPERTY_LIFESTEAL_AMPLIFY_PERCENTAGE,
@@ -112,25 +143,35 @@ function modifier_ancient_apparition_freezing_aura2:DeclareFunctions()
 	}
 	return funcs
 end
+
 --当创建
 function modifier_ancient_apparition_freezing_aura2:OnCreated(keys)
 	-- if not IsServer() then return end
-	self.percentage  = self:GetAbility():GetSpecialValueFor("percentage")
+	self.percentage = self:GetAbility():GetSpecialValueFor("percentage")
 end
 
 --不隐藏
-function  modifier_ancient_apparition_freezing_aura2:IsHidden()return false end
+function modifier_ancient_apparition_freezing_aura2:IsHidden() return false end
+
 --无法驱散
-function  modifier_ancient_apparition_freezing_aura2:IsPurgable() return false end
+function modifier_ancient_apparition_freezing_aura2:IsPurgable() return false end
+
 --回复增强
-function  modifier_ancient_apparition_freezing_aura2:GetModifierHPRegenAmplify_Percentage(keys)return -self.percentage end
+function modifier_ancient_apparition_freezing_aura2:GetModifierHPRegenAmplify_Percentage(keys) return -self.percentage end
+
 --吸血增强
-function  modifier_ancient_apparition_freezing_aura2:GetModifierLifestealRegenAmplify_Percentage(keys)return -self.percentage end
+function modifier_ancient_apparition_freezing_aura2:GetModifierLifestealRegenAmplify_Percentage(keys) return -self
+	.percentage end
+
 --法吸增强
-function  modifier_ancient_apparition_freezing_aura2:GetModifierSpellLifestealRegenAmplify_Percentage(keys)return -self.percentage end
+function modifier_ancient_apparition_freezing_aura2:GetModifierSpellLifestealRegenAmplify_Percentage(keys) return -self
+	.percentage end
+
 --治疗增强
-function  modifier_ancient_apparition_freezing_aura2:GetModifierHealAmplify_PercentageTarget(keys)return -self.percentage end
+function modifier_ancient_apparition_freezing_aura2:GetModifierHealAmplify_PercentageTarget(keys) return -self
+	.percentage end
+
 --回复降低
-function  modifier_ancient_apparition_freezing_aura2:GetModifierConstantHealthRegen(keys)
+function modifier_ancient_apparition_freezing_aura2:GetModifierConstantHealthRegen(keys)
 	return -self:GetAbility():GetSpecialValueFor("hp_regen")
 end

--- a/game/scripts/vscripts/abilities/dark_seer_normal_punch2.lua
+++ b/game/scripts/vscripts/abilities/dark_seer_normal_punch2.lua
@@ -64,7 +64,8 @@ function modifier_dark_seer_normal_punch2:OnAttackLanded(keys)
 		}
 		ApplyDamage(damageInfo)
 
-		keys.target:AddNewModifier(self:GetCaster(), self:GetAbility(), "modifier_stunned", { duration = 1.25 })
+		local stun_duration = self:GetAbility():GetSpecialValueFor("max_stun")
+		keys.target:AddNewModifier(self:GetCaster(), self:GetAbility(), "modifier_stunned", { duration = stun_duration })
 
 		--特效
 		local Particle = ParticleManager:CreateParticle(


### PR DESCRIPTION
Some of my regular passes to help clean up the English localization, including, as per usual, fixing up some stuff that I accidentally left in. Nothing major otherwise for this.

- Adjusted Dark Willow's tooltips to be more relevant to her new changes (i.e. Bedlam DR), and removed information that no longer applies (i.e. Cursed Crown dispel).
- Cleaned up Saint White Lotus tooltips.
- Bonechill Aura modifier tooltips are now all finally correct. There are now exactly two debuff tooltips, and one buff tooltip (for ability owner).
- Fixed Yukari's Moon Phase modifier name actually being its descriptor instead.
- Yukari's Tentacle Portal debuff now properly shows the movement slow amount.
- Removed redundant ALT note regarding upgrading Excaliburs that are dropped by other players, since Excaliburs are no longer dropped by players on death.
- Replicated the Gold/XP ALT note from the Hand of Team to the Hand of Midas.
- Added an ALT note for the Cursed and Liberated Rapiers to assist players in the event they build said rapier in their stash and are unable to equip it.