### PR TITLE
亚军限时强化

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -828,7 +828,6 @@
 		//
 		///////////////////////////////////////////////////
 		//墓碑改说明
-		// "DOTA_Tooltip_ability_undying_tombstone"						"墓碑·改（不生成小僵尸）"
 		"DOTA_Tooltip_ability_undying_tombstone"						"Tombstone·MK2(No Zombie)"
 		//骨隐步改说明
 		"DOTA_Tooltip_ability_clinkz_wind_walk"											"Skeleton Walk·MK2(No Skeleton Archers)"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -830,6 +830,32 @@
 		"npc_dota_hero_techies"					"茶神"
 		// 撼地者
 		"npc_dota_hero_earthshaker"					"宇智波牛神"
+		// 水人
+		"npc_dota_hero_morphling:n"					"传奇3亚王ame的水人"
+		"npc_dota_hero_morphling__en:n"				"Morphling of ame"
+		"DOTA_Tooltip_ability_morphling_waveform"										"波高"
+		"DOTA_Tooltip_ability_morphling_waveform_Description"							"为什么不能波回来 为什么不能波回来 为什么不能波回来"
+		"DOTA_Tooltip_ability_morphling_waveform_Lore"									"团队决策！"
+		"DOTA_Tooltip_ability_morphling_waveform_pct_damage"							"%攻击伤害："
+		"DOTA_Tooltip_ability_morphling_waveform_Facet_morphling_agi"					"波高会攻击路径上的敌人。会施加攻击特效。"
+		// 小小
+		"npc_dota_hero_tiny:n"					"传奇3亚王ame的小小"
+		"npc_dota_hero_tiny__en:n"				"Tiny of ame"
+		"DOTA_Tooltip_ability_lycan_shapeshift"										"我们狼人小小没输过"
+		"DOTA_Tooltip_ability_lycan_shapeshift_Lore"								"我前妻辣么肥"
+		"DOTA_Tooltip_ability_lycan_shapeshift_Description"							"唉，我前期那么肥"
+		// 泰罗 斯温
+		"npc_dota_hero_sven:n"					"传奇3亚王ame的泰罗"
+		"npc_dota_hero_sven__en:n"				"Sven of ame"
+		"DOTA_Tooltip_ability_sven_gods_strength"										"谢谢你，泰罗"
+		// 小骷髅
+		"npc_dota_hero_clinkz:n"					"传奇3亚王ame的小骷髅"
+		"npc_dota_hero_clinkz__en:n"				"Clinkz of ame"
+		"DOTA_Tooltip_ability_clinkz_burning_barrage"											"这对线有这么难打吗"
+		// 剑圣
+		"npc_dota_hero_juggernaut:n"					"传奇3亚王ame的剑圣"
+		"npc_dota_hero_juggernaut__en:n"				"Juggernaut of ame"
+		"DOTA_Tooltip_ability_juggernaut_omni_slash"									"最后的无敌斩"
 
 		// 谜团
 		"DOTA_Tooltip_ability_enigma_malefice_shard_description"						"憎恶的眩晕时间增加%shard_bonus_stun_duration_tooltip%秒。"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -830,6 +830,7 @@
 		"npc_dota_hero_techies"					"茶神"
 		// 撼地者
 		"npc_dota_hero_earthshaker"					"宇智波牛神"
