### PR TITLE
feat(awaken): add Tidehunter Anchor Smash awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3495,6 +3495,12 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken_SummaryDescription"		"Nearby deaths reduce the current cooldowns of all abilities and items."
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>The Quickening Awakened</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"Whenever a unit dies within <font color='#FFFFFF'><b>900</b></font> range, the current cooldowns of all Abaddon's abilities and items are reduced. Non-hero deaths reduce them by <font color='#FFFFFF'><b>0.2</b></font>s; hero deaths reduce them by <font color='#FFFFFF'><b>3</b></font>s."
+		// Tidehunter
+		"DOTA_Tooltip_ability_special_bonus_unique_tidehunter_smash_on_blubber"				"<font color='#d000ff'>Anchor Smash Awakening</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_tidehunter_smash_on_blubber_Description"	"When Kraken Shell triggers a strong dispel, it automatically releases Anchor Smash. This Anchor Smash triggers attack effects normally, but deals no additional regular attack damage."
+		"DOTA_Tooltip_modifier_special_bonus_unique_tidehunter_smash_on_blubber"			"<font color='#d000ff'>Anchor Smash Awakening</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_tidehunter_smash_on_blubber_Description"	"When Kraken Shell triggers a strong dispel, it automatically releases Anchor Smash. This Anchor Smash triggers attack effects normally, but deals no additional regular attack damage."
+		"DOTA_Tooltip_ability_special_bonus_unique_tidehunter_anchor_smash_damage"			"+{s:bonus_attack_damage}% Anchor Smash Attack Damage"
 
 	}
 }

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -616,6 +616,12 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken_SummaryDescription"		"Смерти поблизости сокращают текущее время перезарядки всех способностей и предметов."
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>Ускорение · Пробуждение</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"Когда юнит погибает в радиусе <font color='#FFFFFF'><b>900</b></font> от Abaddon, текущее время перезарядки всех его способностей и предметов сокращается. Смерть не-героя сокращает его на <font color='#FFFFFF'><b>0.2</b></font> сек., а смерть героя — на <font color='#FFFFFF'><b>3</b></font> сек."
+		// Tidehunter
+		"DOTA_Tooltip_ability_special_bonus_unique_tidehunter_smash_on_blubber"				"<font color='#d000ff'>Пробуждение: Удар якорем</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_tidehunter_smash_on_blubber_Description"	"Когда Панцирь кракена применяет сильное развеивание, автоматически срабатывает Удар якорем. Этот Удар якорем активирует эффекты атаки, но не наносит дополнительный обычный урон от атаки."
+		"DOTA_Tooltip_modifier_special_bonus_unique_tidehunter_smash_on_blubber"			"<font color='#d000ff'>Пробуждение: Удар якорем</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_tidehunter_smash_on_blubber_Description"	"Когда Панцирь кракена применяет сильное развеивание, автоматически срабатывает Удар якорем. Этот Удар якорем активирует эффекты атаки, но не наносит дополнительный обычный урон от атаки."
+		"DOTA_Tooltip_ability_special_bonus_unique_tidehunter_anchor_smash_damage"			"+{s:bonus_attack_damage}% к урону от атаки способности «Удар якорем»"
 
 	}
 }

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3504,6 +3504,12 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken_SummaryDescription"		"附近单位阵亡时，减少所有技能和物品的当前冷却。"
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>畅快淋漓 觉醒</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"附近 <font color='#FFFFFF'><b>900</b></font> 范围内有单位阵亡时，亚巴顿所有技能和物品的当前冷却都会减少。非英雄单位阵亡减少 <font color='#FFFFFF'><b>0.2</b></font> 秒，英雄阵亡减少 <font color='#FFFFFF'><b>3</b></font> 秒。"
+		// 潮汐猎人
+		"DOTA_Tooltip_ability_special_bonus_unique_tidehunter_smash_on_blubber"				"<font color='#d000ff'>锚击觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_tidehunter_smash_on_blubber_Description"	"海妖外壳触发强驱散时自动释放锚击。该锚击会正常触发攻击特效，但不会额外造成普通攻击伤害。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_tidehunter_smash_on_blubber"			"<font color='#d000ff'>锚击觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_tidehunter_smash_on_blubber_Description"	"海妖外壳触发强驱散时自动释放锚击。该锚击会正常触发攻击特效，但不会额外造成普通攻击伤害。"
+		"DOTA_Tooltip_ability_special_bonus_unique_tidehunter_anchor_smash_damage"			"+{s:bonus_attack_damage}% 锚击攻击伤害"
 
 	}
 }

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -22,6 +22,17 @@
 			"radius"							"900"
 		}
 	}
