### PR TITLE
Add Morphling Flow awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -148,6 +148,19 @@
 		"PauseDemo_Button"							"Pause"
 		"QuitDemo_Button"							"Quit"
 
+		// Morphling Flow's Echo Awakening
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken"							"<font color='#d000ff'>Flow's Echo Awakened</font>"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_SummaryDescription"		"Current Agility grants spell amplification; a higher current Strength-to-Agility ratio reduces ability and item cooldowns."
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_Description"				"Morphling awakens the ancient power of Flow. Every %agility_per_spell_amp% current Agility grants 1%% spell amplification. A higher current Strength-to-Agility ratio reduces ability and item cooldowns, up to %max_cooldown_speed_bonus%%%."
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_agility_per_spell_amp"		"AGILITY PER 1% SPELL AMPLIFICATION:"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_min_strength_agility_ratio"	"%MINIMUM STRENGTH / AGILITY RATIO:"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_max_strength_agility_ratio"	"%MAXIMUM STRENGTH / AGILITY RATIO:"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_max_cooldown_speed_bonus"	"%MAXIMUM COOLDOWN REDUCTION:"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_Note0"					"Cooldown reduction scales linearly between the minimum and maximum Strength-to-Agility ratios."
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_Note1"					"Affects Morphling's abilities, abilities acquired through Morph, and item cooldowns."
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_Note2"					"Attribute changes dynamically affect abilities and items already on cooldown."
+		"DOTA_Tooltip_modifier_morphling_flow_echo_awaken"						"<font color='#d000ff'>Flow's Echo Awakened</font>"
+		"DOTA_Tooltip_modifier_morphling_flow_echo_awaken_Description"			"Spell Amplification: +%fMODIFIER_PROPERTY_TOOLTIP%%%\nCooldown Reduction: +%fMODIFIER_PROPERTY_TOOLTIP2%%%"
 		// Elder Titan Astral Spirit - Awakened
 		"DOTA_Tooltip_ability_elder_titan_ancestral_spirit_awaken"						"<font color='#d000ff'>Astral Spirit Awakened</font>"
 		"DOTA_Tooltip_ability_elder_titan_ancestral_spirit_awaken_SummaryDescription"		"Autocast: automatically sends the spirit toward the farthest enemy hero and recalls it automatically."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -112,6 +112,19 @@
 		"ToggleDayNight_Button"						"День/Ночь"
 		"PauseDemo_Button"							"Пауза"
 		"QuitDemo_Button"							"Выход"
+		// Морфлинг Эхо Потока — пробуждение
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken"							"<font color='#d000ff'>Эхо Потока: пробуждение</font>"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_SummaryDescription"		"Текущая ловкость усиливает заклинания; чем выше отношение текущей силы к ловкости, тем сильнее сокращается перезарядка способностей и предметов."
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_Description"				"Морфлинг пробуждает древнюю силу Потока. Каждые %agility_per_spell_amp% ед. текущей ловкости дают 1%% усиления заклинаний. Чем выше отношение текущей силы к ловкости, тем сильнее сокращается перезарядка способностей и предметов, вплоть до %max_cooldown_speed_bonus%%%."
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_agility_per_spell_amp"		"ЛОВКОСТИ ЗА 1% УСИЛЕНИЯ ЗАКЛИНАНИЙ:"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_min_strength_agility_ratio"	"%МИНИМАЛЬНОЕ ОТНОШЕНИЕ СИЛЫ К ЛОВКОСТИ:"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_max_strength_agility_ratio"	"%МАКСИМАЛЬНОЕ ОТНОШЕНИЕ СИЛЫ К ЛОВКОСТИ:"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_max_cooldown_speed_bonus"	"%МАКС. СОКРАЩЕНИЕ ПЕРЕЗАРЯДКИ:"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_Note0"					"Сокращение перезарядки линейно растёт между минимальным и максимальным отношением силы к ловкости."
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_Note1"					"Действует на способности Морфлинга, способности, полученные с помощью Morph, и перезарядку предметов."
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_Note2"					"Изменение атрибутов динамически влияет на способности и предметы, которые уже перезаряжаются."
+		"DOTA_Tooltip_modifier_morphling_flow_echo_awaken"						"<font color='#d000ff'>Эхо Потока: пробуждение</font>"
+		"DOTA_Tooltip_modifier_morphling_flow_echo_awaken_Description"			"Усиление заклинаний: +%fMODIFIER_PROPERTY_TOOLTIP%%%\nСокращение перезарядки: +%fMODIFIER_PROPERTY_TOOLTIP2%%%"
 
 		// 泉水 制裁
 		"DOTA_Tooltip_ability_fountain_anti_camp_Description"				"Вражеские герои под управлением игроков подвергаются санкции, приближаясь к радиусу атаки фонтана. Действует только в командном режиме.<br><br>Когда герой-бот погибает в этом радиусе, в убийцу выпускается самонаводящийся огненный шар, который проходит сквозь магический иммунитет и наносит урон, равный %retaliation_damage_pct%%% максимального здоровья убийцы."

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -148,6 +148,19 @@
 		"PauseDemo_Button"							"暂停"
 		"QuitDemo_Button"							"退出"
 