+		// FIXME 限时强化结束后回退
 		// 水人
 		"npc_dota_hero_morphling:n"					"传奇3亚王ame的水人"
 		"npc_dota_hero_morphling__en:n"				"Morphling of ame"

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -2536,19 +2536,30 @@
 	"lycan_shapeshift"
 	{
 		"MaxLevel" "4"
-		"AbilityCooldown"				"90"
+		// "LinkedAbility"					"tiny_grow"
+		// "AbilityDraftPreAbility"		"tiny_grow"
 		"AbilityValues"
 		{
-			"speed"				"800"
+			"duration"
+			{
+				"value"				"40"
+				"special_bonus_unique_lycan_1"	"+20"
+			}
+			"speed"				"900"
 			"crit_multiplier"		"160 200 240 280"
 			"health_bonus"		"500 700 900 1100" // x2
+			"AbilityCooldown"
+			{
+				"value"							"90 80 70 60"
+				"special_bonus_unique_lycan_8"	"-20"
+			}
 		}
 	}
 	// a杖变狼
 	"lycan_wolf_bite"
 	{
 		"MaxLevel" "4"
-		"AbilityCooldown"				"90"
+		"AbilityCooldown"				"60"
 		"AbilityValues"
 		{
 			"lifesteal_range"
@@ -4280,9 +4291,12 @@
 	"sven_storm_bolt"
 	{
 		"MaxLevel" "5"
-		"AbilityCooldown"				"20 18 16 14 12"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityCooldown"				"16 14 12 10 8"
 		"AbilityDamage"					"80 160 240 320 400"
 		"AbilityManaCost"				"110 120 130 140 150"
+		"LinkedAbility"					"sven_great_cleave"
+		"AbilityDraftPreAbility"		"sven_great_cleave"
 		"AbilityValues"
 		{
 				"bolt_stun_duration"
@@ -4293,17 +4307,32 @@
 				{
 					"value"			"250 270 290 310 330"
 				}
+				"cast_range_bonus_scepter"
+				{
+					"special_bonus_scepter"		"650"
+				}
 		}
 	}
 	// 巨力挥舞
 	"sven_great_cleave"
 	{
+		"LinkedAbility"					"sven_storm_bolt"
+		"AbilityDraftPreAbility"		"sven_storm_bolt"
 		"MaxLevel" "5"
 		"AbilityValues"
 		{
+			"cleave_ending_width"
+			{
+				"value"			"270 300 330 360 390"
+			}
+			"cleave_distance"
+			{
+				"value"			"400 500 600 700 800"
+			}
 			"great_cleave_damage"
 			{
-				"value"				"50 60 70 80 90"
+				"value"				"65 75 85 95 105"
+				"special_bonus_unique_sven_8" "+45"
 			}
 		}
 	}
@@ -4311,7 +4340,7 @@
 	"sven_warcry"
 	{
 		"MaxLevel" "5"
-		"AbilityCooldown"				"40 35 30 25 20"
+		"AbilityCooldown"				"35 30 25 20 15"
 		"AbilityManaCost"				"40 45 50 55 60"
 		"AbilityValues"
 		{
@@ -4335,7 +4364,7 @@
 			}
 			"base_barrier_amount"
 			{
-				"special_bonus_facet_sven_heavy_plate"		"=200 =600 =1000 =1400 =1800"
+				"special_bonus_facet_sven_heavy_plate"		"=1000 =2000 =3000 =4000 =5000"
 			}
 		}
 	}
@@ -4343,13 +4372,13 @@
 	"sven_gods_strength"
 	{
 		"MaxLevel" "4"
-		"AbilityCooldown"				"100"	// ，刚好续不上，有真空期
+		"AbilityCooldown"				"80"	// 100s刚好续不上，有真空期
 		"AbilityManaCost"				"150 200 250 300"
 		"AbilityValues"
 		{
 			"gods_strength_damage"
 			{
-				"value"		"100 130 160 190"
+				"value"		"130 160 190 220"
 			}
 		}
 	}
@@ -4610,9 +4639,15 @@
 		// 最大4级，之后技能特效无法正常显示
 		"AbilityValues"
 		{
+				"AbilityCastRange"
+				{
+					"value"		"600"
+					"special_bonus_unique_tiny_4" "+600"
+				}
 				"avalanche_damage"
 				{
 					"value"				"120 240 360 480"		// 100 190 280 370 加强
+					"special_bonus_unique_tiny"			"+320"
 				}
 		}
 	}
