### PR TITLE
Normalize control time and adjust Skywrath ability cast priority

### DIFF
--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_skywrath_upgrade.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_skywrath_upgrade.ts
@@ -12,9 +12,9 @@ import {
 export class SpecialBonusUniqueSkywrathUpgrade extends AutoCastAbility {
   // 每轮 think 最多放一个技能，避免四个技能同帧连发，下一个留给下轮 think
   OnAutoCastThink(caster: CDOTA_BaseNPC_Hero): void {
-    if (this.castAncientSeal(caster)) return;
     if (this.castConcussiveShot(caster)) return;
     if (this.castMysticFlare(caster)) return;
+    if (this.castAncientSeal(caster)) return;
     if (this.castArcaneBolt(caster)) return;
   }
 

--- a/src/vscripts/modules/event/game-end/game-end-point.test.ts
+++ b/src/vscripts/modules/event/game-end/game-end-point.test.ts
@@ -1,6 +1,6 @@
 import { GameEndPlayerDto } from '../../../api/analytics/dto/game-end-dto';
 import { Option } from '../../option';
-import { GameEndPoint } from './game-end-point';
+import { GameEndPoint, normalizeControlTime } from './game-end-point';
 
 export function IsInToolsMode(): boolean {
   return true;
@@ -30,6 +30,16 @@ describe('GameEndPoint', () => {
     battlePoints: 0,
     awaken: 0,
     ...overrides,
+  });
+
+  describe('normalizeControlTime', () => {
+    it('应该保留控制时间的绝对值并过滤非有限值', () => {
+      expect(normalizeControlTime(4)).toBe(4);
+      expect(normalizeControlTime(-4)).toBe(4);
+      expect(normalizeControlTime(0)).toBe(0);
+      expect(normalizeControlTime(Number.NaN)).toBe(0);
+      expect(normalizeControlTime(Number.POSITIVE_INFINITY)).toBe(0);
+    });
   });
 
   describe('GameEndPoint.CalculatePlayerScore', () => {

--- a/src/vscripts/modules/event/game-end/game-end-point.ts
+++ b/src/vscripts/modules/event/game-end/game-end-point.ts
@@ -2,6 +2,10 @@ import { GameEndPlayerDto } from '../../../api/analytics/dto/game-end-dto';
 import { reloadable } from '../../../utils/tstl-utils';
 import { Option } from '../../option';
 
+export function normalizeControlTime(controlTime: number): number {
+  return Number.isFinite(controlTime) ? Math.abs(controlTime) : 0;
+}
+
 @reloadable
 export class GameEndPoint {
   static CalculatePlayerScore(player: GameEndPlayerDto): number {

--- a/src/vscripts/modules/event/game-end/game-end.ts
+++ b/src/vscripts/modules/event/game-end/game-end.ts
@@ -12,7 +12,7 @@ import { reloadable } from '../../../utils/tstl-utils';
 import { isAwakened } from '../../awaken/awaken-replacer';
 import { GameConfig } from '../../GameConfig';
 import { PlayerHelper } from '../../helper/player-helper';
-import { GameEndPoint } from './game-end-point';
+import { GameEndPoint, normalizeControlTime } from './game-end-point';
 
 @reloadable
 export class GameEnd {
@@ -99,8 +99,7 @@ export class GameEnd {
         0,
         PlayerResource.GetTotalEarnedGold(playerId) - transferredBackTotal,
       );
-      const rawStuns = PlayerResource.GetStuns(playerId);
-      const stuns = Number.isFinite(rawStuns) && rawStuns > 0 ? rawStuns : 0;
+      const stuns = normalizeControlTime(PlayerResource.GetStuns(playerId));
 
       const playerDto: GameEndPlayerDto = {
         heroName: PlayerResource.GetSelectedHeroName(playerId),


### PR DESCRIPTION
## Summary

- Normalize player stun time using absolute values and filter non-finite values.
- Add unit coverage for control-time normalization.
- Adjust Skywrath upgrade autocast priority to cast Concussive Shot and Mystic Flare before Ancient Seal.

## Testing

- Added unit tests covering positive, negative, zero, NaN, and infinite control-time values.
- Not run (not requested).