### PR TITLE
Add Magnataur Reverse Polarity awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1258,6 +1258,25 @@
 		///////////////////////////////////////////////////
 // 					Awaken Abilities 觉醒技能
 
+		// 马格纳斯 两极反转-觉醒
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened"						"<font color='#d000ff'>Reverse Polarity Awakened</font>"
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_Description"			"Magnus changes the properties of matter, pulling nearby enemies in front of him, dealing <font color='#FFE56E'>pure damage</font> and stunning them.<br><br>After casting, <font color='#d000ff'>Reverse Reverse Polarity</font> can be cast within %recast_window% seconds. This ability begins its cooldown when the recast is used or the window expires."
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_SummaryDescription"	"Pulls nearby enemies in front of Magnus, dealing pure damage and stunning them, then enables a brief recast."
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_pull_radius"			"RADIUS:"
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_polarity_damage"		"PURE DAMAGE:"
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_hero_stun_duration"	"HERO STUN DURATION:"
+
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened"						"<font color='#d000ff'>Reverse Reverse Polarity</font>"
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_Description"			"Radially pushes enemies away from Magnus, dealing <font color='#FFE56E'>pure damage</font> and stunning them. An enemy that collides with terrain, a tree, a building, or another unit that is not being pushed stops moving and takes the damage and stun again. Each enemy can trigger the collision effect once."
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_SummaryDescription"	"Radially pushes nearby enemies away, dealing damage and stunning them again on collision."
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_push_radius"		"RADIUS:"
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_push_distance"	"MAX PUSH DISTANCE:"
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_push_duration"	"PUSH DURATION:"
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_polarity_damage"	"PURE DAMAGE:"
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_hero_stun_duration"	"HERO STUN DURATION:"
+		"DOTA_Tooltip_modifier_magnataur_reverse_reverse_polarity_window"						"<font color='#d000ff'>Reverse Reverse Polarity</font>"
+		"DOTA_Tooltip_modifier_magnataur_reverse_reverse_polarity_window_Description"			"Reverse Polarity can be recast to radially push nearby enemies. Reverse Polarity begins its cooldown when this window ends."
+
 		// 炸弹人 觉醒
 		"DOTA_Tooltip_ability_techies_squees_scope"					"<font color='#d000ff'>Squee's Scope Awakened</font>"
 		"DOTA_Tooltip_ability_techies_squees_scope_Description"		"Techies gains %attack_range_tooltip% attack range and attack projectile speed for each point of attack speed."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -145,6 +145,25 @@
 		"DOTA_Tooltip_ability_item_sacred_six_vein_manacost_reduction"					"%+Снижение затрат и потери маны"
 		"DOTA_Tooltip_ability_item_sacred_six_vein_cast_speed_pct"						"%+Скорость применения"
 
+		// 马格纳斯 两极反转-觉醒
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened"						"<font color='#d000ff'>Обратная полярность: пробуждение</font>"
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_Description"			"Magnus изменяет свойства материи, притягивая ближайших врагов перед собой, оглушая их и нанося <font color='#FFE56E'>чистый урон</font>.<br><br>После применения в течение %recast_window% сек. можно применить <font color='#d000ff'>Дважды обратную полярность</font>. Перезарядка начинается после повторного применения или окончания окна."
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_SummaryDescription"	"Притягивает ближайших врагов, наносит чистый урон и оглушает, затем ненадолго позволяет применить способность повторно."
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_pull_radius"			"РАДИУС:"
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_polarity_damage"		"ЧИСТЫЙ УРОН:"
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_hero_stun_duration"	"ОГЛУШЕНИЕ ГЕРОЕВ:"
+
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened"						"<font color='#d000ff'>Дважды обратная полярность</font>"
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_Description"			"Радиально отталкивает врагов от Magnus, нанося <font color='#FFE56E'>чистый урон</font> и оглушая их. Столкнувшись с рельефом, деревом, строением или другим неотталкиваемым существом, враг останавливается и повторно получает тот же урон и оглушение. Каждый враг вызывает эффект столкновения один раз."
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_SummaryDescription"	"Радиально отталкивает врагов, повторно нанося урон и оглушая их при столкновении."
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_push_radius"		"РАДИУС:"
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_push_distance"	"МАКС. ДАЛЬНОСТЬ ТОЛЧКА:"
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_push_duration"	"ДЛИТЕЛЬНОСТЬ ТОЛЧКА:"
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_polarity_damage"	"ЧИСТЫЙ УРОН:"
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_hero_stun_duration"	"ОГЛУШЕНИЕ ГЕРОЕВ:"
+		"DOTA_Tooltip_modifier_magnataur_reverse_reverse_polarity_window"						"<font color='#d000ff'>Дважды обратная полярность</font>"
+		"DOTA_Tooltip_modifier_magnataur_reverse_reverse_polarity_window_Description"			"Обратную полярность можно применить повторно, чтобы радиально оттолкнуть ближайших врагов. После окончания окна начинается перезарядка."
+
 		// Elder Titan Astral Spirit - Awakened
 		"DOTA_Tooltip_ability_elder_titan_ancestral_spirit_awaken"						"<font color='#d000ff'>Астральный дух: пробуждение</font>"
 		"DOTA_Tooltip_ability_elder_titan_ancestral_spirit_awaken_SummaryDescription"		"Автоприменение: автоматически посылает духа к самому дальнему вражескому герою и автоматически возвращает его."

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1253,6 +1253,25 @@
 		///////////////////////////////////////////////////
 // 					Awaken Abilities 觉醒技能
 
