### PR TITLE
Add Lone Druid Spirit Bear inheritance awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3494,5 +3494,10 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark"		"Frost Calamity"
 		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark_Description"		"At 3 stacks, triggers a Frost Calamity detonation. Lich can also detonate it early with Frost Blast."
 
+		// 德鲁伊 觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_lone_druid_upgrade"		"<font color='#d000ff'>Symbiotic Spirit Bear Awakening</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_lone_druid_upgrade_Description"		"Spirit Bear inherits all of Lone Druid's currently active out-of-game properties and bonus ability points.<br>It also synchronizes the current levels of abilities gained from the starting lottery, Ability Reset Tome, and Passive Skill Tome."
+		"DOTA_Tooltip_modifier_special_bonus_unique_lone_druid_upgrade"		"<font color='#d000ff'>Symbiotic Spirit Bear Awakening</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lone_druid_upgrade_Description"		"Your Spirit Bear inherits all out-of-game properties, bonus ability points, and current extra abilities. Ability resets and abilities granted by the Passive Skill Tome synchronize automatically."
 	}
 }

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3496,5 +3496,10 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>The Quickening Awakened</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"Whenever a unit dies within <font color='#FFFFFF'><b>900</b></font> range, the current cooldowns of all Abaddon's abilities and items are reduced. Non-hero deaths reduce them by <font color='#FFFFFF'><b>0.2</b></font>s; hero deaths reduce them by <font color='#FFFFFF'><b>3</b></font>s."
 
+		// 德鲁伊 觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_lone_druid_upgrade"		"<font color='#d000ff'>Symbiotic Spirit Bear Awakening</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_lone_druid_upgrade_Description"		"Spirit Bear inherits all of Lone Druid's currently active out-of-game properties and bonus ability points.<br>It also synchronizes the current levels of abilities gained from the starting lottery, Ability Reset Tome, and Passive Skill Tome."
+		"DOTA_Tooltip_modifier_special_bonus_unique_lone_druid_upgrade"		"<font color='#d000ff'>Symbiotic Spirit Bear Awakening</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lone_druid_upgrade_Description"		"Your Spirit Bear inherits all out-of-game properties, bonus ability points, and current extra abilities. Ability resets and abilities granted by the Passive Skill Tome synchronize automatically."
 	}
 }

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -567,5 +567,10 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_tiny_upgrade"					"<font color='#d000ff'>Пробуждение Tiny</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_tiny_upgrade_Description"		"Захваченное дерево больше не разрушается, когда заканчиваются его атаки.<br>Grow больше не снижает скорость атаки."
 
+		// 德鲁伊 觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_lone_druid_upgrade"		"<font color='#d000ff'>Пробуждение: Симбиоз с медведем</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_lone_druid_upgrade_Description"		"Spirit Bear наследует все действующие внематчевые характеристики Lone Druid и дополнительные очки способностей.<br>Он также синхронизирует текущие уровни способностей, полученных в начале игры, после замены через Ability Reset Tome и добавления через Passive Skill Tome."
+		"DOTA_Tooltip_modifier_special_bonus_unique_lone_druid_upgrade"		"<font color='#d000ff'>Пробуждение: Симбиоз с медведем</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lone_druid_upgrade_Description"		"Ваш Spirit Bear наследует все внематчевые характеристики, дополнительные очки способностей и текущие дополнительные способности. Замены через Ability Reset Tome и новые способности из Passive Skill Tome синхронизируются автоматически."
 	}
 }

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -617,5 +617,10 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>Ускорение · Пробуждение</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"Когда юнит погибает в радиусе <font color='#FFFFFF'><b>900</b></font> от Abaddon, текущее время перезарядки всех его способностей и предметов сокращается. Смерть не-героя сокращает его на <font color='#FFFFFF'><b>0.2</b></font> сек., а смерть героя — на <font color='#FFFFFF'><b>3</b></font> сек."
 
+		// 德鲁伊 觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_lone_druid_upgrade"		"<font color='#d000ff'>Пробуждение: Симбиоз с медведем</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_lone_druid_upgrade_Description"		"Spirit Bear наследует все действующие внематчевые характеристики Lone Druid и дополнительные очки способностей.<br>Он также синхронизирует текущие уровни способностей, полученных в начале игры, после замены через Ability Reset Tome и добавления через Passive Skill Tome."
+		"DOTA_Tooltip_modifier_special_bonus_unique_lone_druid_upgrade"		"<font color='#d000ff'>Пробуждение: Симбиоз с медведем</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lone_druid_upgrade_Description"		"Ваш Spirit Bear наследует все внематчевые характеристики, дополнительные очки способностей и текущие дополнительные способности. Замены через Ability Reset Tome и новые способности из Passive Skill Tome синхронизируются автоматически."
 	}
 }

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3501,5 +3501,10 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark"		"寒灾印记"
 		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark_Description"		"达到3层时触发寒灾冰爆；巫妖也可使用寒霜爆发提前引爆。"
 
+		// 德鲁伊 觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_lone_druid_upgrade"		"<font color='#d000ff'>共生灵熊·觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_lone_druid_upgrade_Description"		"灵熊继承德鲁伊当前生效的全部局外属性和额外技能点。<br>同时同步开局抽取、能力重置书替换以及被动技能书新增的技能及其当前等级。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lone_druid_upgrade"		"<font color='#d000ff'>共生灵熊·觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lone_druid_upgrade_Description"		"你的灵熊继承全部局外属性、额外技能点和当前额外技能；使用能力重置书或被动技能书后会自动同步。"
 	}
 }

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3505,5 +3505,10 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>畅快淋漓 觉醒</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"附近 <font color='#FFFFFF'><b>900</b></font> 范围内有单位阵亡时，亚巴顿所有技能和物品的当前冷却都会减少。非英雄单位阵亡减少 <font color='#FFFFFF'><b>0.2</b></font> 秒，英雄阵亡减少 <font color='#FFFFFF'><b>3</b></font> 秒。"
 
+		// 德鲁伊 觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_lone_druid_upgrade"		"<font color='#d000ff'>共生灵熊·觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_lone_druid_upgrade_Description"		"灵熊继承德鲁伊当前生效的全部局外属性和额外技能点。<br>同时同步开局抽取、能力重置书替换以及被动技能书新增的技能及其当前等级。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lone_druid_upgrade"		"<font color='#d000ff'>共生灵熊·觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lone_druid_upgrade_Description"		"你的灵熊继承全部局外属性、额外技能点和当前额外技能；使用能力重置书或被动技能书后会自动同步。"
 	}
 }

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -5,6 +5,21 @@
 	// 英雄专属强化/替换技能，通过抽奖池获得
 	//=================================================================================================================
 
+	// 德鲁伊 觉醒
+	"special_bonus_unique_lone_druid_upgrade"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/special_bonus_unique_lone_druid_upgrade"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"			"lone_druid_spirit_bear"
+		"MaxLevel"						"1"
+
+		"AbilityValues"
+		{
+			"sync_interval"				"1.0"
+		}
+	}
+
 	// 上古巨神 觉醒灵体游魂
 	// 除冷却（觉醒专属强化，免瞄准自动施放，缩短冷却体现觉醒增益）外，
 	// 其余数值仅供技能面板显示，须与 Dota2 原版数值 + npc_abilities_override.txt 差分之后的内容保持一致

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -37,6 +37,20 @@
 			"cooldown_reduction"		"0.1"
 		}
 	}
