### PR TITLE
Balance magic rune upgrade items

### DIFF
--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -4933,7 +4933,7 @@
 		"AbilityValues"
 		{
 				"bonus_damage"			"160"
-				"bonus_health_regen"	"20"
+				"bonus_health_regen"	"15"
 				"bonus_mana_regen"		"8"
 				"cleave_damage_percent"	"80"
 				"cleave_damage_percent_creep"	"80"
@@ -5523,7 +5523,7 @@
 		"AbilityTextureName"		"fusion_magic"
 		"AbilityBehavior"			"DOTA_ABILITY_BEHAVIOR_PASSIVE"
 
-		"ItemCost"					"20000"
+		"ItemCost"					"10000"
 		"ItemIsNeutralDrop"			"0"
 		"ItemPurchasable"			"1"
 		"ItemKillable"				"0"
@@ -6682,7 +6682,7 @@
 
 		// Item Info
 		//-------------------------------------------------------------------------------------------------------------
-		"ItemCost"					"62300"
+		"ItemCost"					"52300"
 		"ItemShopTags"				"move_speed;boost_mana;mana_pool"
 		"ItemQuality"				"rare"
 		"ItemAliases"				"mana;mb;refresh core;refresher orb;octarine core"
@@ -6704,11 +6704,11 @@
 			"bonus_mana_regen"			"15.0"	// tooltip only - 魔法恢复
 
 			// Lua 逻辑需要的参数
-			"manacost_reduction"		"50"	// 新增:减魔耗百分比
+			"manacost_reduction"		"45"	// 新增:减魔耗百分比
 			"cast_speed_pct"			"50"	// 新增:施法速度加成百分比
-			"bonus_cooldown"			"50"
-			"bonus_cooldown_stack"		"25"	// activates to correctly interact
-			"cast_range_bonus"			"400"
+			"bonus_cooldown"			"45"
+			"bonus_cooldown_stack"		"17"	// activates to correctly interact
+			"cast_range_bonus"			"350"
 		}
 	}
 
@@ -7166,10 +7166,10 @@
 		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
 
 		"AbilityCastPoint"				"0.0"
-		"AbilityCooldown"				"20.0"
+		"AbilityCooldown"				"30.0"
 		"AbilityManaCost"				"150"
 
-		"ItemCost"						"59000"
+		"ItemCost"						"49000"
 		"ItemShopTags"					"damage;agi;hard_to_tag"
 		"ItemQuality"					"artifact"
 
@@ -7184,17 +7184,17 @@
 			"bonus_all_stats"			"80"	// 全属性
 
 			// 狂战斧属性（modifier_item_battlefury）
-			"bonus_health_regen"		"30"	// 生命回复
+			"bonus_health_regen"		"25"	// 生命回复
 			"bonus_mana_regen"			"10"	// 魔法回复
 			// 狂战斧溅射参数
 			"cleave_damage_percent"			"100"	// 溅射伤害百分比（英雄）
-			"cleave_damage_percent_creep"	"120"	// 溅射伤害百分比（小兵）
+			"cleave_damage_percent_creep"	"100"	// 溅射伤害百分比（小兵）
 			"cleave_starting_width"			"150"	// 溅射起始宽度
 			"cleave_ending_width"			"500"	// 溅射结束宽度
 			"cleave_distance"				"1000"	// 溅射距离
 
 			// Desolator 参数（从 item_infernal_desolator 继承）
-			"corruption_armor"			"-50"	// 护甲降低
+			"corruption_armor"			"-45"	// 护甲降低
 			"corruption_duration"		"7.0"	// 护甲降低持续时间
 			"bonus_damage_per_kill"		"0"		// 每次击杀增加的攻击力
 			"bonus_damage_per_assist"	"0"		// 每次助攻增加的攻击力
@@ -7202,9 +7202,9 @@
 
 			// 其他 Debuff
 			"debuff_duration"			"4.0"	// Debuff持续时间
-			"attack_slow"				"-200"	// Debuff攻击速度降低
+			"attack_slow"				"-150"	// Debuff攻击速度降低
 			"slow_pct"					"-60"	// Debuff移动速度降低
-			"hp_regen_reduction_pct"	"-70"	// Debuff生命回复降低
+			"hp_regen_reduction_pct"	"-60"	// Debuff生命回复降低
 		}
 
 		"OnSpellStart"

--- a/src/vscripts/ai/build-item/item-tier-config.ts
+++ b/src/vscripts/ai/build-item/item-tier-config.ts
@@ -1312,7 +1312,7 @@ export const ItemTierConfig: Record<string, ItemConfig> = {
     name: 'item_magic_sword',
     nameCN: '魔渊剑',
     tier: ItemTier.T5,
-    cost: 59000,
+    cost: 49000,
     baseItems: ['item_bfury_ultra', 'item_infernal_desolator', 'item_skadi_2'],
   },
   item_beast_shield: {
@@ -1326,7 +1326,7 @@ export const ItemTierConfig: Record<string, ItemConfig> = {
     name: 'item_time_gem',
     nameCN: '时间宝石',
     tier: ItemTier.T5,
-    cost: 62300,
+    cost: 52300,
     baseItems: ['item_refresh_core'],
   },
   item_switchable_crit_blade: {


### PR DESCRIPTION
## Checklist

- [ ] Verify item prices and balance changes in Dota Tools.

## Release Note

```
[b]游戏性更新 v5.50[/b]

- 降低魔渊剑、时间宝石的合成价格，并平衡其属性。
```

```
[b]Gameplay update v5.50[/b]

- Lowered the crafting costs of Demonic Sword and Time Gem, and adjusted their stats.
```