+		// 马格纳斯 两极反转-觉醒
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened"						"<font color='#d000ff'>两极反转 觉醒</font>"
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_Description"			"马格纳斯改变物质的属性，将附近的敌人牵引至自己前方，造成<font color='#FFE56E'>纯粹伤害</font>并眩晕。<br><br>释放后可在%recast_window%秒内再次施放<font color='#d000ff'>两极反转·再反转</font>。二段释放或窗口过期后，本技能进入冷却。"
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_SummaryDescription"	"将附近敌人牵引至前方，造成纯粹伤害并眩晕，随后可在短时间内再次施放。"
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_pull_radius"			"作用范围："
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_polarity_damage"		"纯粹伤害："
+		"DOTA_Tooltip_ability_magnataur_reverse_polarity_awakened_hero_stun_duration"	"英雄眩晕时间："
+
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened"						"<font color='#d000ff'>两极反转·再反转</font>"
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_Description"			"以马格纳斯为中心，将范围内的敌人径向推出，造成<font color='#FFE56E'>纯粹伤害</font>并眩晕。被推动的敌人撞上地形、树木、建筑或未被推动的其他单位时停止移动，并再次受到该伤害和眩晕。每个敌人只会触发一次碰撞效果。"
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_SummaryDescription"	"将周围敌人径向推出，碰撞障碍时再次造成伤害和眩晕。"
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_push_radius"		"作用范围："
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_push_distance"	"最远推出距离："
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_push_duration"	"推动时间："
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_polarity_damage"	"纯粹伤害："
+		"DOTA_Tooltip_ability_magnataur_reverse_reverse_polarity_awakened_hero_stun_duration"	"英雄眩晕时间："
+		"DOTA_Tooltip_modifier_magnataur_reverse_reverse_polarity_window"						"<font color='#d000ff'>两极反转·再反转</font>"
+		"DOTA_Tooltip_modifier_magnataur_reverse_reverse_polarity_window_Description"			"可再次施放两极反转，将周围敌人径向推出。窗口结束后，两极反转进入冷却。"
+
 		// 炸弹人 觉醒
 		"DOTA_Tooltip_ability_techies_squees_scope"					"<font color='#d000ff'>斯奎的瞄准镜 觉醒</font>"
 		"DOTA_Tooltip_ability_techies_squees_scope_Description"		"每点攻击速度都会让工程师获得%attack_range_tooltip%攻击距离和攻击弹道速度。"

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -5,6 +5,78 @@
 	// 英雄专属强化/替换技能，通过抽奖池获得
 	//=================================================================================================================
 
