### PR TITLE
Daily task: GA4 selection/completion analytics event

### DIFF
--- a/src/vscripts/api/analytics/ga4/ga4-daily-task-tracker.ts
+++ b/src/vscripts/api/analytics/ga4/ga4-daily-task-tracker.ts
@@ -1,0 +1,37 @@
+import { GameEndDto, GameEndPlayerDto } from '../dto/game-end-dto';
+import { GA4 } from './ga4';
+
+export class GA4DailyTaskTracker {
+  /** 游戏结束时调用：仅对选择过每日任务的玩家发送选择/完成情况 */
+  public static SendAtGameEnd(gameEndDto: GameEndDto): void {
+    const eventName = 'game_end_daily_task';
+
+    gameEndDto.players.forEach((player) => {
+      const candidate = GameRules.DailyTask.GetSelectedCandidate(player.playerId);
+      if (!candidate) return;
+
+      const completed = this.IsCompleted(player);
+
+      const event = GA4.BuildEvent(eventName, player.steamId, {
+        steam_id: player.steamId,
+        hero_name: player.heroName,
+        difficulty: gameEndDto.difficulty,
+        team_id: player.teamId,
+        is_winner: player.teamId === gameEndDto.winnerTeamId,
+        type: candidate.scope,
+        tier: candidate.star,
+        task_id: candidate.taskId,
+        metric: candidate.metric,
+        completed,
+      });
+
+      GA4.SendEvent(player.steamId, event);
+    });
+  }
+
+  // 掉线玩家不结算每日任务，与 game-end.ts 的结算口径一致（spec 3.5）
+  private static IsCompleted(player: GameEndPlayerDto): boolean {
+    if (player.isDisconnected) return false;
+    return GameRules.DailyTask.EvaluateCompletion(player.playerId) !== undefined;
+  }
+}

--- a/src/vscripts/modules/daily-task/daily-task.test.ts
+++ b/src/vscripts/modules/daily-task/daily-task.test.ts
@@ -160,6 +160,28 @@ describe('DailyTask', () => {
     });
   });
 