+		// 变体精灵 潮落回响 觉醒
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken"							"<font color='#d000ff'>潮落回响 觉醒</font>"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_SummaryDescription"		"当前敏捷提供技能增强；当前力量相对敏捷越高，技能和物品的冷却时间越短。"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_Description"				"变体精灵唤醒古老的潮落力量。每%agility_per_spell_amp%点当前敏捷提供1%%技能增强。当前力量/敏捷比例越高，技能和物品的冷却时间越短，最多降低%max_cooldown_speed_bonus%%%。"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_agility_per_spell_amp"		"每1%技能增强所需敏捷："
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_min_strength_agility_ratio"	"%最低力量/敏捷比例："
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_max_strength_agility_ratio"	"%最高力量/敏捷比例："
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_max_cooldown_speed_bonus"	"%最大冷却时间降低："
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_Note0"					"冷却时间降低在最低和最高力量/敏捷比例之间线性提升。"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_Note1"					"影响变体精灵自身技能、通过变形获得的技能以及物品冷却。"
+		"DOTA_Tooltip_ability_morphling_flow_echo_awaken_Note2"					"属性变化会实时影响已经进入冷却的技能和物品。"
+		"DOTA_Tooltip_modifier_morphling_flow_echo_awaken"						"<font color='#d000ff'>潮落回响 觉醒</font>"
+		"DOTA_Tooltip_modifier_morphling_flow_echo_awaken_Description"			"技能增强：+%fMODIFIER_PROPERTY_TOOLTIP%%%\n冷却时间降低：+%fMODIFIER_PROPERTY_TOOLTIP2%%%"
 		// 上古巨神 灵体游魂-觉醒
 		"DOTA_Tooltip_ability_elder_titan_ancestral_spirit_awaken"						"<font color='#d000ff'>灵体游魂 觉醒</font>"
 		"DOTA_Tooltip_ability_elder_titan_ancestral_spirit_awaken_SummaryDescription"		"自动施法：自动朝最远的敌方英雄放出游魂并自动收回。"

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -4,6 +4,35 @@
 	// 觉醒技能
 	// 英雄专属强化/替换技能，通过抽奖池获得
 	//=================================================================================================================
