### PR TITLE
Mirana Updates

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -926,6 +926,13 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_marci_lunge_range"		"+{s:bonus_max_jump_distance} Rebound Cast/Jump Range/Landing Radius"
 		"DOTA_Tooltip_ability_special_bonus_unique_marci_grapple_damage"	"+{s:bonus_impact_damage} Dispose Damage/Throw Distance"
 
+		// Mirana
+		"DOTA_Tooltip_ability_special_bonus_unique_mirana_4"        "-{s:bonus_AbilityCooldown}s Moonlight Shadow/Solar Flare Cooldowns"
+		"DOTA_Tooltip_ability_special_bonus_unique_mirana_5"        "+{s:bonus_evasion}% Evasion during Moonlight Shadow/Solar Flare"
+		"DOTA_Tooltip_ability_special_bonus_unique_mirana_5_Description"	"Evasion works at all times during both abilties, and they stack diminishingly with themselves and other sources of evasion"
+		"DOTA_Tooltip_ability_mirana_solar_flare_Lore"				"In another time, in another place, Mirana would abandon the favor of the Goddess of the Moon and forge a stronger connection through the lands of her home in the Helio Imperium and become God-Empress of the Sun."
+		
+
 		// 夜魔
 		"DOTA_Tooltip_ability_special_bonus_unique_night_stalker_301"	"+{s:bonus_bonus_movement_speed_pct_night}% Hunter In The Night Movement Speed"
 

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -6717,10 +6717,38 @@
 			"bonus_lotus"	"200"	// 50
 		}
 	}
