### PR TITLE
Quick Marci hotfix

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -921,8 +921,9 @@
 		"DOTA_Tooltip_modifier_marci_guardian_buff"					"Sidekick"
 		"DOTA_Tooltip_modifier_marci_guardian_buff_Description"		"This unit has lifesteal and bonus damage."
 
-		"DOTA_Tooltip_ability_special_bonus_unique_marci_guardian_damage"	"+{s:bonus_bonus_damage}% Bodyguard/Sidekick Bonus Damage/Lifesteal"
-		"DOTA_Tooltip_ability_special_bonus_unique_marci_lunge_range"		"+{s:bonus_throw_distance_behind} Rebound Cast/Jump Range/Landing Radius"
+		"DOTA_Tooltip_ability_special_bonus_unique_marci_guardian_damage"	"+{s:bonus_bonus_damage}% Bodyguard/Sidekick Bonus Damage"
+		"DOTA_Tooltip_ability_special_bonus_unique_marci_guardian_lifesteal" "+{s:bonus_lifesteal_pct}% Bodyguard/Sidekick Lifesteal"
+		"DOTA_Tooltip_ability_special_bonus_unique_marci_lunge_range"		"+{s:bonus_max_jump_distance} Rebound Cast/Jump Range/Landing Radius"
 		"DOTA_Tooltip_ability_special_bonus_unique_marci_grapple_damage"	"+{s:bonus_impact_damage} Dispose Damage/Throw Distance"
 
 		// 夜魔

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -912,7 +912,8 @@
 		"DOTA_Tooltip_modifier_marci_guardian_buff"					"健体术"
 		"DOTA_Tooltip_modifier_marci_guardian_buff_Description"		"这个单位拥有吸血效果和攻击力加成。"
 
-		"DOTA_Tooltip_ability_special_bonus_unique_marci_guardian_damage"	"+{s:bonus_bonus_damage}% 护卫术/健体术吸血和攻击力"
+		"DOTA_Tooltip_ability_special_bonus_unique_marci_guardian_damage"	"+{s:bonus_bonus_damage}% 护卫术/健体术攻击力"
+    	"DOTA_Tooltip_ability_special_bonus_unique_marci_guardian_lifesteal"	"+{s:bonus_lifesteal_pct}% 护卫术/健体术吸血"
 		"DOTA_Tooltip_ability_special_bonus_unique_marci_lunge_range"		"+{s:bonus_max_jump_distance} 回身踢施法/跳跃距离和落地范围"
 		"DOTA_Tooltip_ability_special_bonus_unique_marci_grapple_damage"	"+{s:bonus_impact_damage} 过肩摔伤害/摔扔距离"
 

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -2770,7 +2770,7 @@
 			"lifesteal_pct"
 			{
 				"value"				"15 25 35 45 55"
-				"special_bonus_unique_marci_guardian_damage"			"+25"		// Uses damage talent so that both values increase with one talent
+				"special_bonus_unique_marci_guardian_lifesteal"			"+15"
 			}
 			"bonus_damage"
 			{
@@ -2793,7 +2793,7 @@
 			"lifesteal_pct"
 			{
 				"value"											"15 30 45 60 75"
-				"special_bonus_unique_marci_guardian_damage"			"+25"		// Uses damage talent so that both values increase with one talent
+				"special_bonus_unique_marci_guardian_lifesteal"			"+15"
 			}
 			"bonus_damage"
 			{
@@ -2821,7 +2821,7 @@
 			"pulse_attack_slow_pct"		"120.0 160.0 200.0 240.0"	// 2x
 			"bonus_movespeed"
 			{
-				"value"		"10 15 20 25"
+				"value"		"14 21 28 35"
 				"special_bonus_unique_marci_unleash_speed"	"+15"	// +10
 			}
 			"pulse_silence_duration"
@@ -2842,6 +2842,20 @@
 			}
 		}
 	}
+	"special_bonus_unique_marci_guardian_lifesteal"
+    {
+        // General
+        //-------------------------------------------------------------------------------------------------------------
+        "AbilityType"               "ABILITY_TYPE_ATTRIBUTES"
+        "AbilityBehavior"           "DOTA_ABILITY_BEHAVIOR_PASSIVE"
+        "AbilityValues"
+        {
+            "value"
+            {
+                "value" "15"	// 10
+            }
+        }
+    }
 	//=================================================================================================================
 	// Ability: Mars 玛尔斯
 	//=================================================================================================================

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -2811,7 +2811,7 @@
 		"AbilityValues"
 		{
 			"charges_per_flurry"	"6 8 10 12"	//5
-			"flurry_bonus_attack_speed"	"800 1200 1600 2000"
+			"flurry_bonus_attack_speed"	"700 975 1325 1600"
 			"time_between_flurries"	"1.0 0.8 0.6 0.4"	// 1.5
 			"pulse_damage"
 			{
@@ -2842,20 +2842,6 @@
 			}
 		}
 	}
-	"special_bonus_unique_marci_guardian_lifesteal"
-    {
-        // General
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityType"               "ABILITY_TYPE_ATTRIBUTES"
-        "AbilityBehavior"           "DOTA_ABILITY_BEHAVIOR_PASSIVE"
-        "AbilityValues"
-        {
-            "value"
-            {
-                "value" "15"	// 10
-            }
-        }
-    }
 	//=================================================================================================================
 	// Ability: Mars 玛尔斯
 	//=================================================================================================================

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -414,7 +414,7 @@
 	{
 		"Ability4"		"marci_guardian"
 
-		"Ability10"		"special_bonus_unique_marci_unleash_speed"
+		"Ability10"		"special_bonus_unique_marci_guardian_lifesteal"
 		"Ability11"		"special_bonus_unique_marci_lunge_range"	// 覆盖原有天赋范围
 		"Ability15"		"special_bonus_status_resistance_25"
 


### PR DESCRIPTION
It's probably a bit too soon for me to tweak the hero that I had asked plenty of times to change, but I did notice a couple of inconsistencies that I thought were easy fixes, so I went ahead and patched them up.

-Bodyguard/Sidekick Lifesteal talents are now independent of their damage talents, but since they are acquired much earlier, they now only give 15% versus the originally intended 25%.
--This talent will replace the Unleash movement speed talent. Unleash base movement speed has been increased from 10/15/20/25 to 14/21/28/35 to compensate.
-Added localization for the newly re-introduced Bodyguard/Sidekick Lifesteal talent.
-Removed mention of Lifesteal for the level 25 Bodyguard/Sidekick Damage talent since this in actuality did not add Lifesteal.
-Fixed the Rebound Cast/Jump Range/Landing Radius talent not displaying a number.

No other numerical changes to Marci, and no other broad localization changes in general.
