### PR TITLE
Add Lion Finger of Death awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3496,5 +3496,12 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>The Quickening Awakened</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"Whenever a unit dies within <font color='#FFFFFF'><b>900</b></font> range, the current cooldowns of all Abaddon's abilities and items are reduced. Non-hero deaths reduce them by <font color='#FFFFFF'><b>0.2</b></font>s; hero deaths reduce them by <font color='#FFFFFF'><b>3</b></font>s."
 
+		// 莱恩 死亡一指觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_lion_finger_of_death_awaken"				"<font color='#d000ff'>Cycle of Death Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_lion_finger_of_death_awaken_Description"	"Missing-health bonus damage: <font color='#FFFFFF'><b>%missing_health_damage_pct%</b></font><font color='#FFFFFF'><b>%%</b></font>\nCurrent cooldown reduction per growth: <font color='#FFFFFF'><b>%cooldown_reduction_per_growth%s</b></font>\nDemon-form attack bonus from Finger damage: <font color='#FFFFFF'><b>%melee_finger_damage_pct%</b></font><font color='#FFFFFF'><b>%%</b></font>\n<font color='#00CED1'>Alternative Cast:</font> Only automatically targets real enemy heroes, ignoring Linken's Sphere, Lotus Orb, and spell reflection."
+		"DOTA_Tooltip_ability_special_bonus_unique_lion_finger_of_death_awaken_SummaryDescription"	"Finger deals missing-health damage, growth reduces its cooldown, Alternative Cast automatically executes heroes, and melee demon attacks carry Finger damage."
+		"DOTA_Tooltip_modifier_special_bonus_unique_lion_finger_of_death_awaken"			"<font color='#d000ff'>Cycle of Death Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lion_finger_of_death_awaken_Description"	"Missing-health bonus damage: <font color='#FFFFFF'><b>25%%</b></font>\nCurrent cooldown reduction per growth: <font color='#FFFFFF'><b>10s</b></font>\nDemon-form attack bonus from Finger damage: <font color='#FFFFFF'><b>50%%</b></font>\n<font color='#00CED1'>Alternative Cast:</font> Only automatically targets real enemy heroes, ignoring Linken's Sphere, Lotus Orb, and spell reflection."
+
 	}
 }

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -617,5 +617,12 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>Ускорение · Пробуждение</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"Когда юнит погибает в радиусе <font color='#FFFFFF'><b>900</b></font> от Abaddon, текущее время перезарядки всех его способностей и предметов сокращается. Смерть не-героя сокращает его на <font color='#FFFFFF'><b>0.2</b></font> сек., а смерть героя — на <font color='#FFFFFF'><b>3</b></font> сек."
 
+		// 莱恩 死亡一指觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_lion_finger_of_death_awaken"				"<font color='#d000ff'>Цикл смерти · Пробуждение</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_lion_finger_of_death_awaken_Description"	"Дополнительный урон от потерянного здоровья: <font color='#FFFFFF'><b>%missing_health_damage_pct%</b></font><font color='#FFFFFF'><b>%%</b></font>\nСокращение текущей перезарядки за рост: <font color='#FFFFFF'><b>%cooldown_reduction_per_growth% сек.</b></font>\nДополнительный урон атак в форме демона от Finger: <font color='#FFFFFF'><b>%melee_finger_damage_pct%</b></font><font color='#FFFFFF'><b>%%</b></font>\n<font color='#00CED1'>Альтернативное применение:</font> автоматически выбирает только настоящих вражеских героев, игнорируя Linken's Sphere, Lotus Orb и отражение заклинаний."
+		"DOTA_Tooltip_ability_special_bonus_unique_lion_finger_of_death_awaken_SummaryDescription"	"Finger наносит урон от потерянного здоровья, рост сокращает перезарядку, альтернативное применение автоматически добивает героев, а атаки демона наносят урон Finger."
+		"DOTA_Tooltip_modifier_special_bonus_unique_lion_finger_of_death_awaken"			"<font color='#d000ff'>Цикл смерти · Пробуждение</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lion_finger_of_death_awaken_Description"	"Дополнительный урон от потерянного здоровья: <font color='#FFFFFF'><b>25%%</b></font>\nСокращение текущей перезарядки за рост: <font color='#FFFFFF'><b>10 сек.</b></font>\nДополнительный урон атак в форме демона от Finger: <font color='#FFFFFF'><b>50%%</b></font>\n<font color='#00CED1'>Альтернативное применение:</font> автоматически выбирает только настоящих вражеских героев, игнорируя Linken's Sphere, Lotus Orb и отражение заклинаний."
+
 	}
 }

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3505,5 +3505,12 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>畅快淋漓 觉醒</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"附近 <font color='#FFFFFF'><b>900</b></font> 范围内有单位阵亡时，亚巴顿所有技能和物品的当前冷却都会减少。非英雄单位阵亡减少 <font color='#FFFFFF'><b>0.2</b></font> 秒，英雄阵亡减少 <font color='#FFFFFF'><b>3</b></font> 秒。"
 