+  describe('GetSelectedCandidate（只读查询选中候选）', () => {
+    beforeEach(() => {
+      dailyTask.SetStartData(PLAYER_ID, {
+        steamId: 111,
+        dayId: '20260815',
+        candidates: [GENERAL_CANDIDATE, HERO_CANDIDATE],
+        completedTasks: [],
+        todaySeasonPoint: 0,
+        history: [],
+      });
+    });
+
+    it('未选择候选时返回 undefined', () => {
+      expect(dailyTask.GetSelectedCandidate(PLAYER_ID)).toBeUndefined();
+    });
+
+    it('已选择候选时返回完整候选，不判定是否完成', () => {
+      dailyTask.SelectCandidate(PLAYER_ID, GENERAL_CANDIDATE.taskId);
+      expect(dailyTask.GetSelectedCandidate(PLAYER_ID)).toEqual(GENERAL_CANDIDATE);
+    });
+  });
+
   describe('EvaluateCompletion（达标判定）', () => {
     beforeEach(() => {
       dailyTask.SetStartData(PLAYER_ID, {

--- a/src/vscripts/modules/daily-task/daily-task.ts
+++ b/src/vscripts/modules/daily-task/daily-task.ts
@@ -81,12 +81,21 @@ export class DailyTask {
     });
   }
 
+  /** 只读查询：本局选中的候选（未选择返回 undefined），供 GA4 等统计模块使用 */
+  GetSelectedCandidate(playerId: PlayerID): TaskCandidateDto | undefined {
+    return this.findSelectedCandidate(this.state.get(playerId));
+  }
+
+  private findSelectedCandidate(state?: DailyTaskPlayerState): TaskCandidateDto | undefined {
+    if (!state?.selectedTaskId) {
+      return undefined;
+    }
+    return state.candidates.find((c) => c.taskId === state.selectedTaskId);
+  }
+
   private pushProgress(playerId: PlayerID): void {
     const state = this.state.get(playerId);
-    if (!state?.selectedTaskId) {
-      return;
-    }
-    const candidate = state.candidates.find((c) => c.taskId === state.selectedTaskId);
+    const candidate = this.findSelectedCandidate(state);
     if (!candidate) {
       return;
     }
@@ -106,12 +115,8 @@ export class DailyTask {
       return undefined;
     }
     const state = this.state.get(playerId);
-    if (!state?.selectedTaskId) {
-      return undefined;
-    }
-    // 防御性检查：能被选中的任务本来就一定在候选列表里，理论上必然能找到对应候选
-    const candidate = state.candidates.find((c) => c.taskId === state.selectedTaskId);
-    if (!candidate) {
+    const candidate = this.findSelectedCandidate(state);
+    if (!state || !candidate) {
       return undefined;
     }
     if (candidate.scope === 'personal_hero') {

--- a/src/vscripts/modules/event/game-end/game-end.ts
+++ b/src/vscripts/modules/event/game-end/game-end.ts
@@ -4,6 +4,7 @@ import {
   GameEndPlayerDto,
 } from '../../../api/analytics/dto/game-end-dto';
 import { GA4 } from '../../../api/analytics/ga4/ga4';
+import { GA4DailyTaskTracker } from '../../../api/analytics/ga4/ga4-daily-task-tracker';
 import { GA4ItemTracker } from '../../../api/analytics/ga4/ga4-item-tracker';
 import { GA4PickAbilityTracker } from '../../../api/analytics/ga4/ga4-pick-ability-tracker';
 import { Game } from '../../../api/game';
@@ -203,6 +204,8 @@ export class GameEnd {
     GA4PickAbilityTracker.SendAtGameEnd(gameEndDto);
     // 发送 GA4 物品持有时长事件
     GA4ItemTracker.SendAtGameEnd(gameEndDto);
+    // 发送 GA4 每日任务选择/完成事件
+    GA4DailyTaskTracker.SendAtGameEnd(gameEndDto);
     // 发送 GA4 匹配时间事件
     GA4.SendGameEndMatchTimeEvents();
   }


### PR DESCRIPTION
## Issue

- [x] fix #2344

## Changes

新增每日任务的 GA4 选择/完成数据统计，游戏结束时上报玩家选中的候选任务及是否完成，供产品在 GA4/Looker 分析任务受欢迎度与完成率（不同步 BigQuery）。

- `DailyTask` 新增只读 getter `GetSelectedCandidate()`，暴露玩家本局选中的候选任务；把类内三处重复的"按 selectedTaskId 查候选"逻辑抽成私有 `findSelectedCandidate()`
- 新增 `GA4DailyTaskTracker.SendAtGameEnd()`，仿照 `GA4PickAbilityTracker` 的写法，仅对选择过候选的玩家发送 `game_end_daily_task` 事件（复用 `steam_id`/`hero_name`/`difficulty`/`team_id`/`is_winner`/`type`/`tier` 现有维度，新增 `task_id`/`metric`/`completed` 三个维度）
- `completed` 复用 `DailyTask.EvaluateCompletion()` 的判定口径（该方法为纯查询，`game-end.ts` 结算积分时已调用一次，此处安全地再次调用），掉线玩家恒为 `false`
- `game-end.ts` 的 `SendAnalyticsEvent()` 中接入调用

## Checklist

- [ ] I have tested the changes works well.
- [x] 在 Dota Tools 中跑一局：选择每日任务候选后结束游戏，Tools 控制台确认 `game_end_daily_task` 事件被发送且字段齐全（含掉线玩家 `completed` 恒为 false）
- [x] 确认未选择任务的玩家不发送该事件

## Release Note

无玩家可感知内容（纯后台 GA4 数据统计埋点），不生成 changelog 条目。
