### PR TITLE
Luna updates

### DIFF
--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -6540,23 +6540,27 @@
 		{
 			"AbilityCooldown"
 			{
-				"value"					"9.0 8.0 7.0 6.0 5.0"
-				"special_bonus_unique_luna_2" "-3.0"
+				"value"					"6.0 5.0 4.0 3.0 2.0"
+				"special_bonus_unique_luna_2" "-0.5"
 			}
 			"AbilityManaCost"
 			{
-				"value"					"90 100 110 120 130"
+				"value"					"90 80 70 60 50"
 			}
 			"beam_damage"
 			{
-				"value"					"80 160 240 320 400"
-				"special_bonus_unique_luna_1"	"+150"	// 110
+				"value"					"100 200 300 400 500"
+				"special_bonus_unique_luna_1"	"+125"	// 110
 			}
 			"damage_buff_per_beam"
 			{
 				"value"						"0"
-				"special_bonus_facet_luna_moonstorm"			"+5 8 11 14 17"
-			}
+				"special_bonus_facet_luna_moonstorm"			"+5 10 15 20 25"
+			}	
+			"damage_buff_from_eclipse_pct"
+            {
+                "special_bonus_facet_luna_moonstorm"                "=100"	// 50
+            }
 		}
 	}
 	// 月刃
@@ -6568,8 +6572,8 @@
 			"bounces"							"3 4 5 6 7"
 			"damage_reduction_percent"
 			{
-				"value"							"50 45 40 35 30"
-				"special_bonus_unique_luna_7"	"-10"		// -5
+				"value"							"-10 -15 -20 -25 -30"
+				"special_bonus_unique_luna_7"	"-15"		// -5
 			}
 		}
 	}
@@ -6581,16 +6585,16 @@
 		{
 			"rotating_glaives_duration"
 			{
-				"value"								"5 6 7 8 9"
+				"value"								"6 8 10 12 14"
 			}
 			"rotating_glaives"
 			{
-				"value"								"4"
+				"value"								"4 5 6 7 8"
 				"special_bonus_unique_luna_lunar_orbit_glaive_count"				"+4"	// +1
 			}
 			"rotating_glaives_collision_damage"
 			{
-				"value"								"20 25 30 35 40"
+				"value"								"20 30 40 50 60"
 			}
 			"AbilityCooldown"
 			{
@@ -6598,12 +6602,12 @@
 			}
 			"AbilityManaCost"
 			{
-				"value"			"65 70 75 80 85"
+				"value"			"65 55 45 35 25"
 			}
 			"rotating_glaives_damage_reduction"
 			{
 				"value"									"0"
-				"special_bonus_facet_luna_moonshield"	"15 20 25 30 35"
+				"special_bonus_facet_luna_moonshield"	"15 30 45 60 75"
 			}
 		}
 	}
@@ -6614,17 +6618,17 @@
 		{
 				"bonus_night_vision_self"
 				{
-					"value"			"400"			// 250
+					"value"			"500"			// 250
 				}
 				"bonus_damage_per_level"
 				{
-					"value"							"3"			// 1
-					"special_bonus_unique_luna_3"	"+3"		// +1
+					"value"							"5"			// 1
+					"special_bonus_unique_luna_3"	"+5"		// +1
 				}
 				"self_bonus_damage_per_level"
 				{
-					"value"							"6"			// 2
-					"special_bonus_unique_luna_3"	"+6"		// +2
+					"value"							"10"			// 2
+					"special_bonus_unique_luna_3"	"+10"		// +2
 				}
 		}
 	}