+	// 德鲁伊 觉醒
+	"special_bonus_unique_lone_druid_upgrade"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/special_bonus_unique_lone_druid_upgrade"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"			"lone_druid_spirit_bear"
+		"MaxLevel"						"1"
+
+		"AbilityValues"
+		{
+			"sync_interval"				"1.0"
+		}
+	}
 
 	// 上古巨神 觉醒灵体游魂
 	// 除冷却（觉醒专属强化，免瞄准自动施放，缩短冷却体现觉醒增益）外，

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,10 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_lone_druid',
+    abilityName: 'special_bonus_unique_lone_druid_upgrade',
+  },
+  {
     heroName: 'npc_dota_hero_elder_titan',
     abilityName: 'elder_titan_ancestral_spirit_awaken',
   },

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,10 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_lone_druid',
+    abilityName: 'special_bonus_unique_lone_druid_upgrade',
+  },
+  {
     heroName: 'npc_dota_hero_abaddon',
     abilityName: 'special_bonus_unique_abaddon_quickening_awaken',
     freeTrial: true,

--- a/src/vscripts/abilities/ts_abilities/lone-druid-bear-inheritance.test.ts
+++ b/src/vscripts/abilities/ts_abilities/lone-druid-bear-inheritance.test.ts
@@ -1,0 +1,215 @@
+import {
+  buildInheritedAbilityRuntimeSignature,
+  buildLoneDruidBearInheritanceSignature,
+  calculateInheritedAbilityDiff,
+  collectInheritableAbilities,
+  isOwnedLoneDruidSpiritBearCandidate,
+} from './lone-druid-bear-inheritance';
+import { calculateBonusSkillPointCount } from '../../modules/property/property-calculations';
+
+describe('collectInheritableAbilities', () => {
+  const allowed = new Set(['axe_berserkers_call', 'bristleback_bristleback', 'axe_counter_helix']);
+
+  it('keeps only lottery abilities and preserves current levels', () => {
+    expect(
+      collectInheritableAbilities(
+        [
+          { name: 'axe_berserkers_call', level: 3 },
+          { name: 'bristleback_bristleback', level: 2 },
+          { name: 'lone_druid_spirit_bear', level: 4 },
+          { name: 'special_bonus_unique_lone_druid_upgrade', level: 1 },
+          { name: 'item_tpscroll', level: 1 },
+          { name: 'unknown_custom_ability', level: 1 },
+        ],
+        allowed,
+      ),
+    ).toEqual([
+      { name: 'axe_berserkers_call', level: 3 },
+      { name: 'bristleback_bristleback', level: 2 },
+    ]);
+  });
+
+  it('keeps a newly added tome ability before it gains a level', () => {
+    expect(collectInheritableAbilities([{ name: 'axe_counter_helix', level: 0 }], allowed)).toEqual(
+      [{ name: 'axe_counter_helix', level: 0 }],
+    );
+  });
+
+  it('deduplicates ability names and keeps the highest current level', () => {
+    expect(
+      collectInheritableAbilities(
+        [
+          { name: 'axe_counter_helix', level: 1 },
+          { name: 'axe_counter_helix', level: 3 },
+        ],
+        allowed,
+      ),
+    ).toEqual([{ name: 'axe_counter_helix', level: 3 }]);
+  });
+});
+
+describe('calculateInheritedAbilityDiff', () => {
+  it('removes the reset-book old skill and adds its replacement', () => {
+    expect(
+      calculateInheritedAbilityDiff(
+        [
+          { name: 'bristleback_bristleback', level: 2 },
+          { name: 'sven_gods_strength', level: 1 },
+        ],
+        {
+          axe_berserkers_call: 3,
+          bristleback_bristleback: 2,
+        },
+      ),
+    ).toEqual({
+      add: [{ name: 'sven_gods_strength', level: 1 }],
+      update: [],
+      remove: ['axe_berserkers_call'],
+    });
+  });
+
+  it('adds a passive-tome skill and synchronizes later level changes', () => {
+    expect(
+      calculateInheritedAbilityDiff(
+        [
+          { name: 'bristleback_bristleback', level: 3 },
+          { name: 'axe_counter_helix', level: 1 },
+        ],
+        { bristleback_bristleback: 2 },
+      ),
+    ).toEqual({
+      add: [{ name: 'axe_counter_helix', level: 1 }],
+      update: [{ name: 'bristleback_bristleback', level: 3 }],
+      remove: [],
+    });
+  });
+
+  it('never removes abilities that are not in the awakening ledger', () => {
+    expect(calculateInheritedAbilityDiff([], {})).toEqual({ add: [], update: [], remove: [] });
+  });
+
+  it('repairs an inherited skill that is missing from the bear', () => {
+    expect(
+      calculateInheritedAbilityDiff(
+        [{ name: 'axe_berserkers_call', level: 3 }],
+        { axe_berserkers_call: 3 },
+        { axe_berserkers_call: undefined },
+      ),
+    ).toEqual({
+      add: [],
+      update: [{ name: 'axe_berserkers_call', level: 3 }],
+      remove: [],
+    });
+  });
+
+  it('repairs an inherited skill whose bear level was changed externally', () => {
+    expect(
+      calculateInheritedAbilityDiff(
+        [{ name: 'axe_berserkers_call', level: 3 }],
+        { axe_berserkers_call: 3 },
+        { axe_berserkers_call: 1 },
+      ),
+    ).toEqual({
+      add: [],
+      update: [{ name: 'axe_berserkers_call', level: 3 }],
+      remove: [],
+    });
+  });
+});
+
+describe('calculateBonusSkillPointCount', () => {
+  it.each([
+    [0, 0],
+    [1, 0],
+    [2, 1],
+    [7, 3],
+    [8, 4],
+  ])('converts active property level %s into %s inherited points', (activeLevel, expected) => {
+    expect(calculateBonusSkillPointCount(activeLevel)).toBe(expected);
+  });
+});
+
+describe('buildInheritedAbilityRuntimeSignature', () => {
+  const desired = [{ name: 'axe_berserkers_call', level: 3 }];
+
+  it('changes when a desired bear skill disappears', () => {
+    expect(buildInheritedAbilityRuntimeSignature(desired, { axe_berserkers_call: 3 })).not.toBe(
+      buildInheritedAbilityRuntimeSignature(desired, { axe_berserkers_call: undefined }),
+    );
+  });
+});
+
+describe('buildLoneDruidBearInheritanceSignature', () => {
+  const properties = [
+    { name: 'property_stats_strength_bonus', level: 8 },
+    { name: 'property_skill_points_bonus', level: 8 },
+  ];
+  const abilities = [
+    { name: 'axe_berserkers_call', level: 3 },
+    { name: 'bristleback_bristleback', level: 2 },
+  ];
+
+  it('is stable when input order changes', () => {
+    expect(buildLoneDruidBearInheritanceSignature(30, properties, abilities, 4)).toBe(
+      buildLoneDruidBearInheritanceSignature(
+        30,
+        [...properties].reverse(),
+        [...abilities].reverse(),
+        4,
+      ),
+    );
+  });
+
+  it('changes when an inherited level changes', () => {
+    expect(buildLoneDruidBearInheritanceSignature(30, properties, abilities, 4)).not.toBe(
+      buildLoneDruidBearInheritanceSignature(
+        30,
+        properties,
+        [{ name: 'axe_berserkers_call', level: 4 }, abilities[1]],
+        4,
+      ),
+    );
+  });
+});
+
+describe('isOwnedLoneDruidSpiritBearCandidate', () => {
+  const owned = {
+    unitName: 'npc_dota_lone_druid_bear1',
+    ownerEntityIndex: 100,
+    ownerIsBaseNpc: true,
+    druidEntityIndex: 100,
+    unitPlayerOwnerId: 2,
+    druidPlayerOwnerId: 2,
+    unitTeam: 2,
+    druidTeam: 2,
+  };
+
+  it.each([
+    'npc_dota_lone_druid_bear1',
+    'npc_dota_lone_druid_bear2',
+    'npc_dota_lone_druid_bear3',
+    'npc_dota_lone_druid_bear4',
+  ])('accepts an owned spirit bear variant: %s', (unitName) => {
+    expect(isOwnedLoneDruidSpiritBearCandidate({ ...owned, unitName })).toBe(true);
+  });
+
+  it('accepts the real runtime shape where GetOwnerEntity returns the player entity', () => {
+    expect(
+      isOwnedLoneDruidSpiritBearCandidate({
+        ...owned,
+        ownerEntityIndex: 1,
+        ownerIsBaseNpc: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects a bear owned by another Druid', () => {
+    expect(isOwnedLoneDruidSpiritBearCandidate({ ...owned, ownerEntityIndex: 200 })).toBe(false);
+  });
+
+  it('rejects unrelated summons', () => {
+    expect(
+      isOwnedLoneDruidSpiritBearCandidate({ ...owned, unitName: 'npc_dota_warlock_golem_1' }),
+    ).toBe(false);
+  });
+});

--- a/src/vscripts/abilities/ts_abilities/lone-druid-bear-inheritance.ts
+++ b/src/vscripts/abilities/ts_abilities/lone-druid-bear-inheritance.ts
@@ -1,0 +1,149 @@
+import {
+  abilityTiersActive,
+  abilityTiersPassive,
+} from '../../modules/lottery/ability/lottery-abilities';
+
+export const LONE_DRUID_BEAR_INHERITANCE_MODIFIER =
+  'modifier_special_bonus_unique_lone_druid_upgrade_bear';
+
+export interface InheritedAbilitySnapshot {
+  name: string;
+  level: number;
+}
+
+export interface InheritedPropertySnapshot {
+  name: string;
+  level: number;
+}
+
+export interface InheritedAbilityDiff {
+  add: InheritedAbilitySnapshot[];
+  update: InheritedAbilitySnapshot[];
+  remove: string[];
+}
+
+export interface LoneDruidSpiritBearCandidate {
+  unitName: string;
+  ownerEntityIndex: number | undefined;
+  ownerIsBaseNpc: boolean;
+  druidEntityIndex: number;
+  unitPlayerOwnerId: number;
+  druidPlayerOwnerId: number;
+  unitTeam: number;
+  druidTeam: number;
+}
+
+function buildLotteryAbilityNameSet(): Set<string> {
+  const names = new Set<string>();
+  for (const tier of [...abilityTiersActive, ...abilityTiersPassive]) {
+    for (const name of tier.names) names.add(name);
+  }
+  return names;
+}
+
+export const LONE_DRUID_INHERITABLE_ABILITY_NAMES = buildLotteryAbilityNameSet();
+
+export function collectInheritableAbilities(
+  ownedAbilities: InheritedAbilitySnapshot[],
+  allowedNames: Set<string> = LONE_DRUID_INHERITABLE_ABILITY_NAMES,
+): InheritedAbilitySnapshot[] {
+  const levels = new Map<string, number>();
+  for (const ability of ownedAbilities) {
+    if (!allowedNames.has(ability.name)) continue;
+    levels.set(ability.name, Math.max(levels.get(ability.name) ?? 0, ability.level));
+  }
+
+  return [...levels.entries()]
+    .map(([name, level]) => ({ name, level }))
+    .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+}
+
+export function calculateInheritedAbilityDiff(
+  desiredAbilities: InheritedAbilitySnapshot[],
+  inheritedLedger: Record<string, number>,
+  actualAbilityLevels?: Record<string, number | undefined>,
+): InheritedAbilityDiff {
+  const desiredByName = new Map<string, number>();
+  for (const ability of desiredAbilities) desiredByName.set(ability.name, ability.level);
+
+  const add: InheritedAbilitySnapshot[] = [];
+  const update: InheritedAbilitySnapshot[] = [];
+  for (const ability of desiredAbilities) {
+    const inheritedLevel = inheritedLedger[ability.name];
+    if (inheritedLevel === undefined) add.push(ability);
+    else if (
+      inheritedLevel !== ability.level ||
+      (actualAbilityLevels !== undefined && actualAbilityLevels[ability.name] !== ability.level)
+    ) {
+      update.push(ability);
+    }
+  }
+
+  const remove = Object.keys(inheritedLedger)
+    .filter((name) => !desiredByName.has(name))
+    .sort();
+
+  return {
+    add: add.sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0)),
+    update: update.sort((left, right) =>
+      left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+    ),
+    remove,
+  };
+}
+
+export function buildInheritedAbilityRuntimeSignature(
+  desiredAbilities: InheritedAbilitySnapshot[],
+  actualAbilityLevels: Record<string, number | undefined>,
+): string {
+  return desiredAbilities
+    .map((ability) => `${ability.name}:${actualAbilityLevels[ability.name] ?? 'missing'}`)
+    .sort()
+    .join(',');
+}
+
+export function buildLoneDruidBearInheritanceSignature(
+  druidLevel: number,
+  properties: InheritedPropertySnapshot[],
+  abilities: InheritedAbilitySnapshot[],
+  bonusSkillPoints: number,
+): string {
+  const propertySignature = properties
+    .map((property) => `${property.name}:${property.level}`)
+    .sort()
+    .join(',');
+  const abilitySignature = abilities
+    .map((ability) => `${ability.name}:${ability.level}`)
+    .sort()
+    .join(',');
+  return `${druidLevel}|${bonusSkillPoints}|${propertySignature}|${abilitySignature}`;
+}
+
+export function isLoneDruidSpiritBearUnitName(unitName: string): boolean {
+  return unitName.startsWith('npc_dota_lone_druid_bear');
+}
+
+export function isOwnedLoneDruidSpiritBearCandidate(
+  candidate: LoneDruidSpiritBearCandidate,
+): boolean {
+  if (
+    !isLoneDruidSpiritBearUnitName(candidate.unitName) ||
+    candidate.unitTeam !== candidate.druidTeam
+  ) {
+    return false;
+  }
+
+  if (candidate.ownerEntityIndex === candidate.druidEntityIndex) {
+    return true;
+  }
+
+  if (candidate.ownerEntityIndex !== undefined && candidate.ownerIsBaseNpc) {
+    return false;
+  }
+
+  return (
+    candidate.unitPlayerOwnerId >= 0 &&
+    candidate.druidPlayerOwnerId >= 0 &&
+    candidate.unitPlayerOwnerId === candidate.druidPlayerOwnerId
+  );
+}

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_lone_druid_upgrade.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_lone_druid_upgrade.ts
@@ -1,0 +1,327 @@
+import { Player, PlayerProperty } from '../../api/player';
+import {
+  addAbilityToDynamicSlot,
+  moveAbilityToDynamicSlot,
+} from '../../modules/lottery/ability/ability-slot';
+import { PropertyController } from '../../modules/property/property_controller';
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+import {
+  buildInheritedAbilityRuntimeSignature,
+  buildLoneDruidBearInheritanceSignature,
+  calculateInheritedAbilityDiff,
+  collectInheritableAbilities,
+  InheritedAbilitySnapshot,
+  isLoneDruidSpiritBearUnitName,
+  LONE_DRUID_BEAR_INHERITANCE_MODIFIER,
+  isOwnedLoneDruidSpiritBearCandidate,
+} from './lone-druid-bear-inheritance';
+
+const AWAKEN_MODIFIER = 'modifier_special_bonus_unique_lone_druid_upgrade';
+const BEAR_MODIFIER = LONE_DRUID_BEAR_INHERITANCE_MODIFIER;
+const BEAR_SPAWN_RETRY_DELAYS = [0.03, 0.1, 0.3];
+
+@registerAbility('special_bonus_unique_lone_druid_upgrade')
+export class SpecialBonusUniqueLoneDruidUpgrade extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return AWAKEN_MODIFIER;
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_lone_druid_upgrade')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_lone_druid_upgrade extends BaseModifier {
+  private spawnListenerId: EventListenerID | undefined;
+
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  OnCreated(): void {
+    if (!IsServer()) return;
+    this.spawnListenerId = ListenToGameEvent(
+      'npc_spawned',
+      (event) => this.onNpcSpawned(event),
+      this,
+    );
+    this.scanExistingBears();
+    Timers.CreateTimer(0, () => {
+      if (!this.IsNull()) this.scanExistingBears();
+    });
+  }
+
+  OnRefresh(): void {
+    if (IsServer()) this.scanExistingBears();
+  }
+
+  OnDestroy(): void {
+    if (!IsServer()) return;
+    if (this.spawnListenerId !== undefined) {
+      StopListeningToGameEvent(this.spawnListenerId);
+      this.spawnListenerId = undefined;
+    }
+
+    const druid = this.GetParent();
+    if (druid.IsNull()) return;
+    this.forEachSpiritBear((bear) => bear.RemoveModifierByNameAndCaster(BEAR_MODIFIER, druid));
+  }
+
+  private onNpcSpawned(event: GameEventProvidedProperties & NpcSpawnedEvent): void {
+    const entity = EntIndexToHScript(event.entindex) as CBaseEntity | undefined;
+    if (!entity || entity.IsNull() || !entity.IsBaseNPC()) return;
+    const bear = entity as CDOTA_BaseNPC;
+    if (!isLoneDruidSpiritBearUnitName(bear.GetUnitName())) return;
+    if (!this.tryAttachBearModifier(bear)) this.retryAttachBearModifier(event.entindex, 0);
+  }
+
+  private retryAttachBearModifier(entindex: EntityIndex, retryIndex: number): void {
+    if (retryIndex >= BEAR_SPAWN_RETRY_DELAYS.length) return;
+    Timers.CreateTimer(BEAR_SPAWN_RETRY_DELAYS[retryIndex], () => {
+      if (this.IsNull()) return;
+      const entity = EntIndexToHScript(entindex) as CBaseEntity | undefined;
+      if (!entity || entity.IsNull() || !entity.IsBaseNPC()) return;
+      const bear = entity as CDOTA_BaseNPC;
+      if (!isLoneDruidSpiritBearUnitName(bear.GetUnitName())) return;
+      if (!this.tryAttachBearModifier(bear)) this.retryAttachBearModifier(entindex, retryIndex + 1);
+    });
+  }
+
+  private scanExistingBears(): void {
+    this.forEachSpiritBear((bear) => this.tryAttachBearModifier(bear));
+  }
+
+  private forEachSpiritBear(callback: (bear: CDOTA_BaseNPC) => void): void {
+    let entity = Entities.First() as CBaseEntity | undefined;
+    while (entity) {
+      const next = Entities.Next(entity);
+      if (!entity.IsNull() && entity.IsBaseNPC()) {
+        const unit = entity as CDOTA_BaseNPC;
+        if (isLoneDruidSpiritBearUnitName(unit.GetUnitName())) callback(unit);
+      }
+      entity = next;
+    }
+  }
+
+  private tryAttachBearModifier(bear: CDOTA_BaseNPC): boolean {
+    const druid = this.GetParent();
+    const awaken = this.GetAbility();
+    if (
+      this.IsNull() ||
+      bear.IsNull() ||
+      !bear.IsAlive() ||
+      druid.IsNull() ||
+      !druid.IsRealHero() ||
+      !awaken ||
+      awaken.IsNull() ||
+      awaken.GetLevel() <= 0 ||
+      !awaken.IsActivated() ||
+      !this.isOwnedBear(bear, druid)
+    ) {
+      return false;
+    }
+
+    if (bear.FindModifierByNameAndCaster(BEAR_MODIFIER, druid)) return true;
+    if (bear.HasModifier(BEAR_MODIFIER)) bear.RemoveModifierByName(BEAR_MODIFIER);
+    return bear.AddNewModifier(druid, awaken, BEAR_MODIFIER, {}) !== undefined;
+  }
+
+  private isOwnedBear(bear: CDOTA_BaseNPC, druid: CDOTA_BaseNPC): boolean {
+    const owner = bear.GetOwnerEntity() as CBaseEntity | undefined;
+    const ownerEntityIndex = owner && !owner.IsNull() ? owner.GetEntityIndex() : undefined;
+    const bearPlayerId = bear.GetPlayerOwnerID();
+    const druidPlayerId = druid.GetPlayerOwnerID();
+    return isOwnedLoneDruidSpiritBearCandidate({
+      unitName: bear.GetUnitName(),
+      ownerEntityIndex,
+      ownerIsBaseNpc: owner !== undefined && !owner.IsNull() && owner.IsBaseNPC(),
+      druidEntityIndex: druid.GetEntityIndex(),
+      unitPlayerOwnerId: PlayerResource.IsValidPlayerID(bearPlayerId) ? bearPlayerId : -1,
+      druidPlayerOwnerId: PlayerResource.IsValidPlayerID(druidPlayerId) ? druidPlayerId : -1,
+      unitTeam: bear.GetTeamNumber(),
+      druidTeam: druid.GetTeamNumber(),
+    });
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_lone_druid_upgrade')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_lone_druid_upgrade_bear extends BaseModifier {
+  private signature = '';
+  private bonusSkillPointLedgerKey = '';
+  private inheritedAbilityLedger: Record<string, number> = {};
+
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return true;
+  }
+
+  OnCreated(): void {
+    if (!IsServer()) return;
+    this.bonusSkillPointLedgerKey = `lone-druid-bear:${this.GetParent().GetEntityIndex()}`;
+    this.syncInheritance();
+    const ability = this.GetAbility();
+    this.StartIntervalThink(ability ? ability.GetSpecialValueFor('sync_interval') : 1);
+  }
+
+  OnIntervalThink(): void {
+    this.syncInheritance();
+  }
+
+  OnDestroy(): void {
+    if (!IsServer()) return;
+    const bear = this.GetParent();
+    if (bear.IsNull()) {
+      PropertyController.ForgetBonusSkillPointLedger(this.bonusSkillPointLedgerKey);
+      return;
+    }
+    PropertyController.RemoveAllPlayerPropertyFromUnit(bear);
+    PropertyController.SyncBonusSkillPointsToUnit(bear, 0, this.bonusSkillPointLedgerKey);
+    for (const abilityName of Object.keys(this.inheritedAbilityLedger)) {
+      bear.RemoveAbility(abilityName);
+    }
+    this.inheritedAbilityLedger = {};
+  }
+
+  private syncInheritance(): void {
+    const bear = this.GetParent();
+    const druid = this.GetCaster();
+    if (!druid || druid.IsNull() || !druid.IsRealHero() || bear.IsNull() || !bear.IsAlive()) return;
+
+    const playerId = druid.GetPlayerOwnerID();
+    if (!PlayerResource.IsValidPlayerID(playerId)) return;
+    const steamId = PlayerResource.GetSteamAccountID(playerId);
+    const properties = Player.playerInfoMap.get(steamId.toString())?.properties ?? [];
+    const abilities = collectInheritableAbilities(this.getDruidAbilities(druid));
+    const skillPointProperty = properties.find(
+      (property) => property.name === 'property_skill_points_bonus',
+    );
+    const playerPropertiesEnabled = GameRules.Option.enablePlayerAttribute;
+    const bonusSkillPoints =
+      playerPropertiesEnabled && skillPointProperty
+        ? PropertyController.GetBonusSkillPointCount(druid, skillPointProperty)
+        : 0;
+    const sourceSignature = `${buildLoneDruidBearInheritanceSignature(
+      druid.GetLevel(),
+      properties,
+      abilities,
+      bonusSkillPoints,
+    )}|${playerPropertiesEnabled ? 1 : 0}`;
+    this.ensureInheritedAbilitySlots(bear, abilities);
+    const actualAbilityLevels = this.getBearAbilityLevels(bear, abilities);
+    const signature = `${sourceSignature}|${buildInheritedAbilityRuntimeSignature(
+      abilities,
+      actualAbilityLevels,
+    )}`;
+    if (signature === this.signature) return;
+
+    PropertyController.RemoveAllPlayerPropertyFromUnit(bear);
+    for (const property of properties) {
+      PropertyController.ApplyPlayerPropertyToUnit(
+        druid,
+        bear,
+        property as PlayerProperty,
+        this.bonusSkillPointLedgerKey,
+      );
+    }
+    PropertyController.SyncBonusSkillPointsToUnit(
+      bear,
+      bonusSkillPoints,
+      this.bonusSkillPointLedgerKey,
+    );
+    this.SetStackCount(bonusSkillPoints);
+    this.syncAbilities(bear, abilities, actualAbilityLevels);
+    this.signature = `${sourceSignature}|${buildInheritedAbilityRuntimeSignature(
+      abilities,
+      this.getBearAbilityLevels(bear, abilities),
+    )}`;
+  }
+
+  private getDruidAbilities(druid: CDOTA_BaseNPC): InheritedAbilitySnapshot[] {
+    const abilities: InheritedAbilitySnapshot[] = [];
+    for (let index = 0; index < druid.GetAbilityCount(); index += 1) {
+      const ability = druid.GetAbilityByIndex(index);
+      if (!ability || ability.IsNull()) continue;
+      abilities.push({ name: ability.GetAbilityName(), level: ability.GetLevel() });
+    }
+    return abilities;
+  }
+
+  private ensureInheritedAbilitySlots(
+    bear: CDOTA_BaseNPC,
+    desired: InheritedAbilitySnapshot[],
+  ): void {
+    for (const snapshot of desired) {
+      const ability = bear.FindAbilityByName(snapshot.name);
+      if (ability && !ability.IsNull()) moveAbilityToDynamicSlot(bear, ability);
+    }
+  }
+
+  private getBearAbilityLevels(
+    bear: CDOTA_BaseNPC,
+    desired: InheritedAbilitySnapshot[],
+  ): Record<string, number | undefined> {
+    const levels: Record<string, number | undefined> = {};
+    for (const snapshot of desired) {
+      const ability = bear.FindAbilityByName(snapshot.name);
+      levels[snapshot.name] = ability && !ability.IsNull() ? ability.GetLevel() : undefined;
+    }
+    return levels;
+  }
+
+  private syncAbilities(
+    bear: CDOTA_BaseNPC,
+    desired: InheritedAbilitySnapshot[],
+    actualAbilityLevels: Record<string, number | undefined>,
+  ): void {
+    const diff = calculateInheritedAbilityDiff(
+      desired,
+      this.inheritedAbilityLedger,
+      actualAbilityLevels,
+    );
+    for (const abilityName of diff.remove) {
+      bear.RemoveAbility(abilityName);
+      delete this.inheritedAbilityLedger[abilityName];
+    }
+    for (const snapshot of diff.add) {
+      const existing = bear.FindAbilityByName(snapshot.name);
+      if (existing && !existing.IsNull()) {
+        existing.SetLevel(snapshot.level);
+        continue;
+      }
+      const added = addAbilityToDynamicSlot(bear, snapshot.name);
+      if (!added || added.IsNull()) continue;
+      added.SetLevel(snapshot.level);
+      this.inheritedAbilityLedger[snapshot.name] = snapshot.level;
+    }
+    for (const snapshot of diff.update) {
+      const inherited = bear.FindAbilityByName(snapshot.name);
+      if (!inherited || inherited.IsNull()) {
+        const restored = addAbilityToDynamicSlot(bear, snapshot.name);
+        if (!restored || restored.IsNull()) continue;
+        restored.SetLevel(snapshot.level);
+      } else {
+        inherited.SetLevel(snapshot.level);
+      }
+      this.inheritedAbilityLedger[snapshot.name] = snapshot.level;
+    }
+  }
+}

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,12 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 德鲁伊 觉醒
+  {
+    heroName: 'npc_dota_hero_lone_druid',
+    newAbility: 'special_bonus_unique_lone_druid_upgrade',
+    newLevel: 1,
+  },
   // 上古巨神 觉醒
   {
     heroName: 'npc_dota_hero_elder_titan',

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,12 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 德鲁伊 觉醒
+  {
+    heroName: 'npc_dota_hero_lone_druid',
+    newAbility: 'special_bonus_unique_lone_druid_upgrade',
+    newLevel: 1,
+  },
   // 亚巴顿 觉醒
   {
     heroName: 'npc_dota_hero_abaddon',

--- a/src/vscripts/modules/filter/dragon-wish-filter.test.ts
+++ b/src/vscripts/modules/filter/dragon-wish-filter.test.ts
@@ -10,6 +10,10 @@ describe('DragonWishFilter', () => {
   beforeEach(() => {
     entities = {};
     global.EntIndexToHScript = jest.fn((index: number) => entities[index]);
+    global.PlayerResource = {
+      IsValidPlayerID: jest.fn(() => true),
+      GetSelectedHeroEntity: jest.fn(),
+    };
     global.GameRules = {
       GetGameModeEntity: jest.fn().mockReturnValue({
         SetExecuteOrderFilter: jest.fn((filter) => {
@@ -60,5 +64,37 @@ describe('DragonWishFilter', () => {
     };
 
     expect(orderFilter(createOrder())).toBe(true);
+  });
+  it('redirects inherited Spirit Bear skill training to Lone Druid', () => {
+    let druidAbilityLevel = 0;
+    const druidAbility = {
+      GetLevel: jest.fn(() => druidAbilityLevel),
+    };
+    const druid = {
+      FindAbilityByName: jest.fn(() => druidAbility),
+      UpgradeAbility: jest.fn(() => {
+        druidAbilityLevel += 1;
+      }),
+    };
+    const bear = {
+      GetUnitName: jest.fn(() => 'npc_dota_lone_druid_bear1'),
+      HasModifier: jest.fn(() => true),
+      GetPlayerOwnerID: jest.fn(() => 0),
+    };
+    const bearAbility = {
+      GetAbilityName: jest.fn(() => 'medusa_split_shot'),
+      GetCaster: jest.fn(() => bear),
+      SetLevel: jest.fn(),
+    };
+    entities[1] = bearAbility;
+    global.PlayerResource.GetSelectedHeroEntity.mockReturnValue(druid);
+
+    const order = createOrder(1, 0);
+    order.order_type = UnitOrder.TRAIN_ABILITY;
+    order.entindex_target = 0 as EntityIndex;
+
+    expect(orderFilter(order)).toBe(false);
+    expect(druid.UpgradeAbility).toHaveBeenCalledWith(druidAbility);
+    expect(bearAbility.SetLevel).toHaveBeenCalledWith(1);
   });
 });

--- a/src/vscripts/modules/filter/dragon-wish-filter.ts
+++ b/src/vscripts/modules/filter/dragon-wish-filter.ts
@@ -1,3 +1,9 @@
+import {
+  LONE_DRUID_INHERITABLE_ABILITY_NAMES,
+  LONE_DRUID_BEAR_INHERITANCE_MODIFIER,
+  isLoneDruidSpiritBearUnitName,
+} from '../../abilities/ts_abilities/lone-druid-bear-inheritance';
+
 export const IMMORTALITY_MODIFIER = 'modifier_item_helm_of_the_undying_active';
 const CULLING_BLADE = 'axe_culling_blade';
 
@@ -7,6 +13,10 @@ export class DragonWishFilter {
   }
 
   private filterOrder(args: ExecuteOrderFilterEvent): boolean {
+    if (args.order_type === UnitOrder.TRAIN_ABILITY && args.entindex_ability) {
+      return this.redirectSpiritBearAbilityTraining(args);
+    }
+
     if (
       args.order_type !== UnitOrder.CAST_TARGET ||
       !args.entindex_ability ||
@@ -24,5 +34,36 @@ export class DragonWishFilter {
     if (!target) return true;
 
     return !target.HasModifier(IMMORTALITY_MODIFIER);
+  }
+
+  private redirectSpiritBearAbilityTraining(args: ExecuteOrderFilterEvent): boolean {
+    const bearAbility = EntIndexToHScript(args.entindex_ability) as CDOTABaseAbility | undefined;
+    if (!bearAbility) return true;
+
+    const abilityName = bearAbility.GetAbilityName();
+    if (!LONE_DRUID_INHERITABLE_ABILITY_NAMES.has(abilityName)) return true;
+
+    const bear = bearAbility.GetCaster();
+    if (
+      !bear ||
+      !PlayerResource.IsValidPlayerID(args.issuer_player_id_const) ||
+      bear.GetPlayerOwnerID() !== args.issuer_player_id_const ||
+      !isLoneDruidSpiritBearUnitName(bear.GetUnitName()) ||
+      !bear.HasModifier(LONE_DRUID_BEAR_INHERITANCE_MODIFIER)
+    ) {
+      return true;
+    }
+
+    const druid = PlayerResource.GetSelectedHeroEntity(args.issuer_player_id_const);
+    if (!druid) return false;
+
+    const druidAbility = druid.FindAbilityByName(abilityName);
+    if (!druidAbility) return false;
+
+    const previousLevel = druidAbility.GetLevel();
+    druid.UpgradeAbility(druidAbility);
+    const level = druidAbility.GetLevel();
+    if (level !== previousLevel) bearAbility.SetLevel(level);
+    return false;
   }
 }

--- a/src/vscripts/modules/lottery/ability/ability-lottery.ts
+++ b/src/vscripts/modules/lottery/ability/ability-lottery.ts
@@ -9,6 +9,7 @@ import { PlayerHelper } from '../../helper/player-helper';
 import { AbilityLotteryHelper } from './ability-lottery-helper';
 import { AbilityItemTypes } from './ability-item-type';
 import { abilityTiersActive, abilityTiersPassive } from './lottery-abilities';
+import { addAbilityToDynamicSlot } from './ability-slot';
 
 @reloadable
 export class AbilityLottery {
@@ -18,6 +19,7 @@ export class AbilityLottery {
   // 会员积分刷新累进消耗：首次免费后，第 n 次积分刷新(n 从 0)取此表，封顶 50
   readonly paidRefreshCosts = [10, 20, 30, 50];
   readonly maxPaidRefreshCount = 5;
+  private pendingAbilitySlotIndices: Record<string, number> = {};
 
   constructor() {
     // 启动物品抽奖
@@ -204,7 +206,7 @@ export class AbilityLottery {
   pickAbility(userId: EntityIndex, event: LotteryPickEventData & CustomGameEventDataBase) {
     const steamAccountID = PlayerResource.GetSteamAccountID(event.PlayerID).toString();
     const lotteryStatus = NetTableHelper.GetLotteryStatus(steamAccountID);
-    const abilityType = event.type;
+    const abilityType = event.type as AbilityItemType;
     if (abilityType === AbilityItemTypes.Active && lotteryStatus.activeAbilityName) {
       print('已经抽取过主动技能');
       return;
@@ -222,7 +224,14 @@ export class AbilityLottery {
     if (!hero) {
       return;
     }
-    hero.AddAbility(event.name);
+    const pendingSlotKey = this.getPendingAbilitySlotKey(steamAccountID, abilityType);
+    const added = addAbilityToDynamicSlot(
+      hero,
+      event.name,
+      this.pendingAbilitySlotIndices[pendingSlotKey],
+    );
+    if (!added) return;
+    delete this.pendingAbilitySlotIndices[pendingSlotKey];
 
     // 记录选择的技能
     if (abilityType === AbilityItemTypes.Active) {
@@ -372,6 +381,10 @@ export class AbilityLottery {
     return true;
   }
 
+  private getPendingAbilitySlotKey(steamAccountID: string, abilityType: AbilityItemType): string {
+    return `${steamAccountID}:${abilityType}`;
+  }
+
   /**
    * 重置技能
    */
@@ -418,6 +431,8 @@ export class AbilityLottery {
     const oldAbility = hero.FindAbilityByName(pickedAbilityName);
     if (oldAbility) {
       const abilityPoints = oldAbility.GetLevel();
+      this.pendingAbilitySlotIndices[this.getPendingAbilitySlotKey(steamAccountID, abilityType)] =
+        oldAbility.GetAbilityIndex();
       hero.RemoveAbility(pickedAbilityName);
       if (abilityPoints > 0) {
         hero.SetAbilityPoints(hero.GetAbilityPoints() + abilityPoints);

--- a/src/vscripts/modules/lottery/ability/ability-slot.test.ts
+++ b/src/vscripts/modules/lottery/ability/ability-slot.test.ts
@@ -1,0 +1,85 @@
+import {
+  addAbilityToDynamicSlot,
+  moveAbilityToDynamicSlot,
+  resolveDynamicAbilityTargetIndex,
+} from './ability-slot';
+
+describe('resolveDynamicAbilityTargetIndex', () => {
+  const abilities = [
+    { name: 'lone_druid_spirit_bear', index: 0 },
+    { name: 'lone_druid_spirit_link', index: 1 },
+    { name: 'special_bonus_unique_lone_druid_1', index: 4 },
+    { name: 'special_bonus_unique_lone_druid_2', index: 5 },
+    { name: 'generic_hidden', index: 8 },
+  ];
+
+  it('reuses the removed skill slot for a reset-book replacement', () => {
+    expect(resolveDynamicAbilityTargetIndex(abilities, 2)).toBe(2);
+  });
+
+  it('inserts a newly granted skill before the first talent', () => {
+    expect(resolveDynamicAbilityTargetIndex(abilities)).toBe(4);
+  });
+
+  it('repairs a reset-book replacement whose previous slot was already behind talents', () => {
+    expect(resolveDynamicAbilityTargetIndex(abilities, 8)).toBe(4);
+  });
+
+  it('appends when a unit has no talent abilities', () => {
+    expect(
+      resolveDynamicAbilityTargetIndex([
+        { name: 'lone_druid_spirit_bear', index: 0 },
+        { name: 'lone_druid_spirit_link', index: 2 },
+      ]),
+    ).toBe(3);
+  });
+});
+
+describe('dynamic ability slot integration', () => {
+  function createUnit(addedIndex: number) {
+    const abilities = [
+      { IsNull: () => false, GetAbilityName: () => 'lone_druid_spirit_bear' },
+      { IsNull: () => false, GetAbilityName: () => 'special_bonus_unique_lone_druid_1' },
+    ];
+    const added = {
+      IsNull: () => false,
+      GetAbilityName: () => 'medusa_split_shot',
+      GetAbilityIndex: jest.fn(() => addedIndex),
+      SetAbilityIndex: jest.fn(),
+    };
+    const unit = {
+      GetAbilityCount: () => 2,
+      GetAbilityByIndex: (index: number) => abilities[index],
+      AddAbility: jest.fn(() => added),
+    };
+    return {
+      unit: unit as unknown as CDOTA_BaseNPC,
+      added: added as unknown as CDOTABaseAbility,
+      setAbilityIndex: added.SetAbilityIndex,
+    };
+  }
+
+  it('places a passive-tome skill before talents', () => {
+    const { unit, setAbilityIndex } = createUnit(2);
+
+    addAbilityToDynamicSlot(unit, 'medusa_split_shot');
+
+    expect(setAbilityIndex).toHaveBeenCalledWith(1);
+  });
+
+  it('places a reset-book replacement back into the removed slot', () => {
+    const { unit, setAbilityIndex } = createUnit(2);
+
+    addAbilityToDynamicSlot(unit, 'medusa_split_shot', 0);
+
+    expect(setAbilityIndex).toHaveBeenCalledWith(0);
+  });
+
+  it('repairs an inherited bear skill that sits behind talents', () => {
+    const { unit, added, setAbilityIndex } = createUnit(2);
+
+    moveAbilityToDynamicSlot(unit, added);
+
+    expect(setAbilityIndex).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/vscripts/modules/lottery/ability/ability-slot.ts
+++ b/src/vscripts/modules/lottery/ability/ability-slot.ts
@@ -1,0 +1,72 @@
+export interface AbilitySlotSnapshot {
+  name: string;
+  index: number;
+}
+
+export function resolveDynamicAbilityTargetIndex(
+  abilities: AbilitySlotSnapshot[],
+  preferredIndex?: number,
+): number {
+  const talentIndex = abilities.reduce(
+    (firstIndex, ability) =>
+      ability.name.startsWith('special_bonus_') ? Math.min(firstIndex, ability.index) : firstIndex,
+    Number.MAX_SAFE_INTEGER,
+  );
+  if (preferredIndex !== undefined) {
+    return talentIndex === Number.MAX_SAFE_INTEGER
+      ? preferredIndex
+      : Math.min(preferredIndex, talentIndex);
+  }
+  if (talentIndex !== Number.MAX_SAFE_INTEGER) return talentIndex;
+
+  return abilities.reduce((maxIndex, ability) => Math.max(maxIndex, ability.index), -1) + 1;
+}
+
+export function getAbilitySlotSnapshots(unit: CDOTA_BaseNPC): AbilitySlotSnapshot[] {
+  const abilities: AbilitySlotSnapshot[] = [];
+  for (let index = 0; index < unit.GetAbilityCount(); index += 1) {
+    const ability = unit.GetAbilityByIndex(index);
+    if (!ability || ability.IsNull()) continue;
+    abilities.push({ name: ability.GetAbilityName(), index });
+  }
+  return abilities;
+}
+
+export function moveAbilityToDynamicSlot(
+  unit: CDOTA_BaseNPC,
+  ability: CDOTABaseAbility,
+  preferredIndex?: number,
+): void {
+  const currentIndex = ability.GetAbilityIndex();
+  if (preferredIndex !== undefined) {
+    if (currentIndex !== preferredIndex) ability.SetAbilityIndex(preferredIndex);
+    return;
+  }
+
+  const slots = getAbilitySlotSnapshots(unit);
+  const firstTalentIndex = slots.reduce(
+    (firstIndex, snapshot) =>
+      snapshot.name.startsWith('special_bonus_')
+        ? Math.min(firstIndex, snapshot.index)
+        : firstIndex,
+    Number.MAX_SAFE_INTEGER,
+  );
+  if (firstTalentIndex !== Number.MAX_SAFE_INTEGER && currentIndex > firstTalentIndex) {
+    ability.SetAbilityIndex(firstTalentIndex);
+  }
+}
+
+export function addAbilityToDynamicSlot(
+  unit: CDOTA_BaseNPC,
+  abilityName: string,
+  preferredIndex?: number,
+): CDOTABaseAbility | undefined {
+  const targetIndex = resolveDynamicAbilityTargetIndex(
+    getAbilitySlotSnapshots(unit),
+    preferredIndex,
+  );
+  const added = unit.AddAbility(abilityName);
+  if (!added || added.IsNull()) return undefined;
+  if (added.GetAbilityIndex() !== targetIndex) added.SetAbilityIndex(targetIndex);
+  return added;
+}

--- a/src/vscripts/modules/lottery/ability/passive-tome-lottery.test.ts
+++ b/src/vscripts/modules/lottery/ability/passive-tome-lottery.test.ts
@@ -24,8 +24,13 @@ global.CustomNetTables = {
   GetTableValue: jest.fn((table: string, key: string) => netTable[table]?.[key]),
 };
 
+const addedAbility = {
+  IsNull: jest.fn(() => false),
+  GetAbilityIndex: jest.fn(() => 0),
+  SetAbilityIndex: jest.fn(),
+};
 const mockHero = {
-  AddAbility: jest.fn(),
+  AddAbility: jest.fn(() => addedAbility),
   GetAbilityCount: jest.fn(() => 0),
   GetAbilityByIndex: jest.fn(() => undefined),
   GetPlayerOwnerID: jest.fn(() => 3),

--- a/src/vscripts/modules/lottery/ability/passive-tome-lottery.ts
+++ b/src/vscripts/modules/lottery/ability/passive-tome-lottery.ts
@@ -2,6 +2,7 @@ import { LotteryDto } from '../../../../common/dto/lottery';
 import { reloadable } from '../../../utils/tstl-utils';
 import { AbilityLotteryHelper } from './ability-lottery-helper';
 import { abilityTiersPassive } from './lottery-abilities';
+import { addAbilityToDynamicSlot } from './ability-slot';
 
 /**
  * 被动技能书抽奖：使用技能书触发后弹 4 选 1，倒计时由客户端驱动，归零自动随机选 1。
@@ -50,7 +51,13 @@ export class PassiveTomeLottery {
       return;
     }
 
-    hero.AddAbility(matched.name);
+    const added = addAbilityToDynamicSlot(hero, matched.name);
+    if (!added) {
+      print(
+        '[PassiveTomeLottery] failed to add ability for player ' + playerId + ': ' + matched.name,
+      );
+      return;
+    }
     print('[PassiveTomeLottery] player ' + playerId + ' picked ' + matched.name);
 
     // 清空候选（写空数组，客户端 candidates.length === 0 → UI collapse）。

--- a/src/vscripts/modules/property/property-calculations.ts
+++ b/src/vscripts/modules/property/property-calculations.ts
@@ -1,0 +1,3 @@
+export function calculateBonusSkillPointCount(activePropertyLevel: number): number {
+  return Math.max(0, Math.floor(activePropertyLevel / 2));
+}

--- a/src/vscripts/modules/property/property_controller.ts
+++ b/src/vscripts/modules/property/property_controller.ts
@@ -28,6 +28,7 @@ import {
 } from '../../modifiers/property/property_declare';
 import { reloadable } from '../../utils/tstl-utils';
 import { PlayerHelper } from '../helper/player-helper';
+import { calculateBonusSkillPointCount } from './property-calculations';
 
 @reloadable
 export class PropertyController {
@@ -46,6 +47,8 @@ export class PropertyController {
   private static PLAYER_MODIFER_DATA_DRIVEN_ITEM: CDOTA_Item_DataDriven;
 
   private static bnusSkillPointsAdded = new Map<number, number>();
+
+  private static bonusSkillPointsAddedByUnit = new Map<string, number>();
 
   // 每N级加点一次
   public static HERO_LEVEL_PER_POINT = 2;
@@ -152,32 +155,35 @@ export class PropertyController {
     if (!hero) {
       return;
     }
+    PropertyController.RemoveAllPlayerPropertyFromUnit(hero);
+  }
 
+  public static RemoveAllPlayerPropertyFromUnit(target: CDOTA_BaseNPC) {
     // 移除Lua modifier
     for (const key of PropertyController.propertyLuaModiferMap.keys()) {
-      hero.RemoveModifierByName(key);
+      target.RemoveModifierByName(key);
     }
 
     // 移除DataDriven modifier
     for (const key of PropertyController.propertyDataDrivenModifierMap.keys()) {
       const value = PropertyController.propertyDataDrivenModifierMap.get(key);
       if (value) {
-        PropertyController.RemoveDataDrivenPlayerPropertyModifiers(hero, value);
+        PropertyController.RemoveDataDrivenPlayerPropertyModifiers(target, value);
       }
     }
   }
 
   /** 按注册名卸下：多档卸 1–8，单档卸该名 */
   private static RemoveDataDrivenPlayerPropertyModifiers(
-    hero: CDOTA_BaseNPC_Hero,
+    target: CDOTA_BaseNPC,
     registeredModifierName: string,
   ) {
     if (registeredModifierName.endsWith('_level_')) {
       for (let i = 1; i <= 8; i++) {
-        hero.RemoveModifierByName(`${registeredModifierName}${i}`);
+        target.RemoveModifierByName(`${registeredModifierName}${i}`);
       }
     } else {
-      hero.RemoveModifierByName(registeredModifierName);
+      target.RemoveModifierByName(registeredModifierName);
     }
   }
 
@@ -191,7 +197,7 @@ export class PropertyController {
   }
 
   // 根据英雄等级和加点点数，计算当前应该生效的属性等级
-  private static GetPropertyActiveLevel(hero: CDOTA_BaseNPC_Hero, property: PlayerProperty) {
+  public static GetPropertyActiveLevel(hero: CDOTA_BaseNPC_Hero, property: PlayerProperty) {
     if (PropertyController.limitPropertyNames.includes(property.name)) {
       const activeLevelMax = Math.floor(hero.GetLevel() / PropertyController.HERO_LEVEL_PER_POINT);
       return Math.min(property.level, activeLevelMax);
@@ -252,13 +258,70 @@ export class PropertyController {
     }
   }
 
+  public static ApplyPlayerPropertyToUnit(
+    sourceHero: CDOTA_BaseNPC_Hero,
+    target: CDOTA_BaseNPC,
+    property: PlayerProperty,
+    bonusSkillPointLedgerKey?: string,
+  ) {
+    // 移速属性作为例外,即使禁用玩家属性也生效
+    const isMoveSpeedProperty = property.name === 'property_movespeed_bonus_constant';
+
+    if (!GameRules.Option.enablePlayerAttribute && !isMoveSpeedProperty) {
+      return;
+    }
+    const activeLevel = PropertyController.GetPropertyActiveLevel(sourceHero, property);
+
+    if (property.name === 'property_skill_points_bonus') {
+      PropertyController.SyncBonusSkillPointsToUnit(
+        target,
+        PropertyController.GetBonusSkillPointCount(sourceHero, property),
+        bonusSkillPointLedgerKey ?? `unit:${target.GetEntityIndex()}`,
+      );
+      return;
+    }
+
+    if (!target.IsAlive()) {
+      return;
+    }
+
+    const propertyValuePerLevel = PropertyController.propertyLuaModiferMap.get(property.name);
+    if (propertyValuePerLevel) {
+      const value = propertyValuePerLevel * activeLevel;
+      if (value === 0) {
+        return;
+      }
+      target.RemoveModifierByName(property.name);
+      target.AddNewModifier(sourceHero, undefined, property.name, { value });
+      return;
+    }
+
+    const dataDrivenModifierName = PropertyController.propertyDataDrivenModifierMap.get(
+      property.name,
+    );
+    if (dataDrivenModifierName) {
+      PropertyController.RefreshDataDrivenPlayerPropertyOnUnit(
+        sourceHero,
+        target,
+        dataDrivenModifierName,
+        activeLevel,
+      );
+    }
+  }
+
+  public static GetBonusSkillPointCount(sourceHero: CDOTA_BaseNPC_Hero, property: PlayerProperty) {
+    return calculateBonusSkillPointCount(
+      PropertyController.GetPropertyActiveLevel(sourceHero, property),
+    );
+  }
+
   private static SetBonusSkillPoints(
     hero: CDOTA_BaseNPC_Hero,
     property: PlayerProperty,
     activeLevel: number,
   ) {
     const steamId = property.steamId;
-    const shoudAddSP = Math.floor(activeLevel / 2);
+    const shoudAddSP = calculateBonusSkillPointCount(activeLevel);
     const currentAddedSP = PropertyController.bnusSkillPointsAdded.get(steamId) || 0;
     const deltaSP = shoudAddSP - currentAddedSP;
     if (deltaSP <= 0) {
@@ -269,13 +332,55 @@ export class PropertyController {
     PropertyController.bnusSkillPointsAdded.set(steamId, shoudAddSP);
   }
 
+  public static ForgetBonusSkillPointLedger(ledgerKey: string) {
+    PropertyController.bonusSkillPointsAddedByUnit.delete(ledgerKey);
+  }
+
+  public static SyncBonusSkillPointsToUnit(
+    target: CDOTA_BaseNPC,
+    shouldAddSP: number,
+    ledgerKey: string,
+  ) {
+    const normalizedSP = Math.max(0, Math.floor(shouldAddSP));
+    const currentAddedSP = PropertyController.bonusSkillPointsAddedByUnit.get(ledgerKey) ?? 0;
+    const deltaSP = normalizedSP - currentAddedSP;
+    if (deltaSP === 0) {
+      return;
+    }
+
+    const abilityPointTarget = target as CDOTA_BaseNPC & {
+      GetAbilityPoints?: () => number;
+      SetAbilityPoints?: (points: number) => void;
+    };
+    if (abilityPointTarget.GetAbilityPoints && abilityPointTarget.SetAbilityPoints) {
+      abilityPointTarget.SetAbilityPoints(
+        Math.max(0, abilityPointTarget.GetAbilityPoints() + deltaSP),
+      );
+    }
+
+    if (normalizedSP === 0) {
+      PropertyController.bonusSkillPointsAddedByUnit.delete(ledgerKey);
+    } else {
+      PropertyController.bonusSkillPointsAddedByUnit.set(ledgerKey, normalizedSP);
+    }
+  }
+
   private static RefreshDataDrivenPlayerProperty(
     hero: CDOTA_BaseNPC_Hero,
     modifierName: string,
     level: number,
   ) {
+    PropertyController.RefreshDataDrivenPlayerPropertyOnUnit(hero, hero, modifierName, level);
+  }
+
+  private static RefreshDataDrivenPlayerPropertyOnUnit(
+    sourceHero: CDOTA_BaseNPC_Hero,
+    target: CDOTA_BaseNPC,
+    modifierName: string,
+    level: number,
+  ) {
     const registeredName = modifierName;
-    PropertyController.RemoveDataDrivenPlayerPropertyModifiers(hero, registeredName);
+    PropertyController.RemoveDataDrivenPlayerPropertyModifiers(target, registeredName);
 
     let applyName = modifierName;
     if (registeredName.endsWith('_level_')) {
@@ -294,7 +399,7 @@ export class PropertyController {
         undefined,
       ) as CDOTA_Item_DataDriven;
     }
-    this.PLAYER_MODIFER_DATA_DRIVEN_ITEM.ApplyDataDrivenModifier(hero, hero, applyName, {
+    this.PLAYER_MODIFER_DATA_DRIVEN_ITEM.ApplyDataDrivenModifier(sourceHero, target, applyName, {
       duration: -1,
     });
   }


### PR DESCRIPTION
## Issue

N/A

## Summary

- Adds a Lone Druid awakening that makes Spirit Bear inherit the Druid's out-of-game player properties and drafted abilities.
- Keeps inherited abilities synchronized when the Druid replaces an ability with an Ability Reset Tome or gains one from a Passive Skill Tome.
- Places dynamically granted abilities before talents so Lone Druid and Spirit Bear can train them normally.
- Redirects Spirit Bear inherited ability training to Lone Druid and synchronizes the resulting ability level.

## Checklist

- [x] I have tested the changes works well.
- [x] Verified Ability Reset Tome and Passive Skill Tome training on both Lone Druid and Spirit Bear in Dota Tools.
- [x] VScripts and Panorama builds pass.
- [x] Related Jest, ESLint, localization, KV, and diff checks pass.