+	// 马格纳斯 觉醒
+	"magnataur_reverse_polarity_awakened"
+	{
+		"BaseClass"						"magnataur_reverse_polarity"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityType"					"ABILITY_TYPE_ULTIMATE"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"			"magnataur_reverse_polarity"
+		"RequiredLevel"					"6"
+		"LevelsBetweenUpgrades"			"6"
+		"AbilityCastPoint"				"0.3"
+		"AbilityManaCost"				"150 225 300 375"
+		"MaxLevel"						"4"
+
+		"AbilityValues"
+		{
+			"pull_radius"
+			{
+				"value"						"430"
+				"affected_by_aoe_increase"	"1"
+			}
+			"pull_offset"					"150"
+			"AbilityCooldown"
+			{
+				"value"						"90"
+			}
+			"polarity_damage"
+			{
+				"value"						"100 200 300 400"
+				"CalculateSpellDamageTooltip"	"1"
+			}
+			"hero_stun_duration"
+			{
+				"value"						"2.5 3.0 3.5 4.0"
+			}
+			"recast_window"				"3"
+		}
+	}
+
+	"magnataur_reverse_reverse_polarity_awakened"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/magnataur_reverse_reverse_polarity_awakened"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_PURE"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityTextureName"			"magnataur_reversed_reverse_polarity"
+		"AbilityCastPoint"				"0"
+		"AbilityCooldown"				"0"
+		"AbilityManaCost"				"0"
+		"MaxLevel"						"4"
+
+		"AbilityValues"
+		{
+			"recast_window"				"3"
+			"push_radius"
+			{
+				"value"						"600"
+				"affected_by_aoe_increase"	"1"
+			}
+			"push_distance"				"700"
+			"push_duration"				"0.2"
+			"collision_radius"			"72"
+			"polarity_damage"
+			{
+				"value"						"100 200 300 400"
+				"CalculateSpellDamageTooltip"	"1"
+			}
+			"hero_stun_duration"		"2.5 3.0 3.5 4.0"
+		}
+	}
+
 	// 亚巴顿 觉醒
 	"special_bonus_unique_abaddon_quickening_awaken"
 	{

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,11 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_magnataur',
+    abilityName: 'magnataur_reverse_polarity_awakened',
+    freeTrial: true,
+  },
+  {
     heroName: 'npc_dota_hero_abaddon',
     abilityName: 'special_bonus_unique_abaddon_quickening_awaken',
     freeTrial: true,

--- a/src/vscripts/abilities/ts_abilities/magnataur-reverse-reverse-polarity-logic.test.ts
+++ b/src/vscripts/abilities/ts_abilities/magnataur-reverse-reverse-polarity-logic.test.ts
@@ -1,0 +1,64 @@
+import {
+  finishRecastWindow,
+  getRadialDestination,
+  isTerrainCollision,
+  registerCollision,
+  shouldRestoreDelayedCooldown,
+  startRecastWindow,
+} from './magnataur-reverse-reverse-polarity-logic';
+
+describe('magnataur reverse reverse polarity helpers', () => {
+  it('将目标沿猛犸到目标的方向推至最大距离', () => {
+    expect(getRadialDestination({ x: 100, y: 200 }, { x: 400, y: 600 }, 700)).toEqual({
+      x: 520,
+      y: 760,
+    });
+  });
+
+  it('目标与猛犸重合时使用猛犸朝向作为径向方向', () => {
+    expect(
+      getRadialDestination({ x: 100, y: 200 }, { x: 100, y: 200 }, 700, { x: 0, y: 1 }),
+    ).toEqual({ x: 100, y: 900 });
+  });
+
+  it('一段开启二段窗口时暂不进入冷却', () => {
+    expect(startRecastWindow()).toEqual({ phase: 'recast', cooldownStarted: false });
+  });
+
+  it.each(['cast', 'expired', 'death'] as const)('%s 结束二段窗口并启动冷却', (reason) => {
+    expect(finishRecastWindow(startRecastWindow(), reason)).toEqual({
+      phase: 'cooldown',
+      cooldownStarted: true,
+      reason,
+    });
+  });
+
+  it('二段窗口内未刷新时，在窗口结束后补回完整冷却', () => {
+    expect(shouldRestoreDelayedCooldown(99)).toBe(true);
+  });
+
+  it('二段窗口内已刷新时，在窗口结束后保持一段可用', () => {
+    expect(shouldRestoreDelayedCooldown(0)).toBe(false);
+  });
+
+  it('同一目标只接受一次碰撞二次结算', () => {
+    const first = registerCollision(false);
+    const second = registerCollision(first.collided);
+
+    expect(first).toEqual({ collided: true, shouldSettle: true });
+    expect(second).toEqual({ collided: true, shouldSettle: false });
+  });
+
+  it.each([
+    [false, false, false, 0],
+    [true, true, false, 0],
+    [true, false, true, 0],
+    [true, false, false, 48],
+  ])('不可通行、阻挡、树木或明显高差都属于地形碰撞', (traversable, blocked, tree, dz) => {
+    expect(isTerrainCollision(traversable, blocked, tree, dz, 32)).toBe(true);
+  });
+
+  it('平坦且可通行的位置不属于地形碰撞', () => {
+    expect(isTerrainCollision(true, false, false, 12, 32)).toBe(false);
+  });
+});

--- a/src/vscripts/abilities/ts_abilities/magnataur-reverse-reverse-polarity-logic.ts
+++ b/src/vscripts/abilities/ts_abilities/magnataur-reverse-reverse-polarity-logic.ts
@@ -1,0 +1,71 @@
+export interface Point2D {
+  x: number;
+  y: number;
+}
+
+export type RecastFinishReason = 'cast' | 'expired' | 'death';
+
+export interface RecastWindowState {
+  phase: 'recast' | 'cooldown';
+  cooldownStarted: boolean;
+  reason?: RecastFinishReason;
+}
+
+export function getRadialDestination(
+  center: Point2D,
+  target: Point2D,
+  maxDistance: number,
+  fallbackDirection: Point2D = { x: 1, y: 0 },
+): Point2D {
+  let directionX = target.x - center.x;
+  let directionY = target.y - center.y;
+  let length = Math.sqrt(directionX * directionX + directionY * directionY);
+
+  if (length === 0) {
+    directionX = fallbackDirection.x;
+    directionY = fallbackDirection.y;
+    length = Math.sqrt(directionX * directionX + directionY * directionY);
+  }
+
+  if (length === 0) {
+    directionX = 1;
+    length = 1;
+  }
+
+  return {
+    x: center.x + (directionX / length) * maxDistance,
+    y: center.y + (directionY / length) * maxDistance,
+  };
+}
+
+export function startRecastWindow(): RecastWindowState {
+  return { phase: 'recast', cooldownStarted: false };
+}
+
+export function finishRecastWindow(
+  _state: RecastWindowState,
+  reason: RecastFinishReason,
+): RecastWindowState {
+  return { phase: 'cooldown', cooldownStarted: true, reason };
+}
+
+export function shouldRestoreDelayedCooldown(cooldownRemaining: number): boolean {
+  return cooldownRemaining > 0;
+}
+
+export function registerCollision(alreadyCollided: boolean): {
+  collided: boolean;
+  shouldSettle: boolean;
+} {
+  return { collided: true, shouldSettle: !alreadyCollided };
+}
+
+export function isTerrainCollision(
+  traversable: boolean,
+  blocked: boolean,
+  nearbyTree: boolean,
+  heightDelta: number,
+  maxHeightDelta: number,
+): boolean {
+  return !traversable || blocked || nearbyTree || Math.abs(heightDelta) > maxHeightDelta;
+}

--- a/src/vscripts/abilities/ts_abilities/magnataur_reverse_reverse_polarity_awakened.ts
+++ b/src/vscripts/abilities/ts_abilities/magnataur_reverse_reverse_polarity_awakened.ts
@@ -1,0 +1,381 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  BaseModifierMotionHorizontal,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+import {
+  finishRecastWindow,
+  getRadialDestination,
+  isTerrainCollision,
+  registerCollision,
+  RecastFinishReason,
+  RecastWindowState,
+  shouldRestoreDelayedCooldown,
+  startRecastWindow,
+} from './magnataur-reverse-reverse-polarity-logic';
+
+const SCRIPT_PATH = 'abilities/ts_abilities/magnataur_reverse_reverse_polarity_awakened';
+const FIRST_CAST = 'magnataur_reverse_polarity_awakened';
+const RECAST = 'magnataur_reverse_reverse_polarity_awakened';
+const RECAST_ICON = 'magnataur_reversed_reverse_polarity';
+
+function applyPolarityEffect(
+  caster: CDOTA_BaseNPC,
+  target: CDOTA_BaseNPC,
+  firstCast: CDOTABaseAbility,
+): void {
+  ApplyDamage({
+    victim: target,
+    attacker: caster,
+    ability: firstCast,
+    damage: firstCast.GetSpecialValueFor('polarity_damage'),
+    damage_type: DamageTypes.PURE,
+  });
+  target.AddNewModifier(caster, firstCast, 'modifier_stunned', {
+    duration:
+      firstCast.GetSpecialValueFor('hero_stun_duration') * (1 - target.GetStatusResistance()),
+  });
+}
+
+@registerAbility(RECAST)
+export class MagnataurReverseReversePolarityAwakened extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return modifier_magnataur_reverse_reverse_polarity_controller.name;
+  }
+
+  GetAOERadius(): number {
+    return this.GetSpecialValueFor('push_radius');
+  }
+
+  OnSpellStart(): void {
+    if (!IsServer()) return;
+
+    const caster = this.GetCaster();
+    const window = modifier_magnataur_reverse_reverse_polarity_window.find_on(caster);
+    if (window !== undefined) window.finish('cast');
+
+    const center = caster.GetAbsOrigin();
+    const enemies = FindUnitsInRadius(
+      caster.GetTeamNumber(),
+      center,
+      undefined,
+      this.GetSpecialValueFor('push_radius'),
+      UnitTargetTeam.ENEMY,
+      UnitTargetType.HERO + UnitTargetType.BASIC,
+      UnitTargetFlags.MAGIC_IMMUNE_ENEMIES,
+      FindOrder.ANY,
+      false,
+    );
+
+    EmitSoundOn('Hero_Magnataur.ReversePolarity.Cast', caster);
+    const particle = ParticleManager.CreateParticle(
+      'particles/units/heroes/hero_magnataur/magnataur_reverse_polarity_push.vpcf',
+      ParticleAttachment.WORLDORIGIN,
+      caster,
+    );
+    ParticleManager.SetParticleControl(particle, 0, center);
+    ParticleManager.ReleaseParticleIndex(particle);
+
+    const firstCast = caster.FindAbilityByName(FIRST_CAST);
+    for (const enemy of enemies) {
+      if (firstCast) applyPolarityEffect(caster, enemy, firstCast);
+      modifier_magnataur_reverse_reverse_polarity_motion.apply(enemy, caster, this, {
+        center_x: center.x,
+        center_y: center.y,
+        center_z: center.z,
+        duration: this.GetSpecialValueFor('push_duration'),
+      });
+    }
+  }
+}
+
+@registerModifier(SCRIPT_PATH)
+export class modifier_magnataur_reverse_reverse_polarity_controller extends BaseModifier {
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  OnCreated(): void {
+    if (!IsServer()) return;
+    this.GetAbility()?.SetHidden(true);
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [ModifierFunction.ON_ABILITY_FULLY_CAST];
+  }
+
+  OnAbilityFullyCast(event: ModifierAbilityEvent): void {
+    if (!IsServer()) return;
+    const caster = this.GetParent();
+    if (event.unit !== caster || event.ability?.GetAbilityName() !== FIRST_CAST) return;
+
+    const firstCast = event.ability;
+    const delayedCooldown = firstCast.GetEffectiveCooldown(firstCast.GetLevel() - 1);
+    modifier_magnataur_reverse_reverse_polarity_window.apply(caster, caster, this.GetAbility(), {
+      cooldown: delayedCooldown,
+      duration: this.GetAbility()?.GetSpecialValueFor('recast_window') ?? 3,
+    });
+  }
+}
+
+@registerModifier(SCRIPT_PATH)
+export class modifier_magnataur_reverse_reverse_polarity_window extends BaseModifier {
+  private state: RecastWindowState = startRecastWindow();
+  private delayedCooldown = 0;
+
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return true;
+  }
+
+  GetTexture(): string {
+    return RECAST_ICON;
+  }
+
+  OnCreated(params: { cooldown?: number }): void {
+    if (!IsServer()) return;
+    this.delayedCooldown = params.cooldown ?? 0;
+    const caster = this.GetParent();
+    const firstCast = caster.FindAbilityByName(FIRST_CAST);
+    const recast = caster.FindAbilityByName(RECAST);
+    if (!firstCast || !recast) {
+      this.Destroy();
+      return;
+    }
+
+    recast.SetLevel(firstCast.GetLevel());
+    recast.SetHidden(false);
+    caster.SwapAbilities(FIRST_CAST, RECAST, false, true);
+  }
+
+  finish(reason: RecastFinishReason): void {
+    if (this.state.cooldownStarted) return;
+    this.state = finishRecastWindow(this.state, reason);
+    this.Destroy();
+  }
+
+  OnDestroy(): void {
+    if (!IsServer()) return;
+
+    const caster = this.GetParent();
+    if (!this.state.cooldownStarted) {
+      this.state = finishRecastWindow(this.state, caster.IsAlive() ? 'expired' : 'death');
+    }
+    const firstCast = caster.FindAbilityByName(FIRST_CAST);
+    const recast = caster.FindAbilityByName(RECAST);
+    if (firstCast && recast) {
+      const shouldRestoreCooldown = shouldRestoreDelayedCooldown(
+        firstCast.GetCooldownTimeRemaining(),
+      );
+      caster.SwapAbilities(RECAST, FIRST_CAST, false, true);
+      recast.SetHidden(true);
+      if (shouldRestoreCooldown) {
+        firstCast.EndCooldown();
+        const cooldown =
+          this.delayedCooldown > 0
+            ? this.delayedCooldown
+            : firstCast.GetEffectiveCooldown(firstCast.GetLevel() - 1);
+        firstCast.StartCooldown(cooldown);
+      }
+    }
+  }
+}
+
+@registerModifier(SCRIPT_PATH)
+export class modifier_magnataur_reverse_reverse_polarity_motion extends BaseModifierMotionHorizontal {
+  private center = Vector(0, 0, 0);
+  private destination = Vector(0, 0, 0);
+  private speed = 0;
+  private collisionRadius = 0;
+  private collided = false;
+
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  GetPriority(): ModifierPriority {
+    return ModifierPriority.HIGH;
+  }
+
+  CheckState(): Partial<Record<ModifierState, boolean>> {
+    return {
+      [ModifierState.STUNNED]: true,
+      [ModifierState.NO_UNIT_COLLISION]: true,
+    };
+  }
+
+  OnCreated(params: { center_x?: number; center_y?: number; center_z?: number }): void {
+    if (!IsServer()) return;
+    const ability = this.GetAbility();
+    const caster = this.GetCaster();
+    if (!ability || !caster) {
+      this.Destroy();
+      return;
+    }
+
+    this.center = Vector(params.center_x ?? 0, params.center_y ?? 0, params.center_z ?? 0);
+    const origin = this.GetParent().GetAbsOrigin();
+    const forward = caster.GetForwardVector();
+    const destination = getRadialDestination(
+      { x: this.center.x, y: this.center.y },
+      { x: origin.x, y: origin.y },
+      ability.GetSpecialValueFor('push_distance'),
+      { x: forward.x, y: forward.y },
+    );
+    this.destination = GetGroundPosition(
+      Vector(destination.x, destination.y, origin.z),
+      this.GetParent(),
+    );
+    this.speed =
+      this.distance2D(origin, this.destination) / ability.GetSpecialValueFor('push_duration');
+    this.collisionRadius = ability.GetSpecialValueFor('collision_radius');
+
+    if (!this.ApplyHorizontalMotionController()) this.Destroy();
+  }
+
+  UpdateHorizontalMotion(parent: CDOTA_BaseNPC, dt: number): void {
+    const origin = parent.GetAbsOrigin();
+    const deltaX = this.destination.x - origin.x;
+    const deltaY = this.destination.y - origin.y;
+    const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+    if (distance <= this.speed * dt) {
+      if (this.hitsObstacleAlong(origin, this.destination)) {
+        this.settleCollision();
+      } else {
+        parent.SetAbsOrigin(this.destination);
+      }
+      this.Destroy();
+      return;
+    }
+
+    const step = this.speed * dt;
+    const next = GetGroundPosition(
+      Vector(
+        origin.x + (deltaX / distance) * step,
+        origin.y + (deltaY / distance) * step,
+        origin.z,
+      ),
+      parent,
+    );
+    if (this.hitsObstacleAlong(origin, next)) {
+      this.settleCollision();
+      this.Destroy();
+      return;
+    }
+
+    parent.SetAbsOrigin(next);
+  }
+
+  OnHorizontalMotionInterrupted(): void {
+    if (!IsServer()) return;
+    this.Destroy();
+  }
+
+  OnDestroy(): void {
+    if (!IsServer()) return;
+    const parent = this.GetParent();
+    parent.RemoveHorizontalMotionController(this);
+    ResolveNPCPositions(parent.GetAbsOrigin(), this.collisionRadius);
+  }
+
+  private hitsObstacle(position: Vector): boolean {
+    const parent = this.GetParent();
+    if (
+      isTerrainCollision(
+        GridNav.IsTraversable(position),
+        GridNav.IsBlocked(position),
+        GridNav.IsNearbyTree(position, this.collisionRadius, true),
+        position.z - parent.GetAbsOrigin().z,
+        32,
+      )
+    ) {
+      return true;
+    }
+
+    const caster = this.GetCaster();
+    const units = FindUnitsInRadius(
+      parent.GetTeamNumber(),
+      position,
+      undefined,
+      this.collisionRadius,
+      UnitTargetTeam.BOTH,
+      UnitTargetType.ALL,
+      UnitTargetFlags.INVULNERABLE + UnitTargetFlags.MAGIC_IMMUNE_ENEMIES,
+      FindOrder.ANY,
+      false,
+    );
+    return units.some(
+      (unit) =>
+        unit !== parent &&
+        unit !== caster &&
+        !unit.HasModifier(modifier_magnataur_reverse_reverse_polarity_motion.name),
+    );
+  }
+
+  private hitsObstacleAlong(origin: Vector, destination: Vector): boolean {
+    const distance = this.distance2D(origin, destination);
+    const sampleStep = Math.max(24, this.collisionRadius * 0.5);
+    const samples = Math.max(1, Math.ceil(distance / sampleStep));
+    for (let index = 1; index <= samples; index++) {
+      const progress = index / samples;
+      const sample = GetGroundPosition(
+        Vector(
+          origin.x + (destination.x - origin.x) * progress,
+          origin.y + (destination.y - origin.y) * progress,
+          origin.z,
+        ),
+        this.GetParent(),
+      );
+      if (this.hitsObstacle(sample)) return true;
+    }
+    return false;
+  }
+
+  private settleCollision(): void {
+    const collision = registerCollision(this.collided);
+    this.collided = collision.collided;
+    if (!collision.shouldSettle) return;
+
+    const parent = this.GetParent();
+    const caster = this.GetCaster();
+    const firstCast = caster?.FindAbilityByName(FIRST_CAST);
+    if (!caster || !firstCast) return;
+
+    applyPolarityEffect(caster, parent, firstCast);
+
+    const particle = ParticleManager.CreateParticle(
+      'particles/units/heroes/hero_magnataur/magnataur_reverse_polarity_push.vpcf',
+      ParticleAttachment.ABSORIGIN,
+      parent,
+    );
+    ParticleManager.ReleaseParticleIndex(particle);
+    EmitSoundOn('Hero_Magnataur.ReversePolarity.Stun', parent);
+  }
+
+  private distance2D(a: Vector, b: Vector): number {
+    const x = b.x - a.x;
+    const y = b.y - a.y;
+    return Math.sqrt(x * x + y * y);
+  }
+}