+	// 变体精灵 潮落回响觉醒
+	"morphling_flow_echo_awaken"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/morphling_flow_echo_awaken"
+		"AbilityTextureName"			"morphling_ebb_and_flow"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"MaxLevel"						"1"
+
+		"AbilityValues"
+		{
+			"agility_per_spell_amp"
+			{
+				"value"						"5"
+			}
+			"min_strength_agility_ratio"
+			{
+				"value"						"50"
+			}
+			"max_strength_agility_ratio"
+			{
+				"value"						"175"
+			}
+			"max_cooldown_speed_bonus"
+			{
+				"value"						"60"
+			}
+		}
+	}
 
 	// 亚巴顿 觉醒
 	"special_bonus_unique_abaddon_quickening_awaken"

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,10 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_morphling',
+    abilityName: 'morphling_flow_echo_awaken',
+  },
+  {
     heroName: 'npc_dota_hero_abaddon',
     abilityName: 'special_bonus_unique_abaddon_quickening_awaken',
     freeTrial: true,

--- a/src/vscripts/abilities/ts_abilities/morphling-flow-echo-awaken.test.ts
+++ b/src/vscripts/abilities/ts_abilities/morphling-flow-echo-awaken.test.ts
@@ -1,0 +1,89 @@
+jest.mock('../../utils/dota_ts_adapter', () => ({
+  BaseAbility: class {},
+  BaseModifier: class {},
+  registerAbility: () => (ability: unknown) => ability,
+  registerModifier: () => (modifier: unknown) => modifier,
+}));
+
+const modifierFunctionValues = {
+  SPELL_AMPLIFY_PERCENTAGE: 'SPELL_AMPLIFY_PERCENTAGE',
+  COOLDOWN_PERCENTAGE: 'COOLDOWN_PERCENTAGE',
+  COOLDOWN_PERCENTAGE_ONGOING: 'COOLDOWN_PERCENTAGE_ONGOING',
+  TOOLTIP: 'TOOLTIP',
+  TOOLTIP2: 'TOOLTIP2',
+} as const;
+Object.assign(globalThis, { ModifierFunction: modifierFunctionValues });
+
+import { modifier_morphling_flow_echo_awaken } from './morphling_flow_echo_awaken';
+
+type MockAbility = {
+  IsNull: jest.Mock<boolean, []>;
+  GetLevel: jest.Mock<number, []>;
+  GetSpecialValueFor: jest.Mock<number, [string]>;
+};
+
+type MockParent = {
+  IsIllusion: jest.Mock<boolean, []>;
+  PassivesDisabled: jest.Mock<boolean, []>;
+  GetAgility: jest.Mock<number, []>;
+  GetStrength: jest.Mock<number, []>;
+};
+
+type TestModifier = modifier_morphling_flow_echo_awaken & {
+  GetAbility: () => MockAbility;
+  GetParent: () => MockParent;
+};
+
+describe('modifier_morphling_flow_echo_awaken', () => {
+  function createModifier() {
+    const modifier = new modifier_morphling_flow_echo_awaken() as unknown as TestModifier;
+    const ability: MockAbility = {
+      IsNull: jest.fn(() => false),
+      GetLevel: jest.fn(() => 1),
+      GetSpecialValueFor: jest.fn((name: string) => {
+        const values: Record<string, number> = {
+          agility_per_spell_amp: 5,
+          min_strength_agility_ratio: 50,
+          max_strength_agility_ratio: 175,
+          max_cooldown_speed_bonus: 60,
+        };
+        return values[name] ?? 0;
+      }),
+    };
+    const parent: MockParent = {
+      IsIllusion: jest.fn(() => false),
+      PassivesDisabled: jest.fn(() => false),
+      GetAgility: jest.fn(() => 100),
+      GetStrength: jest.fn(() => 100),
+    };
+    const testModifier = modifier as unknown as {
+      GetAbility: () => MockAbility;
+      GetParent: () => MockParent;
+    };
+    testModifier.GetAbility = jest.fn(() => ability);
+    testModifier.GetParent = jest.fn(() => parent);
+    return { modifier, ability, parent };
+  }
+
+  it('keeps the awakening active without relying on IsActivated', () => {
+    const { modifier } = createModifier();
+
+    expect(modifier.GetModifierSpellAmplify_Percentage()).toBe(20);
+    expect(modifier.OnTooltip()).toBe(20);
+    expect(modifier.OnTooltip2()).toBe(24);
+  });
+
+  it('declares both initial and ongoing cooldown recovery hooks', () => {
+    const { modifier, ability } = createModifier();
+    const event = { ability } as unknown as ModifierAbilityEvent;
+
+    expect(modifier.DeclareFunctions()).toEqual(
+      expect.arrayContaining([
+        ModifierFunction.COOLDOWN_PERCENTAGE,
+        ModifierFunction.COOLDOWN_PERCENTAGE_ONGOING,
+      ]),
+    );
+    expect(modifier.GetModifierPercentageCooldown(event)).toBe(24);
+    expect(modifier.GetModifierPercentageCooldownOngoing(event)).toBe(24);
+  });
+});

--- a/src/vscripts/abilities/ts_abilities/morphling-flow-echo-math.test.ts
+++ b/src/vscripts/abilities/ts_abilities/morphling-flow-echo-math.test.ts
@@ -1,0 +1,81 @@
+import {
+  calculateMorphlingFlowCooldownSpeedBonus,
+  calculateMorphlingFlowSpellAmplification,
+  roundMorphlingFlowTooltipValue,
+} from './morphling-flow-echo-math';
+
+describe('Morphling Flow Echo math', () => {
+  it.each([
+    [100, 5, 20],
+    [250, 5, 50],
+    [400, 5, 80],
+    [1000, 5, 200],
+    [102.5, 5, 20.5],
+  ])('converts %s agility with divisor %s into %s%% spell amp', (agility, divisor, expected) => {
+    expect(calculateMorphlingFlowSpellAmplification(agility, divisor)).toBe(expected);
+  });
+
+  it.each([
+    [100, 50, 0],
+    [100, 100, 24],
+    [100, 150, 48],
+    [100, 175, 60],
+    [100, 200, 60],
+    [33, 16, 0],
+    [16, 33, 60],
+    [494, 231, 0],
+  ])(
+    'maps %s agility and %s strength to %s%% cooldown reduction',
+    (agility, strength, expected) => {
+      expect(calculateMorphlingFlowCooldownSpeedBonus(agility, strength, 50, 175, 60)).toBe(
+        expected,
+      );
+    },
+  );
+
+  it('keeps cooldown scaling continuous between integer ratios', () => {
+    expect(calculateMorphlingFlowCooldownSpeedBonus(100, 101, 50, 175, 60)).toBeCloseTo(24.48, 10);
+  });
+
+  it('uses one as the safe agility denominator', () => {
+    expect(calculateMorphlingFlowCooldownSpeedBonus(0, 1, 50, 175, 60)).toBe(24);
+  });
+
+  it.each([
+    [20.54, 20.5],
+    [24.48, 24.5],
+    [60, 60],
+  ])('rounds %s to %s for the modifier tooltip', (value, expected) => {
+    expect(roundMorphlingFlowTooltipValue(value)).toBe(expected);
+  });
+
+  it.each([
+    [-1, 5],
+    [100, 0],
+    [100, -5],
+    [Number.NaN, 5],
+  ])('returns zero spell amp for invalid input (%s, %s)', (agility, divisor) => {
+    expect(calculateMorphlingFlowSpellAmplification(agility, divisor)).toBe(0);
+  });
+
+  it.each([
+    [-1, 100, 50, 175, 60],
+    [100, -1, 50, 175, 60],
+    [100, 100, 175, 50, 60],
+    [100, 100, 50, 175, 0],
+    [Number.NaN, 100, 50, 175, 60],
+  ])(
+    'returns zero cooldown speed for invalid values',
+    (agility, strength, minimumRatio, maximumRatio, maximumBonus) => {
+      expect(
+        calculateMorphlingFlowCooldownSpeedBonus(
+          agility,
+          strength,
+          minimumRatio,
+          maximumRatio,
+          maximumBonus,
+        ),
+      ).toBe(0);
+    },
+  );
+});

--- a/src/vscripts/abilities/ts_abilities/morphling-flow-echo-math.ts
+++ b/src/vscripts/abilities/ts_abilities/morphling-flow-echo-math.ts
@@ -1,0 +1,48 @@
+function isFiniteNonNegative(value: number): boolean {
+  return Number.isFinite(value) && value >= 0;
+}
+
+export function roundMorphlingFlowTooltipValue(value: number): number {
+  if (!isFiniteNonNegative(value)) return 0;
+  return Math.round(value * 10) / 10;
+}
+
+export function calculateMorphlingFlowSpellAmplification(
+  agility: number,
+  agilityPerSpellAmp: number,
+): number {
+  if (
+    !isFiniteNonNegative(agility) ||
+    !Number.isFinite(agilityPerSpellAmp) ||
+    agilityPerSpellAmp <= 0
+  ) {
+    return 0;
+  }
+
+  return agility / agilityPerSpellAmp;
+}
+
+export function calculateMorphlingFlowCooldownSpeedBonus(
+  agility: number,
+  strength: number,
+  minimumRatioPercent: number,
+  maximumRatioPercent: number,
+  maximumBonus: number,
+): number {
+  if (
+    !isFiniteNonNegative(agility) ||
+    !isFiniteNonNegative(strength) ||
+    !isFiniteNonNegative(minimumRatioPercent) ||
+    !Number.isFinite(maximumRatioPercent) ||
+    maximumRatioPercent <= minimumRatioPercent ||
+    !Number.isFinite(maximumBonus) ||
+    maximumBonus <= 0
+  ) {
+    return 0;
+  }
+
+  const ratioPercent = (strength / Math.max(agility, 1)) * 100;
+  const progress =
+    (ratioPercent - minimumRatioPercent) / (maximumRatioPercent - minimumRatioPercent);
+  return Math.max(0, Math.min(maximumBonus, progress * maximumBonus));
+}

--- a/src/vscripts/abilities/ts_abilities/morphling_flow_echo_awaken.ts
+++ b/src/vscripts/abilities/ts_abilities/morphling_flow_echo_awaken.ts
@@ -1,0 +1,121 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+import {
+  calculateMorphlingFlowCooldownSpeedBonus,
+  calculateMorphlingFlowSpellAmplification,
+  roundMorphlingFlowTooltipValue,
+} from './morphling-flow-echo-math';
+
+const SCRIPT_PATH = 'abilities/ts_abilities/morphling_flow_echo_awaken';
+const MODIFIER_NAME = 'modifier_morphling_flow_echo_awaken';
+
+@registerAbility('morphling_flow_echo_awaken')
+export class MorphlingFlowEchoAwaken extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return MODIFIER_NAME;
+  }
+}
+
+@registerModifier(SCRIPT_PATH)
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_morphling_flow_echo_awaken extends BaseModifier {
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  AllowIllusionDuplicate(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return 'morphling_ebb_and_flow';
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [
+      ModifierFunction.SPELL_AMPLIFY_PERCENTAGE,
+      ModifierFunction.COOLDOWN_PERCENTAGE,
+      ModifierFunction.COOLDOWN_PERCENTAGE_ONGOING,
+      ModifierFunction.TOOLTIP,
+      ModifierFunction.TOOLTIP2,
+    ];
+  }
+
+  GetModifierSpellAmplify_Percentage(): number {
+    return this.isActiveForParent() ? this.getSpellAmplification() : 0;
+  }
+
+  GetModifierPercentageCooldown(event: ModifierAbilityEvent): number {
+    return this.getCooldownSpeedBonusForAbility(event);
+  }
+
+  GetModifierPercentageCooldownOngoing(event: ModifierAbilityEvent): number {
+    return this.getCooldownSpeedBonusForAbility(event);
+  }
+
+  OnTooltip(): number {
+    return this.isActiveForParent()
+      ? roundMorphlingFlowTooltipValue(this.getSpellAmplification())
+      : 0;
+  }
+
+  OnTooltip2(): number {
+    return this.isActiveForParent()
+      ? roundMorphlingFlowTooltipValue(this.getCooldownSpeedBonus())
+      : 0;
+  }
+
+  private isActiveForParent(): boolean {
+    const parent = this.GetParent();
+    const ability = this.GetAbility();
+    return (
+      !parent.IsIllusion() &&
+      !parent.PassivesDisabled() &&
+      !!ability &&
+      !ability.IsNull() &&
+      ability.GetLevel() > 0
+    );
+  }
+
+  private getSpellAmplification(): number {
+    const parent = this.GetParent() as CDOTA_BaseNPC_Hero;
+    const ability = this.GetAbility();
+    if (!ability) return 0;
+
+    return calculateMorphlingFlowSpellAmplification(
+      parent.GetAgility(),
+      ability.GetSpecialValueFor('agility_per_spell_amp'),
+    );
+  }
+
+  private getCooldownSpeedBonusForAbility(event: ModifierAbilityEvent): number {
+    if (!this.isActiveForParent() || !event.ability || event.ability.IsNull()) return 0;
+    return this.getCooldownSpeedBonus();
+  }
+
+  private getCooldownSpeedBonus(): number {
+    const parent = this.GetParent() as CDOTA_BaseNPC_Hero;
+    const ability = this.GetAbility();
+    if (!ability) return 0;
+
+    return calculateMorphlingFlowCooldownSpeedBonus(
+      parent.GetAgility(),
+      parent.GetStrength(),
+      ability.GetSpecialValueFor('min_strength_agility_ratio'),
+      ability.GetSpecialValueFor('max_strength_agility_ratio'),
+      ability.GetSpecialValueFor('max_cooldown_speed_bonus'),
+    );
+  }
+}

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,12 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 变体精灵 觉醒
+  {
+    heroName: 'npc_dota_hero_morphling',
+    newAbility: 'morphling_flow_echo_awaken',
+    newLevel: 1,
+  },
   // 亚巴顿 觉醒
   {
     heroName: 'npc_dota_hero_abaddon',

--- a/src/vscripts/modules/awaken/awaken-replacer.test.ts
+++ b/src/vscripts/modules/awaken/awaken-replacer.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { applyAwakenByHero, canAwaken, executeReplacement, isAwakened } from './awaken-replacer';
+import { ABILITY_REPLACEMENTS, FREE_TRIAL_HEROES } from './awaken-config';
 
 /** 构造一个记录技能槽状态的假英雄，用于验证三分支的增删与退点数逻辑 */
 function createFakeHero(opts: {
@@ -214,6 +215,29 @@ describe('applyAwakenByHero', () => {
   });
 });
 
+describe('Morphling awakening configuration', () => {
+  it('adds Flow Echo as a hidden level-one awakening ability', () => {
+    const replacement = ABILITY_REPLACEMENTS.find(
+      (entry) => entry.heroName === 'npc_dota_hero_morphling',
+    );
+
+    expect(replacement).toEqual({
+      heroName: 'npc_dota_hero_morphling',
+      newAbility: 'morphling_flow_echo_awaken',
+      newLevel: 1,
+    });
+
+    const f = createFakeHero({ abilities: [] });
+    executeReplacement(f.hero, replacement!);
+    expect(f.abilities).toEqual([
+      expect.objectContaining({ name: 'morphling_flow_echo_awaken', level: 1 }),
+    ]);
+  });
+
+  it('does not add Morphling to the free trial list', () => {
+    expect(FREE_TRIAL_HEROES).not.toContain('npc_dota_hero_morphling');
+  });
+});
 describe('canAwaken', () => {
   it('配置表内的英雄返回 true', () => {
     const f = createFakeHero({ unitName: 'npc_dota_hero_pudge' });


### PR DESCRIPTION
## Issue

No linked issue.

## Summary

- Adds Morphling's Flow awakening as a hidden passive with a visible status modifier.
- Grants 1% spell amplification per 5 current Agility.
- Linearly reduces ability and item cooldowns as the current Strength-to-Agility ratio increases, up to 60%, including cooldowns already in progress.
- Registers the awakening in the profile UI and adds Chinese, English, and Russian tooltips.

## Checklist

- [x] User confirmed the awakening display in Dota Tools.
- [x] `npm test -- --runInBand` (28 suites / 300 tests passed).
- [x] `npm run build:vscripts`.
- [x] `npm run build:panorama`.
- [x] `npm run lint`.
- [x] Localization key parity, percent escaping, and `git diff --check`.

## Release Note

```
[b]游戏性更新[/b]

- 新增变体精灵觉醒：当前敏捷提供技能增强，力量相对敏捷越高，技能和物品的冷却时间越短。
```

```
[b]Gameplay update[/b]

- Added Morphling's awakening: current Agility grants spell amplification, while a higher Strength-to-Agility ratio shortens ability and item cooldowns.
```