### PR TITLE
Enable localhost game settlement rewards

### DIFF
--- a/src/vscripts/api/api-client.ts
+++ b/src/vscripts/api/api-client.ts
@@ -20,6 +20,7 @@ export interface ApiParameter {
 export class ApiClient {
   private static TIMEOUT_SECONDS = 10;
   private static RETRY_TIMES = 3;
+  private static LOCAL_ALLOWED_PATHS = ['/game/start', '/game/end/local'];
 
   // private static HOST_NAME: string = (() => {
   //   return IsInToolsMode() ? 'http://localhost:5000/api' : 'https://windy10v10ai.com/api';
@@ -64,9 +65,10 @@ export class ApiClient {
     print(`[ApiClient] ${method} ${ApiClient.HOST_NAME}${fullPath} body ${json.encode(body)}`);
     const request = CreateHTTPRequestScriptVM(method, ApiClient.HOST_NAME + fullPath);
     const apiKey = this.GetServerAuthKey();
+    const isLocalhost = this.IsLocalhost();
 
     // 本地主机只发送开局请求
-    if (this.IsLocalhost() && path !== '/game/start') {
+    if (isLocalhost && !ApiClient.LOCAL_ALLOWED_PATHS.includes(path)) {
       callbackFunc({
         StatusCode: 401,
         Body: ApiClient.LOCAL_APIKEY,

--- a/src/vscripts/api/game.ts
+++ b/src/vscripts/api/game.ts
@@ -17,6 +17,7 @@ class GameStart {
 export class Game {
   public static readonly GAME_START_URL = '/game/start';
   public static readonly GAME_END_URL = '/game/end';
+  public static readonly LOCAL_GAME_END_URL = '/game/end/local';
 
   constructor() {}
 
@@ -121,7 +122,7 @@ export class Game {
 
     const apiParameter = {
       method: HttpMethod.POST,
-      path: Game.GAME_END_URL,
+      path: ApiClient.IsLocalhost() ? Game.LOCAL_GAME_END_URL : Game.GAME_END_URL,
       body: gameEndDto,
       successFunc: (data: string) => {
         // CustomNetTables.SetTableValue('ending_status', 'ending_status', {

--- a/src/vscripts/modules/daily-task/daily-task.test.ts
+++ b/src/vscripts/modules/daily-task/daily-task.test.ts
@@ -36,11 +36,6 @@ global.PlayerResource = {
   GetSelectedHeroName: (playerId: number) => mockGetSelectedHeroName(playerId),
 };
 
-const mockIsLocalhost = jest.fn(() => false);
-jest.mock('../../api/api-client', () => ({
-  ApiClient: { IsLocalhost: () => mockIsLocalhost() },
-}));
-
 const mockReadTaskMetric = jest.fn();
 jest.mock('./daily-task-metric-reader', () => ({
   ReadTaskMetric: (playerId: number, metric: string) => mockReadTaskMetric(playerId, metric),
@@ -76,7 +71,6 @@ describe('DailyTask', () => {
   beforeEach(() => {
     for (const k of Object.keys(netTable)) delete netTable[k];
     mockIsCheatMode.mockReturnValue(false);
-    mockIsLocalhost.mockReturnValue(false);
     mockIsInToolsMode.mockReturnValue(false);
     mockGetMapName.mockReturnValue('dota');
     mockGetSelectedHeroName.mockReturnValue('npc_dota_hero_lina');
@@ -87,11 +81,6 @@ describe('DailyTask', () => {
   describe('IsDailyTaskEnabled（模式门控）', () => {
     it('作弊模式下禁用', () => {
       mockIsCheatMode.mockReturnValue(true);
-      expect(dailyTask.IsDailyTaskEnabled()).toBe(false);
-    });
-
-    it('localhost 下禁用', () => {
-      mockIsLocalhost.mockReturnValue(true);
       expect(dailyTask.IsDailyTaskEnabled()).toBe(false);
     });
 
@@ -107,10 +96,9 @@ describe('DailyTask', () => {
       expect(dailyTask.IsDailyTaskEnabled()).toBe(true);
     });
 
-    it('工具模式下忽略作弊/localhost，仍按地图判定', () => {
+    it('工具模式下忽略作弊状态，仍按地图判定', () => {
       mockIsInToolsMode.mockReturnValue(true);
       mockIsCheatMode.mockReturnValue(true);
-      mockIsLocalhost.mockReturnValue(true);
       expect(dailyTask.IsDailyTaskEnabled()).toBe(true);
     });
 

--- a/src/vscripts/modules/helper/environment-helper.ts
+++ b/src/vscripts/modules/helper/environment-helper.ts
@@ -1,12 +1,6 @@
-import { ApiClient } from '../../api/api-client';
-
 export class EnvironmentHelper {
-  /** 判断当前是否为无效游戏环境（作弊模式或本地主机） */
+  /** 判断当前是否为无效游戏环境 */
   static IsInvalidGameEnvironment(): boolean {
-    // 工具模式下始终视为有效环境，方便开发调试
-    if (IsInToolsMode()) {
-      return false;
-    }
-    return GameRules.IsCheatMode() || ApiClient.IsLocalhost();
+    return !IsInToolsMode() && GameRules.IsCheatMode();
   }
 }


### PR DESCRIPTION


## Checklist

- [x] I have tested the changes works well.
- [x] Ran focused unit tests and `npm run build:vscripts`.
- [x] Verify localhost settlement end-to-end after Firebase #1068 is deployed.

## Release Note

```
[b]游戏性更新 v5.50[/b]

- 临时允许本地主机结算获得勇士积分，每日上限1000积分
```

```
[b]Gameplay update v5.50[/b]

- Temporarily enabled Battle Point rewards for localhost game settlements, capped at 1,000 points per day.
```