+	// 潮汐猎人 锚击-觉醒
+	"special_bonus_unique_tidehunter_smash_on_blubber"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/special_bonus_unique_tidehunter_smash_on_blubber"
+		"AbilityType"					"ABILITY_TYPE_BASIC"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"			"tidehunter_anchor_smash"
+		"MaxLevel"						"1"
+	}
+
 	// 天怒法师-觉醒
 	"special_bonus_unique_skywrath_upgrade"
 	{

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -4130,6 +4130,7 @@
 			"attack_damage"
 			{
 				"value"										"50 100 150 200 250"
+				"special_bonus_unique_tidehunter_anchor_smash_damage"	"+50%"
 			}
 			"damage_reduction"
 			{
@@ -4178,6 +4179,17 @@
 			"fish_attack_range"				"4"		// 2 x2
 			"fish_damage_block"				"4"		// 1 x4
 			"fish_health_bonus"				"60"	// 3 x20
+		}
+	}
+	// 自定义天赋 锚击攻击伤害
+	"special_bonus_unique_tidehunter_anchor_smash_damage"
+	{
+		"AbilityType"					"ABILITY_TYPE_ATTRIBUTES"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"BaseClass"						"special_bonus_base"
+		"AbilityValues"
+		{
+			"attack_damage"					"50"
 		}
 	}
 	//=================================================================================================================

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -2223,6 +2223,49 @@
 	"npc_dota_hero_morphling"
 	{
 	}