@@ -4621,7 +4656,7 @@
 	{
 		"MaxLevel" "5"
 		"AbilityCastRange"				"800 900 1000 1100 1200"
-		"AbilityCooldown"				"20 18 16 14 12"
+		"AbilityCooldown"				"18 16 14 12 10"
 		"AbilityManaCost"				"110 125 140 155 170"
 		"AbilityValues"
 		{
@@ -4659,6 +4694,11 @@
 		"AbilityCooldown"				"16 15 14 13 12"
 		"AbilityValues"
 		{
+			"attack_count"
+			{
+				"value"					"10 15 20 25 30"
+				"special_bonus_shard"	"=0"
+			}
 			"bonus_damage"
 			{
 				"value"							"10 20 30 40 50"
@@ -4684,6 +4724,8 @@
 	"tiny_grow"
 	{
 		"MaxLevel" "4"
+		"LinkedAbility"					"lycan_shapeshift"
+		"AbilityDraftPreAbility"		"lycan_shapeshift"
 		"AbilityValues"
 		{
 				"bonus_armor"				"10 20 30 40"		// 5 10 15 x2
@@ -4693,7 +4735,7 @@
 				}
 				"attack_speed_reduction"
 				{
-					"value"		"-20"						// -35 +15
+					"value"		"-0"						// -35 +15
 					"special_bonus_unique_tiny_6" "+10"		// +8 +2
 				}
 				"toss_bonus_damage"
@@ -5542,17 +5584,27 @@
 			"attack_speed_bonus"
 			{
 				"value"									"100 140 180 220 260"
-				"special_bonus_unique_clinkz_7"			"+40"
+				"special_bonus_unique_clinkz_7"			"+200"
 			}
 			"duration"
 			{
 				"value"									"6.5"
-				"special_bonus_unique_clinkz_1"			"+1.5"
+				"special_bonus_unique_clinkz_1"			"+2.5"
 			}
 			"AbilityCooldown"
 			{
 				"value"								"30 25 20 15 10"
 				"special_bonus_unique_clinkz_4"		"-5"
+			}
+			"debuff_duration"
+			{
+				"value"							"0"
+				"special_bonus_facet_clinkz_suppressive_fire"			"=2.0"
+			}
+			"blind_pct"
+			{
+				"value"							"0"
+				"special_bonus_facet_clinkz_suppressive_fire"			"=100"
 			}
 		}
 	}
@@ -5579,7 +5631,7 @@
 			}
 			"AbilityCooldown"
 			{
-				"value"									"20 16 12"
+				"value"									"16 13 10"
 				"special_bonus_unique_clinkz_10"		"-4"
 			}
 		}
@@ -5587,8 +5639,10 @@
 	// 炽烈火雨
 	"clinkz_burning_barrage"
 	{
-		"AbilityCooldown"				"8"
+		"AbilityCooldown"				"6"
 		"AbilityManaCost"				"90"
+		"Innate" 						"1"
+		"IsGrantedByShard"				"0"
 		"AbilityValues"
 		{
 			"wave_count"		"9"
@@ -5614,7 +5668,7 @@
 			{
 				"value"					"20 30 40 50 60"
 			}
-			"slow_movement_speed"			"-16 -19 -22 -25 -28"
+			"slow_movement_speed"			"-15 -25 -35 -45 -55"
 			"impact_damage"
 			{
 				"value"				"40 60 80 100 120"
@@ -5639,6 +5693,11 @@
 			{
 				"value"				"200 300 400 500 600"
 				"special_bonus_unique_clinkz_8"		"+400"
+			}
+			"AbilityChargeRestoreTime"
+			{
+				"value"				"30"
+				"special_bonus_facet_clinkz_engulfing_step"				"-15"
 			}
 			"skeletons_spawned"
 			{
@@ -6285,16 +6344,17 @@
 	"juggernaut_omni_slash"
 	{
 		"MaxLevel" "4"
-		"AbilityCooldown"				"90"		// 120
+		"AbilityCooldown"				"90 90 90 1"		// 120
 		"AbilityManaCost"				"250 300 350 400"
+		"LevelsBetweenUpgrades"					"12"
 		"AbilityValues"
 		{
-			"attack_rate_multiplier"	"1.5 1.6 1.7 1.8"
-			"bonus_damage"				"50 60 70 80"	// x2
+			"attack_rate_multiplier"	"1.5 1.7 1.9 2.1"
+			"bonus_damage"				"50 70 90 110"	// x2
 			"bonus_attack_speed"				"100"	// 40
 			"duration"
 			{
-				"value"						"3.1 3.4 3.7 4.0"
+				"value"						"3.1 4.0 5.0 80000"
 			}
 			"omni_slash_radius"
 			{
@@ -6302,7 +6362,7 @@
 			}
 			"AbilityCastRange"
 			{
-				"value"					"600"		// 450
+				"value"					"600 600 600 1200"		// 450
 			}
 		}
 	}
@@ -6907,24 +6967,51 @@
 		"AbilityDamage"					"75 150 225 300 375"
 		"AbilityValues"
 		{
+			"speed"					"1250"
+			"width"
+			{
+				"value"				"200"
+				"affected_by_aoe_increase"	"1"
+			}
+			"AbilityCharges"
+			{
+				"value"	"0"
+			}
+			// "charge_restore_time"
+			// {
+			// 	"value"	"17 15 13 11 9"
+			// 	"special_bonus_unique_morphling_waveform_cooldown"			"-60%"
+			// }
 			"AbilityCastRange"
 			{
 				"value"				"700 800 900 1000 1100"
-				"special_bonus_unique_morphling_1"	"+250"
+				"special_bonus_unique_morphling_1"	"+400"
 			}
 			"AbilityCooldown"
 			{
-				"value"									"20 18 16 14 12"
+				"value"														"17 15 13 11 9"
+				"special_bonus_unique_morphling_waveform_cooldown"			"-60%"
+			}
+			"pct_damage"
+			{
+				"value"										"0"
+				"special_bonus_facet_morphling_agi"			"+100"
+				"special_bonus_unique_morphling_4"			"+100"
+				"CalculateSpellDamageTooltip"				"0"
+				"DamageTypeTooltip"							"DAMAGE_TYPE_PHYSICAL"
+			}
+			"process_procs"
+			{
+				"value" "1"
 			}
 		}
 	}
-	// 变体打击敏捷（实际包含力量打击）fixme无视魔免后现在力水像个怪物，暂时发现的人不多
+	// 变体打击敏捷（实际包含力量打击）
 	"morphling_adaptive_strike_agi"
 	{
 		"MaxLevel" "5"
 		"AbilityCastRange"				"600 700 800 900 1000"
 		"AbilityManaCost"				"40 60 80 100 120"
-		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
 		"AbilityValues"
 		{
 				"AbilityCooldown"
@@ -6956,7 +7043,7 @@
 				}
 				"extra_targets"
 				{
-					"value"								"1"
+					"value"								"2"
 				}
 		}
 	}
@@ -6993,7 +7080,7 @@
 	{
 		"AbilityValues"
 		{
-			"agi_per_one_spell_amp"			"3"			// fixme可能是力水怪物的原因之一，暂时发现的人不多
+			"agi_per_one_spell_amp"			"3"
 			"one_percent_tooltip"			"1"
 		}
 	}
@@ -7007,7 +7094,7 @@
 		{
 			"duration"
 			{
-				"value"								"30"
+				"value"								"45"
 				"special_bonus_unique_morphling_8" "+15"
 			}
 			"scepter_stat_steal"

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -2536,16 +2536,15 @@
 	"lycan_shapeshift"
 	{
 		"MaxLevel" "4"
-		// "LinkedAbility"					"tiny_grow"
-		// "AbilityDraftPreAbility"		"tiny_grow"
 		"AbilityValues"
 		{
+			// FIXME 限时强化结束后 削弱持续时间
 			"duration"
 			{
-				"value"				"40"
-				"special_bonus_unique_lycan_1"	"+20"
+				"value"				"40"	// 25
+				"special_bonus_unique_lycan_1"	"+20"	// +7
 			}
-			"speed"				"900"
+			"speed"				"900"	// 550
 			"crit_multiplier"		"160 200 240 280"
 			"health_bonus"		"500 700 900 1100" // x2
 			"AbilityCooldown"
@@ -2559,13 +2558,16 @@
 	"lycan_wolf_bite"
 	{
 		"MaxLevel" "4"
-		"AbilityCooldown"				"60"
 		"AbilityValues"
 		{
 			"lifesteal_range"
 			{
 				"value"		"1800" // 1200
 				"affected_by_aoe_increase"	"1"
+			}
+			"AbilityCooldown"
+			{
+				"value"							"60"	// 110 100 90
 			}
 		}
 	}
@@ -4291,12 +4293,11 @@
 	"sven_storm_bolt"
 	{
 		"MaxLevel" "5"
-		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
+		// FIXME 限时强化结束后回退
+		// "AbilityCooldown"				"20 18 16 14 12"
 		"AbilityCooldown"				"16 14 12 10 8"
 		"AbilityDamage"					"80 160 240 320 400"
 		"AbilityManaCost"				"110 120 130 140 150"
-		"LinkedAbility"					"sven_great_cleave"
-		"AbilityDraftPreAbility"		"sven_great_cleave"
 		"AbilityValues"
 		{
 				"bolt_stun_duration"
@@ -4307,17 +4308,16 @@
 				{
 					"value"			"250 270 290 310 330"
 				}
+				// FIXME 限时强化结束后回退
 				"cast_range_bonus_scepter"
 				{
-					"special_bonus_scepter"		"650"
+					"special_bonus_scepter"		"650"	// 350
 				}
 		}
 	}
 	// 巨力挥舞
 	"sven_great_cleave"
 	{
-		"LinkedAbility"					"sven_storm_bolt"
-		"AbilityDraftPreAbility"		"sven_storm_bolt"
 		"MaxLevel" "5"
 		"AbilityValues"
 		{
@@ -4331,6 +4331,8 @@
 			}
 			"great_cleave_damage"
 			{
+				// "value"				"50 60 70 80 90"
+				// FIXME 限时强化结束后回退
 				"value"				"65 75 85 95 105"
 				"special_bonus_unique_sven_8" "+45"
 			}
@@ -4340,6 +4342,8 @@
 	"sven_warcry"
 	{
 		"MaxLevel" "5"
+		// FIXME 限时强化结束后回退
+		// "AbilityCooldown"				"40 35 30 25 20"
 		"AbilityCooldown"				"35 30 25 20 15"
 		"AbilityManaCost"				"40 45 50 55 60"
 		"AbilityValues"
@@ -4378,7 +4382,7 @@
 		{
 			"gods_strength_damage"
 			{
-				"value"		"130 160 190 220"
+				"value"		"130 160 190 220"	// 110 150 190
 			}
 		}
 	}
@@ -4641,13 +4645,14 @@
 		{
 				"AbilityCastRange"
 				{
-					"value"		"600"
-					"special_bonus_unique_tiny_4" "+600"
+					// FIXME 限时强化结束后削弱
+					"special_bonus_unique_tiny_4" "+600"	// 200
 				}
 				"avalanche_damage"
 				{
 					"value"				"120 240 360 480"		// 100 190 280 370 加强
-					"special_bonus_unique_tiny"			"+320"
+					// FIXME 限时强化结束后削弱
+					"special_bonus_unique_tiny"			"+320"	// 100
 				}
 		}
 	}
@@ -4696,8 +4701,7 @@
 		{
 			"attack_count"
 			{
-				"value"					"10 15 20 25 30"
-				"special_bonus_shard"	"=0"
+				"value"					"10 15 20 25 30"	// 5
 			}
 			"bonus_damage"
 			{
@@ -4724,8 +4728,6 @@
 	"tiny_grow"
 	{
 		"MaxLevel" "4"
-		"LinkedAbility"					"lycan_shapeshift"
-		"AbilityDraftPreAbility"		"lycan_shapeshift"
 		"AbilityValues"
 		{
 				"bonus_armor"				"10 20 30 40"		// 5 10 15 x2
@@ -4735,6 +4737,8 @@
 				}
 				"attack_speed_reduction"
 				{
+					// FIXME 限时强化结束后回退
+					// "value"		"-20"						// -35 +15
 					"value"		"-0"						// -35 +15
 					"special_bonus_unique_tiny_6" "+10"		// +8 +2
 				}
@@ -5584,6 +5588,7 @@
 			"attack_speed_bonus"
 			{
 				"value"									"100 140 180 220 260"
+				// FIXME 限时强化结束后回退
 				"special_bonus_unique_clinkz_7"			"+200"
 			}
 			"duration"
@@ -5596,11 +5601,7 @@
 				"value"								"30 25 20 15 10"
 				"special_bonus_unique_clinkz_4"		"-5"
 			}
-			"debuff_duration"
-			{
-				"value"							"0"
-				"special_bonus_facet_clinkz_suppressive_fire"			"=2.0"
-			}
+			// FIXME 限时强化结束后回退
 			"blind_pct"
 			{
 				"value"							"0"
@@ -5639,10 +5640,8 @@
 	// 炽烈火雨
 	"clinkz_burning_barrage"
 	{
-		"AbilityCooldown"				"6"
+		"AbilityCooldown"				"6"		// 17
 		"AbilityManaCost"				"90"
-		"Innate" 						"1"
-		"IsGrantedByShard"				"0"
 		"AbilityValues"
 		{
 			"wave_count"		"9"
@@ -6344,17 +6343,22 @@
 	"juggernaut_omni_slash"
 	{
 		"MaxLevel" "4"
-		"AbilityCooldown"				"90 90 90 1"		// 120
-		"AbilityManaCost"				"250 300 350 400"
+		// "AbilityCooldown"				"90"		// 120
+		// FIXME 限时强化结束后回退
+		"AbilityCooldown"				"90 60 30 3"		// 120
 		"LevelsBetweenUpgrades"					"12"
+
+		"AbilityManaCost"				"250 300 350 400"
 		"AbilityValues"
 		{
-			"attack_rate_multiplier"	"1.5 1.7 1.9 2.1"
+			"attack_rate_multiplier"	"1.5 1.7 1.9 2.1"	// 1.5
 			"bonus_damage"				"50 70 90 110"	// x2
 			"bonus_attack_speed"				"100"	// 40
 			"duration"
 			{
-				"value"						"3.1 4.0 5.0 80000"
+				// "value"						"3.1 3.4 3.7 4.0"
+				// FIXME 限时强化结束后回退
+				"value"						"3.0 4.0 5.0 6.0"
 			}
 			"omni_slash_radius"
 			{
@@ -6362,6 +6366,8 @@
 			}
 			"AbilityCastRange"
 			{
+				// "value"					"600"		// 450
+				// FIXME 限时强化结束后回退
 				"value"					"600 600 600 1200"		// 450
 			}
 		}
@@ -6967,21 +6973,6 @@
 		"AbilityDamage"					"75 150 225 300 375"
 		"AbilityValues"
 		{
-			"speed"					"1250"
-			"width"
-			{
-				"value"				"200"
-				"affected_by_aoe_increase"	"1"
-			}
-			"AbilityCharges"
-			{
-				"value"	"0"
-			}
-			// "charge_restore_time"
-			// {
-			// 	"value"	"17 15 13 11 9"
-			// 	"special_bonus_unique_morphling_waveform_cooldown"			"-60%"
-			// }
 			"AbilityCastRange"
 			{
 				"value"				"700 800 900 1000 1100"
@@ -6989,17 +6980,16 @@
 			}
 			"AbilityCooldown"
 			{
+				// "value"									"20 18 16 14 12"
+				// FIXME 限时强化结束后回退
 				"value"														"17 15 13 11 9"
 				"special_bonus_unique_morphling_waveform_cooldown"			"-60%"
 			}
 			"pct_damage"
 			{
-				"value"										"0"
 				"special_bonus_facet_morphling_agi"			"+100"
-				"special_bonus_unique_morphling_4"			"+100"
-				"CalculateSpellDamageTooltip"				"0"
-				"DamageTypeTooltip"							"DAMAGE_TYPE_PHYSICAL"
 			}
+			// FIXME 限时强化结束后回退
 			"process_procs"
 			{
 				"value" "1"
@@ -7043,6 +7033,8 @@
 				}
 				"extra_targets"
 				{
+					// "value"								"1"
+					// FIXME 限时强化结束后回退
 					"value"								"2"
 				}
 		}
@@ -7080,8 +7072,9 @@
 	{
 		"AbilityValues"
 		{
-			"agi_per_one_spell_amp"			"3"
-			"one_percent_tooltip"			"1"
+			// 每N点敏捷增加1%魔法伤害
+			// FIXME 限时强化结束后削弱
+			"agi_per_one_spell_amp"			"3"	// 4
 		}
 	}
 	// 变形
@@ -7094,7 +7087,7 @@
 		{
 			"duration"
 			{
-				"value"								"45"
+				"value"								"45"	// 24
 				"special_bonus_unique_morphling_8" "+15"
 			}
 			"scepter_stat_steal"

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -1289,6 +1289,8 @@
 				"9"		"juggernaut_blade_dance"
 				"10"		"special_bonus_unique_juggernaut"
 				"11"		"juggernaut_healing_ward"
+				// FIXME 限时强化结束后回退
+				// "12"		"juggernaut_omni_slash"
 				"12"		""//只让bot学3级
 				"13"		"juggernaut_healing_ward"
 				"14"		"juggernaut_healing_ward"
@@ -1782,6 +1784,7 @@
 	{
 		"Ability5"		"generic_hidden" // Remove 烈焰之军
 		"Ability12"		"special_bonus_attack_range_100"
+		// FIXME 限时强化结束后回退
 		"Ability15"		"special_bonus_unique_clinkz_1"
 		"Ability13"		"special_bonus_unique_clinkz_10"
 		"Ability11"		"special_bonus_unique_clinkz_9"
@@ -2372,6 +2375,7 @@
 	// 水人
 	"npc_dota_hero_morphling"
 	{
+		// FIXME 限时强化结束后回退
 		"Ability15"		"special_bonus_magic_resistance_15"
 		"Ability21"		"special_bonus_unique_morphling_1"
 		"Ability18"		"special_bonus_attack_range_75"
@@ -2383,8 +2387,7 @@
 	// 小小
 	"npc_dota_hero_tiny"
 	{
-		// "Ability6"		"lycan_shapeshift"
-		// "Ability8"		"tiny_grow"
+		// FIXME 限时强化结束后回退
 		"Ability15"		"special_bonus_unique_tiny_4"
 		"Ability11"		"special_bonus_strength_8"
 		"Ability14"		"special_bonus_unique_tiny_6"

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -1289,7 +1289,7 @@
 				"9"		"juggernaut_blade_dance"
 				"10"		"special_bonus_unique_juggernaut"
 				"11"		"juggernaut_healing_ward"
-				"12"		"juggernaut_omni_slash"
+				"12"		""//只让bot学3级
 				"13"		"juggernaut_healing_ward"
 				"14"		"juggernaut_healing_ward"
 				"15"		"special_bonus_unique_juggernaut_blade_fury_movespeed"
@@ -1782,6 +1782,13 @@
 	{
 		"Ability5"		"generic_hidden" // Remove 烈焰之军
 		"Ability12"		"special_bonus_attack_range_100"
+		"Ability15"		"special_bonus_unique_clinkz_1"
+		"Ability13"		"special_bonus_unique_clinkz_10"
+		"Ability11"		"special_bonus_unique_clinkz_9"
+		"Ability14"		"special_bonus_unique_clinkz_8"
+		"Ability17"		"special_bonus_unique_clinkz_7"
+		"Ability16"		"special_bonus_unique_clinkz_4"
+		"Ability10"		"special_bonus_unique_clinkz_3"
 	}
 	// 全能骑士
 	"npc_dota_hero_omniknight"
@@ -2362,9 +2369,30 @@
 			}
 		}
 	}
+	// 水人
+	"npc_dota_hero_morphling"
+	{
+		"Ability15"		"special_bonus_magic_resistance_15"
+		"Ability21"		"special_bonus_unique_morphling_1"
+		"Ability18"		"special_bonus_attack_range_75"
+		"Ability19"		"special_bonus_unique_morphling_7"
+		"Ability17"		"special_bonus_unique_morphling_waveform_cooldown"
+		"Ability20"		"special_bonus_attack_range_100"
+		"Ability22"		"special_bonus_attack_range_150"
+	}
 	// 小小
 	"npc_dota_hero_tiny"
 	{
+		// "Ability6"		"lycan_shapeshift"
+		// "Ability8"		"tiny_grow"
+		"Ability15"		"special_bonus_unique_tiny_4"
+		"Ability11"		"special_bonus_strength_8"
+		"Ability14"		"special_bonus_unique_tiny_6"
+		"Ability16"		"special_bonus_unique_tiny"
+		"Ability12"		"special_bonus_unique_tiny_7"
+		"Ability17"		"special_bonus_unique_tiny_5"
+		"Ability13"		"special_bonus_unique_tiny_3"
+		"Ability10"		"special_bonus_unique_tiny_2"
 		"Bot"
 		{
 			"Build"

--- a/src/vscripts/modules/GameConfig.ts
+++ b/src/vscripts/modules/GameConfig.ts
@@ -1,5 +1,5 @@
 export class GameConfig {
-  public static readonly GAME_VERSION = 'v4.46';
+  public static readonly GAME_VERSION = 'v4.47';
   public static readonly MEMBER_BUYBACK_CD = 120;
   public static readonly PRE_GAME_TIME = 60;
   // 英雄击杀经验系数

--- a/src/vscripts/modules/debug/Debug.ts
+++ b/src/vscripts/modules/debug/Debug.ts
@@ -56,6 +56,14 @@ export class Debug {
       });
     }
     // ---- item ----
+    // add bkb to all
+    if (cmd === CMD.ADD_BKB_ALL) {
+      PlayerHelper.ForEachPlayer((playerId) => {
+        const hero = PlayerResource.GetSelectedHeroEntity(playerId);
+        if (!hero) return;
+        hero.AddItemByName('item_black_king_bar_2');
+      });
+    }
     if (cmd === CMD.ADD_ITEM_ALL) {
       const itemName = args[0];
       PlayerHelper.ForEachPlayer((playerId) => {

--- a/src/vscripts/modules/debug/debug-cmd.ts
+++ b/src/vscripts/modules/debug/debug-cmd.ts
@@ -36,6 +36,7 @@ export enum CMD {
   ADD_ABILITY_ALL = '-aball',
 
   // ---- item ----
+  ADD_BKB_ALL = '-bkball', // 所有人添加bkb
   ADD_ITEM_ALL = '-additemall', // 所有人添加物品
   RM_ITEM = '-rmitem', // 移除物品
   REPLACE_NEUTRAL_ITEM = '-rn', // 替换中立物品


### PR DESCRIPTION
致敬传奇3亚王ame，5个英雄获得强化——分别是来自ti8的波高水人，ti10没输过的小小，ti14输掉决赛的小骷髅、斯温、剑圣
水人：力水削弱，水炮不再无视魔免。敏水加强，波触发攻击特效，天赋树顺序调整以方便波高
小小：获得与大招绑定的变狼，天赋树调整，小技能加强方便前期肥
小骷髅：天赋树调整，全技能加强，人形高达
斯温：锤与分裂绑定升级，加强全方位数值，锤无视魔免
剑圣：无敌斩6级之后每12级升级一次，满级无限无敌斩不砍死美杜莎不下来