+	"mirana_solar_flare"
+	{
+		"DependentOnAbility"			"mirana_invis"
+		"Innate"						"1"
+		"MaxLevel"						"5"
+		"AbilityCastPoint"              "0"
+		"AbilityValues"
+        {
+            "AbilityCooldown"               
+            {
+                "value"         "145.0 125.0 105.0 85.0 65.0"
+                "special_bonus_unique_mirana_4"         "-25"               
+            }
+            "smoothness"                        "0.015"
+            "increase_rate"                     "25"
+            "max_total_increase"                "75 125 175 225 275"
+            "ally_pct"                          "60 70 80 90 100"
+            "duration"                          "16 18 20 22 24"
+            "max_damage_time"                   "6"
+            "evasion"       
+            {
+                "special_bonus_unique_mirana_5"     "+35"
+            }
+        }
+	}
 	// 月神之箭 射箭
 	"mirana_arrow"
 	{
 		"MaxLevel"						"5"
+		"AbilityUnitDamageType"         "DAMAGE_TYPE_PURE"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
+		"SpellDispellableType"          "SPELL_DISPELLABLE_NO"
 		"AbilityCastRange"				"4500"
 		"AbilityCastPoint"				"0.2"	// 0.5
 		"AbilityDamage"					"60 150 240 330 420"
@@ -6728,7 +6756,7 @@
 		{
 				"AbilityCooldown"
 				{
-					"value"						"17 16 15 14 13"	// -2
+					"value"						"15 14 13 12 11"	// -4
 				}
 				"arrow_speed"		"1200.0"		// 900
 				"arrow_min_stun"	"1.0"			// 0.01
@@ -6743,6 +6771,7 @@
 	"mirana_invis"
 	{
 		"MaxLevel" "4"
+		"AbilityCastPoint"              "0"
 		"AbilityValues"
 		{
 			"AbilityCooldown"
@@ -6750,33 +6779,52 @@
 				"value"			"85.0"
 				"special_bonus_unique_mirana_4"			"-25"
 			}
-				"fade_delay"			"2.5 2.0 1.5 1.0"
-				"bonus_movement_speed"		"12 16 20 24"
-				"bonus_outgoing_damage_pct"				"9.0 12.0 15.0 18.0"
+			"fade_delay"			"2.5 2.0 1.5 1.0"
+			"bonus_movement_speed"		"12 16 20 24"
+			"evasion"       
+                {
+                    "special_bonus_unique_mirana_5"     "+35"	// 20
+                }
+			"bonus_outgoing_damage_pct"				"14.0 16.0 18.0 20.0"
 		}
 	}
 	// 跳跃
 	"mirana_leap"
 	{
 		"MaxLevel" "5"
+		"SpellDispellableType"          "SPELL_DISPELLABLE_NO"
+		"AbilityCharges"                "3"
 		"AbilityChargeRestoreTime"		"24 21 18 15 12"
+		"AbilityManaCost"               "48 36 24 12 0"
 		"AbilityValues"
 		{
+			"leap_distance"         
+            {
+                "value"                         "650 750 850 950 1050"	// 650
+                "special_bonus_unique_mirana_6" "+150"
+            }
+			"leap_speed"            "2000.0"	// 1300.0
 			"leap_speedbonus"	"8 16 24 32 40"
 			"leap_speedbonus_as"
 			{
 				"value"				"25 50 75 100 125"
 				"special_bonus_unique_mirana_1"	"+125"	// +90
 			}
+			"leap_bonus_duration"   "6"	// 5
+			"crit_damage_pct"
+            {
+                "value"                 "0"
+                "special_bonus_shard"   "+225"	// 150
+            }
 			"root_radius"
 			{
 				"value"											"0"
-				"special_bonus_facet_mirana_leaps_and_bounds"	"+450"		// +250
+				"special_bonus_facet_mirana_leaps_and_bounds"	"+600"		// +250
 			}
 			"root_duration"
 			{
 				"value"											"0"
-				"special_bonus_facet_mirana_leaps_and_bounds"	"=1.5 =1.75 =2.0 =2.25 =2.5"
+				"special_bonus_facet_mirana_leaps_and_bounds"	"=1.5 =2.0 =2.5 =3.0 =3.5"
 			}
 		}
 	}
@@ -6785,7 +6833,7 @@
 	{
 		"MaxLevel" "5"
 		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
-		"AbilityCastPoint"				"0.2"		// 0.4
+		"AbilityCastPoint"				"0"		// 0.4
 		"AbilityManaCost"				"80 90 100 110 120"
 		"AbilityValues"
 		{
@@ -6796,9 +6844,15 @@
 			}
 			"damage"
 			{
-				"value"			"150 250 350 400 450"
+				"value"			"150 225 300 375 450"
 				"special_bonus_unique_mirana_7"	"+350"	// +250
 			}
+			"secondary_starfall_damage_percent"
+            {
+                "value"                                 "100"	// 60
+                "CalculateSpellDamageTooltip"           "0"
+                "special_bonus_facet_mirana_starstruck" "+100"	// 40
+            }
 			"starfall_radius"
 			{
 				"value"			"825"	// 675
@@ -6807,6 +6861,14 @@
 			{
 				"value"			"825"	// 675
 			}
+			"starstruck_blind_pct"
+            {
+                "special_bonus_facet_mirana_starstruck" "+100.0"	// 60.0
+            }
+            "starstruck_duration"
+            {
+                "special_bonus_facet_mirana_starstruck" "=5.0"		// 3.0
+            }
 		}
 	}
 	//=================================================================================================================

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -6812,7 +6812,6 @@
 	"mirana_arrow"
 	{
 		"MaxLevel"						"5"
-		"AbilityUnitDamageType"         "DAMAGE_TYPE_PURE"
 		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
 		"SpellDispellableType"          "SPELL_DISPELLABLE_NO"
 		"AbilityCastRange"				"4500"
@@ -6824,7 +6823,7 @@
 				{
 					"value"						"15 14 13 12 11"	// -4
 				}
-				"arrow_range"       	"4500"		// 3000	Matches cast range
+				"arrow_range"       	"4500"		// 3000 - Now Matches cast range
                 "arrow_max_stunrange"   "1500"
 				"arrow_speed"		"1500.0"		// 900
 				"arrow_min_stun"	"1.0"			// 0.01

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -6765,6 +6765,14 @@
 				{
 					"value"				"360"	// 180 (x2)
 				}
+				"scepter_radius"        
+                {
+                    "special_bonus_scepter" 	"600"	// 500
+                }
+                "scepter_starstorm_target_pct"      
+                {
+                    "special_bonus_scepter"     "100"	// 80
+                }
 		}
 	}
 	// 月之暗面

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -6824,12 +6824,14 @@
 				{
 					"value"						"15 14 13 12 11"	// -4
 				}