+	// 潮汐猎人
+	"npc_dota_hero_tidehunter"
+	{
+		"Ability14"		"special_bonus_unique_tidehunter_anchor_smash_damage"
+
+		"Bot"
+		{
+			"Build"
+			{
+				"1"		"tidehunter_gush"
+				"2"		"tidehunter_kraken_shell"
+				"3"		"tidehunter_anchor_smash"
+				"4"		"tidehunter_kraken_shell"
+				"5"		"tidehunter_anchor_smash"
+				"6"		"tidehunter_ravage"
+				"7"		"tidehunter_anchor_smash"
+				"8"		"tidehunter_kraken_shell"
+				"9"		"tidehunter_kraken_shell"
+				"10"		"special_bonus_unique_tidehunter_5"
+				"11"		"tidehunter_anchor_smash"
+				"12"		"tidehunter_ravage"
+				"13"		"tidehunter_gush"
+				"14"		"tidehunter_gush"
+				"15"		"special_bonus_unique_tidehunter_2"
+				"16"		"tidehunter_gush"
+				"17"		""
+				"18"		"tidehunter_ravage"
+				"19"		""
+				"20"		"special_bonus_unique_tidehunter"
+				"21"		""
+				"22"		""
+				"23"		"tidehunter_gush"
+				"24"		"tidehunter_ravage"
+				"25"		"special_bonus_unique_tidehunter_7"
+				"26"		"tidehunter_kraken_shell"
+				"27"		"special_bonus_unique_tidehunter_3"
+				"28"		"special_bonus_unique_tidehunter_ravage_cooldown"
+				"29"		"special_bonus_unique_tidehunter_anchor_smash_damage"
+				"30"		"special_bonus_unique_tidehunter_10"
+				"31"		"tidehunter_anchor_smash"
+			}
+		}
+	}
 	// 小小
 	"npc_dota_hero_tiny"
 	{

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,11 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_tidehunter',
+    abilityName: 'special_bonus_unique_tidehunter_smash_on_blubber',
+    freeTrial: true,
+  },
+  {
     heroName: 'npc_dota_hero_abaddon',
     abilityName: 'special_bonus_unique_abaddon_quickening_awaken',
     freeTrial: true,

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_tidehunter_smash_on_blubber.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_tidehunter_smash_on_blubber.ts
@@ -1,0 +1,131 @@
+﻿import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+import {
+  getTidehunterAwakenCarrierTotalDamageOutgoingPercentage,
+  shouldTriggerTidehunterAwakenProcCarrier,
+} from './tidehunter-anchor-smash-awaken-logic';
+
+const ANCHOR_SMASH_ABILITY = 'tidehunter_anchor_smash';
+
+/** 潮汐猎人 锚击-觉醒：复用原生海妖外壳净化锚击，并为其补齐攻击特效。 */
+@registerAbility('special_bonus_unique_tidehunter_smash_on_blubber')
+export class SpecialBonusUniqueTidehunterSmashOnBlubber extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return modifier_special_bonus_unique_tidehunter_smash_on_blubber.name;
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_tidehunter_smash_on_blubber')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_tidehunter_smash_on_blubber extends BaseModifier {
+  private carrierAttackInProgress = false;
+  private carrierAttackRecords: Record<number, boolean> = {};
+
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  IsPurgeException(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  AllowIllusionDuplicate(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return ANCHOR_SMASH_ABILITY;
+  }
+
+  OnCreated(): void {
+    if (!IsServer()) return;
+    this.carrierAttackInProgress = false;
+    this.carrierAttackRecords = {};
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [
+      ModifierFunction.ON_TAKEDAMAGE,
+      ModifierFunction.ON_ATTACK_RECORD,
+      ModifierFunction.ON_ATTACK_RECORD_DESTROY,
+      ModifierFunction.TOTALDAMAGEOUTGOING_PERCENTAGE,
+    ];
+  }
+
+  OnTakeDamage(event: ModifierInstanceEvent): void {
+    if (!IsServer()) return;
+
+    const tidehunter = this.GetParent() as CDOTA_BaseNPC_Hero;
+    const awakenAbility = this.GetAbility();
+    const target = event.unit;
+    const inflictor = event.inflictor;
+    const targetIsValid =
+      !!target &&
+      !target.IsNull() &&
+      target.IsAlive() &&
+      target !== tidehunter &&
+      target.GetTeamNumber() !== tidehunter.GetTeamNumber();
+
+    if (
+      !shouldTriggerTidehunterAwakenProcCarrier({
+        attackerMatches: event.attacker === tidehunter,
+        awakenAbilityActive:
+          !!awakenAbility && !awakenAbility.IsNull() && awakenAbility.GetLevel() > 0,
+        carrierAttackInProgress: this.carrierAttackInProgress,
+        inflictorAbilityName:
+          inflictor && !inflictor.IsNull() ? inflictor.GetAbilityName() : undefined,
+        damageFlags: event.damage_flags,
+        reflectionFlag: DamageFlag.REFLECTION,
+        damage: event.damage,
+        targetIsValid,
+      })
+    ) {
+      return;
+    }
+
+    this.carrierAttackInProgress = true;
+    tidehunter.PerformAttack(
+      target,
+      true,
+      true,
+      true,
+      false,
+      tidehunter.IsRangedAttacker(),
+      false,
+      false,
+    );
+    this.carrierAttackInProgress = false;
+  }
+
+  OnAttackRecord(event: ModifierAttackEvent): void {
+    if (!IsServer()) return;
+    if (event.attacker !== this.GetParent() || !this.carrierAttackInProgress) return;
+
+    this.carrierAttackRecords[event.record] = true;
+  }
+
+  OnAttackRecordDestroy(event: ModifierAttackEvent): void {
+    if (!IsServer()) return;
+    delete this.carrierAttackRecords[event.record];
+  }
+
+  GetModifierTotalDamageOutgoing_Percentage(event: ModifierAttackEvent): number {
+    return getTidehunterAwakenCarrierTotalDamageOutgoingPercentage(
+      this.carrierAttackRecords[event.record] === true,
+      event.damage_category,
+      DamageCategory.ATTACK,
+    );
+  }
+}

--- a/src/vscripts/abilities/ts_abilities/tidehunter-anchor-smash-awaken-logic.test.ts
+++ b/src/vscripts/abilities/ts_abilities/tidehunter-anchor-smash-awaken-logic.test.ts
@@ -1,0 +1,89 @@
+﻿import {
+  getTidehunterAwakenCarrierTotalDamageOutgoingPercentage,
+  shouldTriggerTidehunterAwakenProcCarrier,
+} from './tidehunter-anchor-smash-awaken-logic';
+
+const REFLECTION = 16;
+
+function createEvent(
+  overrides: Partial<Parameters<typeof shouldTriggerTidehunterAwakenProcCarrier>[0]> = {},
+) {
+  return {
+    attackerMatches: true,
+    awakenAbilityActive: true,
+    carrierAttackInProgress: false,
+    inflictorAbilityName: 'tidehunter_anchor_smash',
+    damageFlags: REFLECTION,
+    reflectionFlag: REFLECTION,
+    damage: 100,
+    targetIsValid: true,
+    ...overrides,
+  };
+}
+
+describe('shouldTriggerTidehunterAwakenProcCarrier', () => {
+  it('accepts reflected Anchor Smash damage while the awakening is active', () => {
+    expect(shouldTriggerTidehunterAwakenProcCarrier(createEvent())).toBe(true);
+  });
+
+  it.each([
+    { awakenAbilityActive: false },
+    { damageFlags: 0 },
+    { inflictorAbilityName: 'tidehunter_anchor_smash', damageFlags: 0 },
+    { inflictorAbilityName: 'item_blade_mail' },
+    { attackerMatches: false },
+    { carrierAttackInProgress: true },
+    { damage: 0 },
+    { targetIsValid: false },
+  ])('rejects inactive awakening, unrelated damage, or recursion: %o', (overrides) => {
+    expect(shouldTriggerTidehunterAwakenProcCarrier(createEvent(overrides))).toBe(false);
+  });
+
+  it('rejects an actively cast Anchor Smash because it is not reflection damage', () => {
+    expect(
+      shouldTriggerTidehunterAwakenProcCarrier(
+        createEvent({ inflictorAbilityName: 'tidehunter_anchor_smash', damageFlags: 0 }),
+      ),
+    ).toBe(false);
+  });
+
+  it('accepts separate targets independently when the native smash reports damage for each one', () => {
+    expect(shouldTriggerTidehunterAwakenProcCarrier(createEvent({ damage: 80 }))).toBe(true);
+    expect(shouldTriggerTidehunterAwakenProcCarrier(createEvent({ damage: 120 }))).toBe(true);
+  });
+});
+
+describe('getTidehunterAwakenCarrierTotalDamageOutgoingPercentage', () => {
+  const ATTACK_DAMAGE_CATEGORY = 1;
+  const SPELL_DAMAGE_CATEGORY = 0;
+
+  it('removes only the normal attack damage from the proc-carrier record', () => {
+    expect(
+      getTidehunterAwakenCarrierTotalDamageOutgoingPercentage(
+        true,
+        ATTACK_DAMAGE_CATEGORY,
+        ATTACK_DAMAGE_CATEGORY,
+      ),
+    ).toBe(-100);
+  });
+
+  it('preserves spell-like damage produced by attack effects on the carrier record', () => {
+    expect(
+      getTidehunterAwakenCarrierTotalDamageOutgoingPercentage(
+        true,
+        SPELL_DAMAGE_CATEGORY,
+        ATTACK_DAMAGE_CATEGORY,
+      ),
+    ).toBe(0);
+  });
+
+  it('does not modify unrelated attack records', () => {
+    expect(
+      getTidehunterAwakenCarrierTotalDamageOutgoingPercentage(
+        false,
+        ATTACK_DAMAGE_CATEGORY,
+        ATTACK_DAMAGE_CATEGORY,
+      ),
+    ).toBe(0);
+  });
+});

--- a/src/vscripts/abilities/ts_abilities/tidehunter-anchor-smash-awaken-logic.ts
+++ b/src/vscripts/abilities/ts_abilities/tidehunter-anchor-smash-awaken-logic.ts
@@ -1,0 +1,42 @@
+﻿export interface TidehunterAnchorSmashAwakenCarrierEvent {
+  attackerMatches: boolean;
+  awakenAbilityActive: boolean;
+  carrierAttackInProgress: boolean;
+  inflictorAbilityName?: string;
+  damageFlags: number;
+  reflectionFlag: number;
+  damage: number;
+  targetIsValid: boolean;
+}
+
+const ANCHOR_SMASH_ABILITY = 'tidehunter_anchor_smash';
+
+/**
+ * Kraken Shell's native Anchor Smash talent reports its damage as reflected Anchor Smash damage.
+ * The awakening reuses that native trigger and adds only a zero-normal-damage attack to carry procs.
+ */
+export function shouldTriggerTidehunterAwakenProcCarrier(
+  event: TidehunterAnchorSmashAwakenCarrierEvent,
+): boolean {
+  return (
+    event.attackerMatches &&
+    event.awakenAbilityActive &&
+    !event.carrierAttackInProgress &&
+    event.inflictorAbilityName === ANCHOR_SMASH_ABILITY &&
+    (event.damageFlags & event.reflectionFlag) === event.reflectionFlag &&
+    event.damage > 0 &&
+    event.targetIsValid
+  );
+}
+
+/**
+ * Suppress only the carrier record's ordinary attack damage. Spell-like damage created by attack
+ * effects must remain so the synthetic attack behaves like Anchor Smash for proc purposes.
+ */
+export function getTidehunterAwakenCarrierTotalDamageOutgoingPercentage(
+  isCarrierRecord: boolean,
+  damageCategory: number | undefined,
+  attackDamageCategory: number,
+): number {
+  return isCarrierRecord && damageCategory === attackDamageCategory ? -100 : 0;
+}

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,12 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 潮汐猎人 觉醒
+  {
+    heroName: 'npc_dota_hero_tidehunter',
+    newAbility: 'special_bonus_unique_tidehunter_smash_on_blubber',
+    newLevel: 1,
+  },
   // 亚巴顿 觉醒
   {
     heroName: 'npc_dota_hero_abaddon',
@@ -245,6 +251,7 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  * 新觉醒发布时加入，下次发版由 awaken-ability skill 流程确认移出。
  */
 export const FREE_TRIAL_HEROES: string[] = [
+  'npc_dota_hero_tidehunter', // 潮汐猎人
   'npc_dota_hero_abaddon', // 亚巴顿
   'npc_dota_hero_skywrath_mage', // 天怒法师
   'npc_dota_hero_dazzle', // 戴泽


### PR DESCRIPTION
﻿## Summary

- move Tidehunter's Kraken Shell-triggered Anchor Smash talent into the awakening system so it is active immediately after awakening and exposed through a persistent status modifier
- let the awakening-triggered Anchor Smash carry attack effects while suppressing the synthetic attack's ordinary attack damage
- replace the level 20 talent with `+50% Anchor Smash Attack Damage` and add Simplified Chinese, English, and Russian localization
- classify the hidden awakening ability as a basic ability so it does not create a ninth talent node in the native talent UI

## Validation

- `npm test -- --runInBand` (27 suites, 283 tests)
- targeted ESLint for the touched TS/TSX files
- `npm run build:vscripts`
- `npm run build:panorama`
- `git diff --check`