+		// 莱恩 死亡一指觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_lion_finger_of_death_awaken"				"<font color='#d000ff'>死亡循环 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_lion_finger_of_death_awaken_Description"	"已损失生命额外伤害：<font color='#FFFFFF'><b>%missing_health_damage_pct%</b></font><font color='#FFFFFF'><b>%%</b></font>\n每次成长减少当前冷却：<font color='#FFFFFF'><b>%cooldown_reduction_per_growth%秒</b></font>\n恶魔形态普攻附带大招伤害：<font color='#FFFFFF'><b>%melee_finger_damage_pct%</b></font><font color='#FFFFFF'><b>%%</b></font>\n<font color='#00CED1'>多样施法：</font>只自动对敌方真实英雄释放，无视林肯、莲花和技能反弹。"
+		"DOTA_Tooltip_ability_special_bonus_unique_lion_finger_of_death_awaken_SummaryDescription"	"死亡一指根据目标已损失生命追加伤害，合规成长减少当前冷却，多样施法自动处决英雄，近战恶魔形态普攻附带死亡一指伤害。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lion_finger_of_death_awaken"			"<font color='#d000ff'>死亡循环 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lion_finger_of_death_awaken_Description"	"已损失生命额外伤害：<font color='#FFFFFF'><b>25%%</b></font>\n每次成长减少当前冷却：<font color='#FFFFFF'><b>10秒</b></font>\n恶魔形态普攻附带大招伤害：<font color='#FFFFFF'><b>50%%</b></font>\n<font color='#00CED1'>多样施法：</font>只自动对敌方真实英雄释放，无视林肯、莲花和技能反弹。"
+
 	}
 }

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -1,6 +1,28 @@
 "DOTAAbilities"
 {
 	//=================================================================================================================
+	// 莱恩 觉醒
+	"special_bonus_unique_lion_finger_of_death_awaken"
+	{
+		"BaseClass"					"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/special_bonus_unique_lion_finger_of_death_awaken"
+		"AbilityBehavior"			"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE"
+		"AbilityTextureName"		"lion_finger_of_death"
+		"IsOnCastBar"				"1"
+		"MaxLevel"					"1"
+
+		"AbilityValues"
+		{
+			"missing_health_damage_pct"
+			{
+				"value"					"25"
+			}
+			"cooldown_reduction_per_growth"	"10"
+			"melee_finger_damage_pct"		"50"
+		}
+	}
+
+	//=================================================================================================================
 	// 觉醒技能
 	// 英雄专属强化/替换技能，通过抽奖池获得
 	//=================================================================================================================

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,11 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_lion',
+    abilityName: 'special_bonus_unique_lion_finger_of_death_awaken',
+    freeTrial: true,
+  },
+  {
     heroName: 'npc_dota_hero_abaddon',
     abilityName: 'special_bonus_unique_abaddon_quickening_awaken',
     freeTrial: true,

--- a/src/vscripts/abilities/ts_abilities/lion-finger-of-death-awaken-math.test.ts
+++ b/src/vscripts/abilities/ts_abilities/lion-finger-of-death-awaken-math.test.ts
@@ -1,0 +1,77 @@
+import {
+  calculateCurrentFingerDamage,
+  calculateFingerMeleeBonusDamage,
+  calculateMissingHealthBonusDamage,
+  calculateObservedGrowthDelta,
+  initializeObservedGrowthStacks,
+  reduceRemainingCooldown,
+  settlePendingGrowthCooldown,
+} from './lion-finger-of-death-awaken-math';
+
+describe('Lion Finger of Death awaken math', () => {
+  test('includes permanent Finger growth in the current Finger damage', () => {
+    expect(calculateCurrentFingerDamage(1400, 12, 50)).toBe(2000);
+  });
+
+  test('converts the current Finger damage into melee-form bonus damage', () => {
+    expect(calculateFingerMeleeBonusDamage(1400, 50)).toBe(700);
+    expect(calculateFingerMeleeBonusDamage(1400, 0)).toBe(0);
+  });
+
+  test('deals a percentage of health missing in the pre-hit snapshot', () => {
+    expect(calculateMissingHealthBonusDamage(300, 1000, 25)).toBe(175);
+  });
+
+  test('is independent of lethal or overflowing trigger damage because it only uses the snapshot', () => {
+    expect(calculateMissingHealthBonusDamage(300, 1000, 25)).toBe(175);
+    expect(calculateMissingHealthBonusDamage(0, 1000, 25)).toBe(250);
+  });
+
+  test('establishes a baseline without settling historical growth and only returns positive deltas', () => {
+    expect(calculateObservedGrowthDelta(undefined, 12)).toEqual({ nextStackCount: 12, delta: 0 });
+    expect(calculateObservedGrowthDelta(12, 15)).toEqual({ nextStackCount: 15, delta: 3 });
+    expect(calculateObservedGrowthDelta(15, 2)).toEqual({ nextStackCount: 2, delta: 0 });
+  });
+
+  test('starts at zero before the counter exists so the first growth is settled', () => {
+    const initialStacks = initializeObservedGrowthStacks(undefined);
+    expect(calculateObservedGrowthDelta(initialStacks, 1)).toEqual({
+      nextStackCount: 1,
+      delta: 1,
+    });
+  });
+
+  test('uses existing historical growth as the initialization baseline', () => {
+    const initialStacks = initializeObservedGrowthStacks(12);
+    expect(calculateObservedGrowthDelta(initialStacks, 12)).toEqual({
+      nextStackCount: 12,
+      delta: 0,
+    });
+  });
+
+  test('reduces remaining cooldown per growth without going below zero', () => {
+    expect(reduceRemainingCooldown(38, 2, 10)).toBe(18);
+    expect(reduceRemainingCooldown(7, 1, 10)).toBe(0);
+  });
+
+  test('keeps pending growth while Finger is temporarily unavailable', () => {
+    expect(settlePendingGrowthCooldown(2, undefined, 10)).toEqual({
+      pendingGrowthDelta: 2,
+      nextRemainingCooldown: undefined,
+    });
+  });
+
+  test('consumes pending growth when Finger exists without a current cooldown', () => {
+    expect(settlePendingGrowthCooldown(2, 0, 10)).toEqual({
+      pendingGrowthDelta: 0,
+      nextRemainingCooldown: 0,
+    });
+  });
+
+  test('applies and consumes pending growth when Finger is cooling down', () => {
+    expect(settlePendingGrowthCooldown(2, 38, 10)).toEqual({
+      pendingGrowthDelta: 0,
+      nextRemainingCooldown: 18,
+    });
+  });
+});

--- a/src/vscripts/abilities/ts_abilities/lion-finger-of-death-awaken-math.ts
+++ b/src/vscripts/abilities/ts_abilities/lion-finger-of-death-awaken-math.ts
@@ -1,0 +1,77 @@
+export function calculateMissingHealthBonusDamage(
+  preHitHealth: number,
+  maxHealth: number,
+  missingHealthDamagePct: number,
+): number {
+  const missingHealth = Math.max(0, maxHealth - preHitHealth);
+  return (missingHealth * missingHealthDamagePct) / 100;
+}
+
+export function calculateFingerMeleeBonusDamage(
+  fingerDamage: number,
+  meleeDamagePct: number,
+): number {
+  return (Math.max(0, fingerDamage) * Math.max(0, meleeDamagePct)) / 100;
+}
+
+export function calculateCurrentFingerDamage(
+  baseDamage: number,
+  growthStacks: number,
+  damagePerGrowth: number,
+): number {
+  return Math.max(0, baseDamage) + Math.max(0, growthStacks) * Math.max(0, damagePerGrowth);
+}
+
+export interface ObservedGrowthDelta {
+  nextStackCount: number;
+  delta: number;
+}
+
+export function initializeObservedGrowthStacks(currentStackCount: number | undefined): number {
+  return currentStackCount ?? 0;
+}
+
+export function calculateObservedGrowthDelta(
+  previousStackCount: number | undefined,
+  currentStackCount: number,
+): ObservedGrowthDelta {
+  return {
+    nextStackCount: currentStackCount,
+    delta:
+      previousStackCount === undefined || currentStackCount <= previousStackCount
+        ? 0
+        : currentStackCount - previousStackCount,
+  };
+}
+
+export function reduceRemainingCooldown(
+  currentRemainingCooldown: number,
+  growthDelta: number,
+  cooldownReductionPerGrowth: number,
+): number {
+  return Math.max(0, currentRemainingCooldown - growthDelta * cooldownReductionPerGrowth);
+}
+
+export interface PendingGrowthCooldownSettlement {
+  pendingGrowthDelta: number;
+  nextRemainingCooldown: number | undefined;
+}
+
+export function settlePendingGrowthCooldown(
+  pendingGrowthDelta: number,
+  currentRemainingCooldown: number | undefined,
+  cooldownReductionPerGrowth: number,
+): PendingGrowthCooldownSettlement {
+  if (currentRemainingCooldown === undefined) {
+    return { pendingGrowthDelta, nextRemainingCooldown: undefined };
+  }
+
+  return {
+    pendingGrowthDelta: 0,
+    nextRemainingCooldown: reduceRemainingCooldown(
+      currentRemainingCooldown,
+      pendingGrowthDelta,
+      cooldownReductionPerGrowth,
+    ),
+  };
+}

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_lion_finger_of_death_awaken.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_lion_finger_of_death_awaken.ts
@@ -1,0 +1,325 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+import {
+  calculateCurrentFingerDamage,
+  calculateFingerMeleeBonusDamage,
+  calculateMissingHealthBonusDamage,
+  calculateObservedGrowthDelta,
+  initializeObservedGrowthStacks,
+  settlePendingGrowthCooldown,
+} from './lion-finger-of-death-awaken-math';
+import { HeroUtil } from '../../ai/hero/hero-util';
+import { findEnemiesInRange, getFullCastRange } from './shared/auto-cast-ability';
+
+const FINGER_OF_DEATH_ABILITY = 'lion_finger_of_death';
+const FINGER_GROWTH_MODIFIER = 'modifier_lion_finger_of_death_kill_counter';
+const FINGER_DELAY_MODIFIER = 'modifier_lion_finger_of_death_delay';
+const FINGER_MELEE_MODIFIER = 'modifier_lion_finger_punch';
+const GROWTH_POLL_INTERVAL = 0.1;
+const AUTO_CAST_INTERVAL = 0.3;
+const MAX_SPELL_ABSORB_LAYERS = 16;
+const AWAKEN_ICON = 'lion_finger_of_death';
+
+interface FingerTargetSnapshot {
+  health: number;
+  maxHealth: number;
+}
+
+interface FingerCastSnapshots {
+  id: number;
+  remainingTargets: number;
+  targets: Record<number, FingerTargetSnapshot | undefined>;
+}
+
+@registerAbility('special_bonus_unique_lion_finger_of_death_awaken')
+export class SpecialBonusUniqueLionFingerOfDeathAwaken extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return modifier_special_bonus_unique_lion_finger_of_death_awaken.name;
+  }
+}
+
+/** 观察死亡一指的成长与延迟标记，为觉醒伤害、冷却反馈和近战附伤提供状态。 */
+@registerModifier('abilities/ts_abilities/special_bonus_unique_lion_finger_of_death_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_lion_finger_of_death_awaken extends BaseModifier {
+  private observedGrowthStacks?: number;
+  private pendingGrowthDelta = 0;
+  private applyingAwakenDamage = false;
+  private castSnapshots: FingerCastSnapshots[] = [];
+  private nextSnapshotId = 0;
+  private nextAutoCastTime = 0;
+  private lastFingerDamage = 0;
+
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  IsBuff(): boolean {
+    return true;
+  }
+
+  GetTexture(): string {
+    return AWAKEN_ICON;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [
+      ModifierFunction.ON_ABILITY_FULLY_CAST,
+      ModifierFunction.ON_ATTACK_LANDED,
+      ModifierFunction.ON_TAKEDAMAGE,
+    ];
+  }
+
+  OnAbilityFullyCast(event: ModifierAbilityEvent): void {
+    if (!IsServer()) return;
+
+    const parent = this.GetParent();
+    if (event.unit !== parent || event.ability.GetAbilityName() !== FINGER_OF_DEATH_ABILITY) return;
+
+    this.updateFingerDamage(event.ability);
+    this.scheduleFingerTargetSnapshots();
+  }
+
+  OnAttackLanded(event: ModifierAttackEvent): void {
+    if (!IsServer()) return;
+
+    const parent = this.GetParent();
+    const target = event.target;
+    if (
+      event.attacker !== parent ||
+      event.no_attack_cooldown ||
+      !parent.IsRealHero() ||
+      parent.IsIllusion() ||
+      parent.PassivesDisabled() ||
+      !parent.HasModifier(FINGER_MELEE_MODIFIER) ||
+      !target ||
+      target.IsNull() ||
+      !target.IsAlive() ||
+      target.GetTeamNumber() === parent.GetTeamNumber() ||
+      target.IsBuilding() ||
+      target.IsOther()
+    ) {
+      return;
+    }
+
+    const awaken = this.GetAbility();
+    if (!awaken || awaken.IsNull()) return;
+
+    const finger = parent.FindAbilityByName(FINGER_OF_DEATH_ABILITY);
+    if (finger && !finger.IsNull()) this.updateFingerDamage(finger);
+
+    const bonusDamage = calculateFingerMeleeBonusDamage(
+      this.lastFingerDamage,
+      awaken.GetSpecialValueFor('melee_finger_damage_pct'),
+    );
+    if (bonusDamage <= 0) return;
+
+    this.applyingAwakenDamage = true;
+    try {
+      ApplyDamage({
+        victim: target,
+        attacker: parent,
+        damage: bonusDamage,
+        damage_type: DamageTypes.MAGICAL,
+        ability: awaken,
+      });
+    } finally {
+      this.applyingAwakenDamage = false;
+    }
+  }
+
+  private scheduleFingerTargetSnapshots(): void {
+    const parent = this.GetParent();
+    const cast: FingerCastSnapshots = {
+      id: ++this.nextSnapshotId,
+      remainingTargets: 0,
+      targets: {},
+    };
+    // The native delay marker is applied by Finger's own cast path. Scan on the next frame so
+    // the engine can finish attaching every Scepter target marker before its delayed damage.
+    Timers.CreateTimer(0, () => {
+      if (this.IsNull()) return;
+
+      for (const hero of HeroList.GetAllHeroes()) {
+        if (hero.IsNull()) continue;
+        if (hero.GetTeamNumber() === parent.GetTeamNumber()) continue;
+        if (!hero.IsRealHero() || hero.IsIllusion()) continue;
+        if (!hero.FindModifierByNameAndCaster(FINGER_DELAY_MODIFIER, parent)) continue;
+
+        cast.targets[hero.GetEntityIndex()] = {
+          health: hero.GetHealth(),
+          maxHealth: hero.GetMaxHealth(),
+        };
+        cast.remainingTargets += 1;
+      }
+
+      if (cast.remainingTargets <= 0) return;
+      this.castSnapshots.push(cast);
+      // Native Finger resolves shortly after applying its delay marker. Expire an unmatched
+      // batch defensively so immunity or an interrupted native path cannot retain stale data.
+      Timers.CreateTimer(3, () => this.removeCastSnapshots(cast.id));
+    });
+  }
+
+  private updateFingerDamage(finger: CDOTABaseAbility): void {
+    const growth = this.GetParent().FindModifierByName(FINGER_GROWTH_MODIFIER);
+    this.lastFingerDamage = calculateCurrentFingerDamage(
+      finger.GetSpecialValueFor('damage'),
+      growth ? growth.GetStackCount() : 0,
+      finger.GetSpecialValueFor('damage_per_kill'),
+    );
+  }
+
+  private removeCastSnapshots(id: number): void {
+    const index = this.castSnapshots.findIndex((cast) => cast.id === id);
+    if (index >= 0) this.castSnapshots.splice(index, 1);
+  }
+
+  OnCreated(): void {
+    if (!IsServer()) return;
+
+    const growth = this.GetParent().FindModifierByName(FINGER_GROWTH_MODIFIER);
+    this.observedGrowthStacks = initializeObservedGrowthStacks(
+      growth ? growth.GetStackCount() : undefined,
+    );
+    this.StartIntervalThink(GROWTH_POLL_INTERVAL);
+  }
+
+  OnTakeDamage(event: ModifierInstanceEvent): void {
+    if (!IsServer() || this.applyingAwakenDamage) return;
+
+    const parent = this.GetParent();
+    const inflictor = event.inflictor;
+    if (event.attacker !== parent || !inflictor) return;
+    if (inflictor.GetAbilityName() !== FINGER_OF_DEATH_ABILITY) return;
+
+    const target = event.unit;
+    if (!target || target.IsNull()) return;
+    if (target.GetTeamNumber() === parent.GetTeamNumber()) return;
+
+    const targetIndex = target.GetEntityIndex();
+    const cast = this.castSnapshots.find((entry) => entry.targets[targetIndex] !== undefined);
+    const snapshot = cast?.targets[targetIndex];
+    if (!cast || !snapshot) return;
+    cast.targets[targetIndex] = undefined;
+    cast.remainingTargets -= 1;
+    if (cast.remainingTargets <= 0) this.removeCastSnapshots(cast.id);
+
+    const ability = this.GetAbility();
+    if (!ability || ability.IsNull()) return;
+
+    const bonusDamage = calculateMissingHealthBonusDamage(
+      snapshot.health,
+      snapshot.maxHealth,
+      ability.GetSpecialValueFor('missing_health_damage_pct'),
+    );
+    if (bonusDamage <= 0) return;
+
+    this.applyingAwakenDamage = true;
+    try {
+      ApplyDamage({
+        victim: target,
+        attacker: parent,
+        damage: bonusDamage,
+        damage_type: DamageTypes.MAGICAL,
+        ability: inflictor,
+      });
+    } finally {
+      this.applyingAwakenDamage = false;
+    }
+  }
+
+  OnIntervalThink(): void {
+    if (!IsServer()) return;
+
+    const parent = this.GetParent();
+    this.tryAutoCastFinger(parent);
+    const growth = parent.FindModifierByName(FINGER_GROWTH_MODIFIER);
+    if (!growth) return;
+
+    const currentStacks = growth.GetStackCount();
+    const observation = calculateObservedGrowthDelta(this.observedGrowthStacks, currentStacks);
+    this.observedGrowthStacks = observation.nextStackCount;
+    this.pendingGrowthDelta += observation.delta;
+    if (this.pendingGrowthDelta <= 0) return;
+
+    const finger = parent.FindAbilityByName(FINGER_OF_DEATH_ABILITY);
+    const awaken = this.GetAbility();
+    if (!finger || !awaken || awaken.IsNull()) return;
+    this.updateFingerDamage(finger);
+
+    const currentRemaining = finger.GetCooldownTimeRemaining();
+    const settlement = settlePendingGrowthCooldown(
+      this.pendingGrowthDelta,
+      currentRemaining,
+      awaken.GetSpecialValueFor('cooldown_reduction_per_growth'),
+    );
+    this.pendingGrowthDelta = settlement.pendingGrowthDelta;
+    const reducedRemaining = settlement.nextRemainingCooldown;
+    if (currentRemaining <= 0 || reducedRemaining === undefined) return;
+
+    finger.EndCooldown();
+    if (reducedRemaining > 0) finger.StartCooldown(reducedRemaining);
+  }
+
+  private tryAutoCastFinger(parent: CDOTA_BaseNPC): void {
+    const now = GameRules.GetGameTime();
+    if (now < this.nextAutoCastTime) return;
+    this.nextAutoCastTime = now + AUTO_CAST_INTERVAL;
+
+    const awaken = this.GetAbility();
+    if (!awaken || awaken.IsNull()) return;
+    if (HeroUtil.NotActionable(parent) || parent.IsSilenced() || parent.IsChanneling()) return;
+
+    const finger = parent.FindAbilityByName(FINGER_OF_DEATH_ABILITY);
+    if (
+      !finger ||
+      finger.IsNull() ||
+      finger.IsHidden() ||
+      !finger.IsActivated() ||
+      !finger.IsFullyCastable()
+    ) {
+      return;
+    }
+
+    const enemies = findEnemiesInRange(
+      parent,
+      getFullCastRange(parent, finger),
+      UnitTargetType.HERO,
+      UnitTargetFlags.NOT_ILLUSIONS,
+    );
+    let target: CDOTA_BaseNPC | undefined;
+    for (const enemy of enemies) {
+      if (!enemy.IsRealHero() || enemy.IsIllusion()) continue;
+      if (!target || enemy.GetHealth() < target.GetHealth()) target = enemy;
+    }
+    if (!target) return;
+
+    for (let layer = 0; layer < MAX_SPELL_ABSORB_LAYERS; layer++) {
+      if (!target.TriggerSpellAbsorb(finger)) break;
+    }
+
+    const previousTarget = parent.GetCursorCastTarget();
+    try {
+      parent.SetCursorCastTarget(target);
+      this.updateFingerDamage(finger);
+      finger.UseResources(true, false, false, true);
+      finger.OnSpellStart();
+      this.scheduleFingerTargetSnapshots();
+    } finally {
+      parent.SetCursorCastTarget(previousTarget);
+    }
+  }
+}

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,12 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 莱恩 觉醒
+  {
+    heroName: 'npc_dota_hero_lion',
+    newAbility: 'special_bonus_unique_lion_finger_of_death_awaken',
+    newLevel: 1,
+  },
   // 亚巴顿 觉醒
   {
     heroName: 'npc_dota_hero_abaddon',
@@ -245,6 +251,7 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  * 新觉醒发布时加入，下次发版由 awaken-ability skill 流程确认移出。
  */
 export const FREE_TRIAL_HEROES: string[] = [
+  'npc_dota_hero_lion', // 莱恩
   'npc_dota_hero_abaddon', // 亚巴顿
   'npc_dota_hero_skywrath_mage', // 天怒法师
   'npc_dota_hero_dazzle', // 戴泽


### PR DESCRIPTION
## Issue

No linked issue.

## Summary

- Adds Lion's Cycle of Death awakening without replacing the native Finger of Death ability.
- Deals bonus magical damage from the target's pre-impact missing-health snapshot.
- Reduces Finger of Death's current cooldown whenever the native kill counter grows.
- Automatically casts Finger of Death only on visible real enemy heroes and bypasses spell block/reflection order handling.
- Adds bonus magical Finger damage to attacks during the native melee demon form.
- Adds the awakening page entry, visible ability/modifier state, KV values, and Chinese, English, and Russian tooltips.

## Validation

- `npm run build:vscripts`
- `npm run build:panorama`
- `npm run lint`
- `npm test -- --runInBand src/vscripts/abilities/ts_abilities/lion-finger-of-death-awaken-math.test.ts src/vscripts/modules/awaken/awaken-replacer.test.ts` (27 tests)
- KV/tab, localization placeholder/HTML, and `git diff --check`
- Dota Tools: correct addon and shared local player data; user confirmed the final Chinese tooltip and melee-form bonus damage flow.


## Release Note

```
[b]游戏性更新 v5.49f[/b]

- 新增莱恩觉醒「死亡循环」：死亡一指根据目标已损失生命追加伤害，击杀成长减少当前冷却并自动锁定英雄施放，近战恶魔形态普攻附带死亡一指伤害。
```

```
[b]Gameplay update v5.49f[/b]

- Added Lion awakening Cycle of Death: Finger of Death deals bonus missing-health damage, kill growth reduces its current cooldown and automatically targets heroes, and melee demon-form attacks carry Finger damage.
```