-				"arrow_speed"		"1200.0"		// 900
+				"arrow_range"       	"4500"		// 3000	Matches cast range
+                "arrow_max_stunrange"   "1500"
+				"arrow_speed"		"1500.0"		// 900
 				"arrow_min_stun"	"1.0"			// 0.01
 				"arrow_max_stun"	"4.0 4.5 5.0 5.5 6.0"	// 2.6 3.4 4.2 5.0
 				"arrow_bonus_damage"
 				{
-					"value"				"360"	// 180 (x2)
+					"value"						"360"	// 180 (x2)
 				}
 				"scepter_radius"        
                 {
@@ -6844,8 +6846,8 @@
 	// 月之暗面
 	"mirana_invis"
 	{
-		"MaxLevel" "4"
-		"AbilityCastPoint"              "0"
+		"MaxLevel"					"4"
+		"AbilityCastPoint"			"0"
 		"AbilityValues"
 		{
 			"AbilityCooldown"
@@ -6853,42 +6855,42 @@
 				"value"			"85.0"
 				"special_bonus_unique_mirana_4"			"-25"
 			}
-			"fade_delay"			"2.5 2.0 1.5 1.0"
+			"fade_delay"				"2.5 2.0 1.5 1.0"
 			"bonus_movement_speed"		"12 16 20 24"
 			"evasion"       
                 {
                     "special_bonus_unique_mirana_5"     "+35"	// 20
                 }
-			"bonus_outgoing_damage_pct"				"14.0 16.0 18.0 20.0"
+			"bonus_outgoing_damage_pct"					"14.0 16.0 18.0 20.0"
 		}
 	}
 	// 跳跃
 	"mirana_leap"
 	{
 		"MaxLevel" "5"
-		"SpellDispellableType"          "SPELL_DISPELLABLE_NO"
-		"AbilityCharges"                "3"
+		"SpellDispellableType"			"SPELL_DISPELLABLE_NO"
+		"AbilityCharges"				"3"
 		"AbilityChargeRestoreTime"		"24 21 18 15 12"
-		"AbilityManaCost"               "48 36 24 12 0"
+		"AbilityManaCost"				"40 30 20 10 0"
 		"AbilityValues"
 		{
 			"leap_distance"         
             {
-                "value"                         "650 750 850 950 1050"	// 650
+                "value"							"650 750 850 950 1050"	// 650
                 "special_bonus_unique_mirana_6" "+150"
             }
-			"leap_speed"            "2000.0"	// 1300.0
-			"leap_speedbonus"	"8 16 24 32 40"
+			"leap_speed"						"2000.0"	// 1300.0
+			"leap_speedbonus"					"8 16 24 32 40"
 			"leap_speedbonus_as"
 			{
 				"value"				"25 50 75 100 125"
 				"special_bonus_unique_mirana_1"	"+125"	// +90
 			}
-			"leap_bonus_duration"   "6"	// 5
+			"leap_bonus_duration"				"6"	// 5
 			"crit_damage_pct"
             {
-                "value"                 "0"
-                "special_bonus_shard"   "+225"	// 150
+                "value"							"0"
+                "special_bonus_shard"			"+225"	// 150
             }
 			"root_radius"
 			{
@@ -6918,14 +6920,14 @@
 			}
 			"damage"
 			{
-				"value"			"150 225 300 375 450"
-				"special_bonus_unique_mirana_7"	"+350"	// +250
+				"value"										"150 225 300 375 450"
+				"special_bonus_unique_mirana_7"				"+350"	// +250
 			}
 			"secondary_starfall_damage_percent"
             {
-                "value"                                 "100"	// 60
-                "CalculateSpellDamageTooltip"           "0"
-                "special_bonus_facet_mirana_starstruck" "+100"	// 40
+                "value"										"100"	// 60
+                "CalculateSpellDamageTooltip"				"0"
+                "special_bonus_facet_mirana_starstruck"		"+100"	// 40
             }
 			"starfall_radius"
 			{

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -428,7 +428,24 @@
 		"AttributeBaseIntelligence"	"22"	// 19
 		"AttributeIntelligenceGain" "2.1"	// 1.9
 	}
+	"npc_dota_hero_mirana"
+	{
+		"Ability4"      				"mirana_solar_flare"
 
+		"Ability15"     				"special_bonus_agility_40"
+
+		"ArmorPhysical"     			"2"		// -2
+		"AttackRate"					"1.5"	// 1.7
+		"AttackRange"       			"650"	// 630
+		"ProjectileSpeed"				"1400"	// 900
+		"AttributeBaseStrength"			"23"	// 20
+        "AttributeStrengthGain"			"2.5"	// 2.2
+        "AttributeBaseAgility"			"29"	// 26
+        "AttributeAgilityGain"			"3.4"	// 3.1
+        "AttributeBaseIntelligence"		"26"	// 22
+        "AttributeIntelligenceGain"		"2.8"	// 1.9
+		"MovementSpeed"					"315"	// 285
+	}
 	"npc_dota_hero_obsidian_destroyer"
 	{
 		"AttackRate"	"1.7"


### PR DESCRIPTION
As I had already touched up on her recently, I decided to go ahead and go the full mile for Mirana. As she also had a mostly-worthless innate like Marci, I felt it was needed to replace it. The ability to replace it most definitely works, so there should be no troubles whatsoever.

Below are all the changes done to Mirana.

General:
-Replaced Selemene's Favor innate with Solar Flare.
-Improved Mirana's base attributes and attribute gain.
-Improved various other aspects of Mirana

Talents:
-Replaced +35 Base Damage with +40 Agility.
-20% Evasion during Moonlight Shadow increased to 35%.
-The talents that affected Moonlight Shadow now also affect Solar Flare.

Starstorm:
-Damage rescaled from 150/250/350/400/450 to 150/225/300/375/450.
--This was for smoother scaling between levels.
-Cast point removed.
-Second Star Damage from 60% to 100% (meaning double total damage).
-Starstruck bonus damage from 40% to 100% (meaning triple total damage).
-Starstruck miss chance from 60% to 100%.
-Starstruck blind duration from 3s to 5s.

Sacred Arrow:
-Now deals pure damage.
-Stun can no longer be dispelled.
-Now pierces debuff immunity.
--The above changes were done simply because bots are absolutely annoying to hit with Sacred Arrow, because they will make an active effort to avoid skill shots as soon as they see either a single pixel of the ability, or see the hero casting the ability nearby. Thus, I felt it should be rewarding when hitting an enemy with an arrow, and it should not be at all diminished or negated.
-Scepter Starstorm radius increased from 500 to 600.
-Scepter Starstorm damage on direct hit increased from 80% to 100%.

Leap:
-Base charges from 2 to 3.
-Distance increased from 650 to 650/750/850/950/1050.
-Leap speed bonus duration increased from 5s to 6s.
-Leap speed bonus can no longer be dispelled.
-Shard Crit Damage increased from 150% to 225%.
-Leaps and Bounds root radius from 450 to 600.
-Leaps and Bounds root duration from 1.5/1.75/2/2.25/2.5 to 1.5/2/2.5/3/3.5

Moonlight Shadow:
-Mirana's outgoing damage during Moonlight Shadow increased from 9%/12%/15%/18% to 14%/16%/18%/20%.

Solar Flare:
-Levels in tandem with Moonlight Shadow.
-Ally values increased from 50% to 60%/70%/80%/90%/100%
-Increase rate affixed to 25.
-Max values are now 75/125/175/225/275.
--If Solar Flare never lands on any of these values, this might require tinkering with either the increase rate or the smoothness.
-Duration increased from 16 to 16/18/20/22/24.

Since both Mirana and WR are now pending full updates, take your time to decide if either are good to go. I'm most certainly not expecting an answer right away.