@@ -6642,14 +6646,14 @@
 			}
 			"beam_interval"
 			{
-				"value"					"0.6 0.6 0.6 0.5"
-				"special_bonus_scepter"	"-0.3"
+				"value"					"0.6 0.6 0.6 0.6"
+				"special_bonus_scepter"	"-0.4"
 			}
 			"beam_interval_scepter"		"0.2" // purely for the tooltip Note, since the scepter tooltip doesn't show this.
 			"hit_count"
 			{
-				"value"					"5"
-				"special_bonus_scepter"	"+1 +7 +13 +19"
+				"value"					"6 12 18 24"
+				"special_bonus_scepter"	"+0"
 			}
 			"AbilityDuration"
 			{
@@ -6658,8 +6662,8 @@
 			}
 			"AbilityCooldown"
 			{
-				"value"							"90"	// 105
-				"special_bonus_unique_luna_6"	"-20.0"	// -40.0
+				"value"							"90 80 70 60"	// 105
+				"special_bonus_unique_luna_6"	"-30.0"	// -40.0
 			}
 		}
 	}

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -1501,6 +1501,19 @@
 	}
 	"npc_dota_hero_luna"
 	{
+		"Ability12"						"special_bonus_unique_luna_8"
+		"ArmorPhysical"					"4"			// 2
+		"AttackRate"					"1.4"		// 1.7
+		"AttackRange"					"450"		// 330
+		"ProjectileSpeed"				"1250"		// 900
+		"AttributeBaseStrength"			"25"		// 21
+        "AttributeStrengthGain"			"2.6"		// 2.2
+        "AttributeBaseAgility"			"36"		// 24
+        "AttributeAgilityGain"			"4.1"		// 3.4
+        "AttributeIntelligenceGain"		"2.3"		// 1.9
+        "StatusHealthRegen"				"5"			// 0.5
+		"MovementSpeed"					"340"		// 325
+		"VisionNighttimeRange"      	"1800"		// 800
 		"Bot"
 		{
 			"Build"
@@ -1532,7 +1545,7 @@
 				"25"		"special_bonus_unique_luna_5"
 				"26"		""
 				"27"		"special_bonus_unique_luna_7"
-				"28"		"special_bonus_unique_luna_lunar_orbit_glaive_count"
+				"28"		"special_bonus_unique_luna_5"
 				"29"		"special_bonus_unique_luna_2"
 				"30"		"special_bonus_unique_luna_3"
 				"31"		"luna_eclipse"

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -1501,7 +1501,10 @@
 	}
 	"npc_dota_hero_luna"
 	{
-		"Ability12"						"special_bonus_unique_luna_8"
+		"Ability11"						"special_bonus_attack_range_150"
+		"Ability12"						"special_bonus_unique_luna_2"
+		"Ability15"						"special_bonus_unique_luna_3"
+		"Ability16"						"special_bonus_unique_luna_8"
 		"ArmorPhysical"					"4"			// 2
 		"AttackRate"					"1.4"		// 1.7
 		"AttackRange"					"450"		// 330
@@ -1527,12 +1530,12 @@
 				"7"		"luna_lucent_beam"
 				"8"		"luna_lunar_orbit"
 				"9"		"luna_lucent_beam"
-				"10"		"special_bonus_unique_luna_4"
+				"10"		"special_bonus_unique_luna_7"
 				"11"		"luna_moon_glaive"
 				"12"		"luna_eclipse"
 				"13"		"luna_moon_glaive"
 				"14"		"luna_lunar_orbit"
-				"15"		"special_bonus_unique_luna_6"
+				"15"		"special_bonus_attack_range_150"
 				"16"		"luna_lunar_orbit"
 				"17"		""
 				"18"		"luna_eclipse"
@@ -1542,12 +1545,12 @@
 				"22"		""
 				"23"		""
 				"24"		""
-				"25"		"special_bonus_unique_luna_5"
+				"25"		"special_bonus_unique_luna_8"
 				"26"		""
 				"27"		"special_bonus_unique_luna_7"
-				"28"		"special_bonus_unique_luna_5"
-				"29"		"special_bonus_unique_luna_2"
-				"30"		"special_bonus_unique_luna_3"
+				"28"		"special_bonus_unique_luna_6"
+				"29"		"special_bonus_unique_luna_3"
+				"30"		"special_bonus_unique_luna_5"
 				"31"		"luna_eclipse"
 				"32"		"luna_moon_glaive"
 				"33"		"luna_lunar_orbit"


### PR DESCRIPTION
So, you're looking to buff the bots? Well, it just so happens that one of my favorite heroes, who also happens to be a hero the bot plays as, is Luna. And I was gonna tweak her numbers down the line, but hey, since you seem so keen on bringing up bot winrates and lowering player winrates in your game, I thought 'why not make Luna stronger to make it so if there's a Luna bot, she'd be a force to be reckoned with?' After all, Tinker gets a 90% status resist shield, Jugg gets a 4s CD ult, there's plenty of possibilities I could do with Luna!

In addition to my usual stat sweeps (and don't worry, if Valve somehow manages to change how those work, I'll be on top of those in a heartbeat), I've also vastly changed her abilities to be much more potent, though her Beams and Eclipse will not pierce BKBs nor will they deal a different damage type other than magical, those will remain as is otherwise.