--- a/src/vscripts/ai/ability/specs/index.ts
+++ b/src/vscripts/ai/ability/specs/index.ts
@@ -18,6 +18,7 @@ import { SPECS as lionFingerOfDeath } from './lion_finger_of_death';
 import { SPECS as lionImpale } from './lion_impale';
 import { SPECS as lionManaDrain } from './lion_mana_drain';
 import { SPECS as lionVoodoo } from './lion_voodoo';
+import { SPECS as magnataurReversePolarityAwakened } from './magnataur_reverse_polarity_awakened';
 import { SPECS as medusaSplitShot } from './medusa_split_shot';
 import { SPECS as omniknightHammerOfPurity } from './omniknight_hammer_of_purity';
 import { SPECS as omniknightPurification } from './omniknight_purification';
@@ -78,6 +79,9 @@ export function registerAbilitySpecs(): void {
   AbilityRegistry.registerAll(axeBerserkerSCall);
   AbilityRegistry.registerAll(axeBattleHunger);
   AbilityRegistry.registerAll(axeCullingBlade);
+
+  // Magnus 马格纳斯
+  AbilityRegistry.registerAll(magnataurReversePolarityAwakened);
 
   // Sand King 沙王
   AbilityRegistry.registerAll(sandkingBurrowstrike);

--- a/src/vscripts/ai/ability/specs/magnataur_reverse_polarity_awakened.ts
+++ b/src/vscripts/ai/ability/specs/magnataur_reverse_polarity_awakened.ts
@@ -1,0 +1,24 @@
+import { AbilitySpec, TargetSide } from '../ability-spec';
+
+export const SPECS: AbilitySpec[] = [
+  {
+    abilityName: 'magnataur_reverse_polarity_awakened',
+    targetSide: TargetSide.EnemyHero,
+    condition: {
+      target: {
+        rangeFromAbilityValue: 'pull_radius',
+        ignoresMagicImmune: true,
+      },
+    },
+  },
+  {
+    abilityName: 'magnataur_reverse_reverse_polarity_awakened',
+    targetSide: TargetSide.EnemyHero,
+    condition: {
+      target: {
+        rangeFromAbilityValue: 'push_radius',
+        ignoresMagicImmune: true,
+      },
+    },
+  },
+];

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,19 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 马格纳斯 觉醒
+  {
+    heroName: 'npc_dota_hero_magnataur',
+    targetAbility: 'magnataur_reverse_polarity',
+    newAbility: 'magnataur_reverse_polarity_awakened',
+    newLevel: 0,
+  },
+  {
+    heroName: 'npc_dota_hero_magnataur',
+    newAbility: 'magnataur_reverse_reverse_polarity_awakened',
+    // 二段需要 1 级来常驻监听一段施法；窗口开启时再同步一段的实际等级。
+    newLevel: 1,
+  },
   // 亚巴顿 觉醒
   {
     heroName: 'npc_dota_hero_abaddon',
@@ -245,6 +258,7 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  * 新觉醒发布时加入，下次发版由 awaken-ability skill 流程确认移出。
  */
 export const FREE_TRIAL_HEROES: string[] = [
+  'npc_dota_hero_magnataur', // 马格纳斯
   'npc_dota_hero_abaddon', // 亚巴顿
   'npc_dota_hero_skywrath_mage', // 天怒法师
   'npc_dota_hero_dazzle', // 戴泽

--- a/src/vscripts/modules/awaken/awaken-replacer.test.ts
+++ b/src/vscripts/modules/awaken/awaken-replacer.test.ts
@@ -153,6 +153,19 @@ describe('executeReplacement', () => {
 });
 
 describe('applyAwakenByHero', () => {
+  it('猛犸觉醒替换两极反转并加入二段控制器', () => {
+    const f = createFakeHero({
+      unitName: 'npc_dota_hero_magnataur',
+      abilities: [{ name: 'magnataur_reverse_polarity', level: 3 }],
+    });
+
+    expect(applyAwakenByHero(f.hero)).toBe(true);
+    expect(f.abilities).toEqual([
+      { name: 'magnataur_reverse_polarity_awakened', level: 3 },
+      { name: 'magnataur_reverse_reverse_polarity_awakened', level: 1 },
+    ]);
+  });
+
   it('上古巨神觉醒替换二技能并继承原等级', () => {
     const f = createFakeHero({
       unitName: 'npc_dota_hero_elder_titan',


### PR DESCRIPTION
## Issue

N/A

## Summary

- Add a Magnataur awakening that makes Reverse Polarity deal pure damage and enables a three-second recast.
- Make Reverse Reverse Polarity radially push nearby enemies, with terrain, tree, building, and unit collisions repeating its damage and stun once.
- Start the full cooldown after the recast or window expiry, while preserving refresh effects used during the recast window.
- Add awakening availability, AI casting support, and English, Simplified Chinese, and Russian localization.

## Checklist

- [x] The requester tested the first cast, recast push, collision effect, and refresh interaction in Dota Tools.
- [x] `npm run lint`
- [x] `npm run build:vscripts`
- [x] `npm run build:panorama`
- [x] Focused Jest suites: 31 tests passed.

## Release Note

```
[b]游戏性更新 v5.50[/b]

- 新增马格纳斯觉醒：两极反转造成纯粹伤害，释放后可再次施放两极反转·再反转，径向推出敌人并在碰撞障碍时再次造成伤害和眩晕。
```

```
[b]Gameplay update v5.50[/b]

- Added Magnus awakening: Reverse Polarity deals pure damage and enables Reverse Reverse Polarity, radially pushing enemies and repeating its damage and stun when they collide with obstacles.
```
