### PR TITLE
Add Tusk Tag Team awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3572,6 +3572,13 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Shallow Grave Awakened</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"After casting Shallow Grave on yourself or an ally, the target gains the <font color='#FFCC66'>Black King Bar</font> effect for the duration of Shallow Grave."
 
+		// 巨牙海民 摔角行家觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_tusk_tag_team_awaken"					"<font color='#d000ff'>Tag Team Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_tusk_tag_team_awaken_Description"		"Whenever Tag Team is cast, Tusk stores %damage_taken_to_bonus_pct%%% of damage actually taken during that activation as bonus damage. Every damage instance dealt by Tusk or his allies to enemies within Tag Team's radius gains Tag Team's current base bonus plus the stored damage. Attacks already include Tag Team's base bonus and therefore gain only the stored portion. The added damage keeps the original damage type and is not affected by spell amplification. Recasting while active refreshes the duration without clearing stored damage; the stored damage is cleared when Tag Team ends."
+		"DOTA_Tooltip_ability_special_bonus_unique_tusk_tag_team_awaken_SummaryDescription"	"Damage taken during Tag Team becomes fixed bonus damage for all allied damage dealt within its radius."
+		"DOTA_Tooltip_modifier_special_bonus_unique_tusk_tag_team_awaken"				"<font color='#d000ff'>Tag Team Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_tusk_tag_team_awaken_Description"		"During Tag Team, <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%%%</b></font> of damage actually taken is stored as bonus damage. Every damage instance dealt by Tusk or his allies to enemies within its radius gains Tag Team's current base bonus plus the stored damage, while attacks gain only the stored portion. The added damage keeps the original damage type and is not affected by spell amplification.<br>Current stored damage: <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP2%</b></font>"
+
 		// Slark Essence Erosion - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>Essence Erosion Awakened</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"When Slark kills an enemy hero, he permanently steals %permanent_steal_pct%%% of the total attributes his Essence Shift has taken from that hero.<br>An enemy hero's base attributes never fall below <font color='#FFFFFF'><b>1</b></font>."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -693,6 +693,13 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Пробуждение Shallow Grave</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"После применения Shallow Grave на себя или союзника цель получает эффект <font color='#FFCC66'>Black King Bar</font> на время действия Shallow Grave."
 
+		// 巨牙海民 摔角行家觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_tusk_tag_team_awaken"					"<font color='#d000ff'>Tag Team · Пробуждение</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_tusk_tag_team_awaken_Description"		"При каждом применении Tag Team Tusk накапливает %damage_taken_to_bonus_pct%%% фактически полученного урона за время действия в виде дополнительного урона. Каждый случай урона от Tusk или его союзников по врагам в радиусе Tag Team получает текущий базовый бонус Tag Team и накопленный урон. Атаки уже включают базовый бонус Tag Team, поэтому дополнительно получают только накопленную часть. Дополнительный урон сохраняет исходный тип и не усиливается увеличением урона от заклинаний. Повторное применение во время действия обновляет длительность и сохраняет накопленный урон; по окончании Tag Team он обнуляется."
+		"DOTA_Tooltip_ability_special_bonus_unique_tusk_tag_team_awaken_SummaryDescription"	"Урон, полученный во время Tag Team, превращается в фиксированный дополнительный урон для всего союзного урона в радиусе действия."
+		"DOTA_Tooltip_modifier_special_bonus_unique_tusk_tag_team_awaken"				"<font color='#d000ff'>Tag Team · Пробуждение</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_tusk_tag_team_awaken_Description"		"Во время Tag Team <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%%%</b></font> фактически полученного урона накапливается как дополнительный урон. Каждый случай урона от Tusk или его союзников по врагам в радиусе получает текущий базовый бонус Tag Team и накопленный урон, а атаки получают только накопленную часть. Дополнительный урон сохраняет исходный тип и не усиливается увеличением урона от заклинаний.<br>Текущий накопленный урон: <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP2%</b></font>"
+
 		// Slark Essence Erosion - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>Разъедание сущности · Пробуждение</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"Когда Slark убивает вражеского героя, он навсегда забирает %permanent_steal_pct%%% от общего количества атрибутов, похищенных у этого героя его Essence Shift.<br>Базовые атрибуты вражеского героя не опускаются ниже <font color='#FFFFFF'><b>1</b></font>."

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3581,6 +3581,13 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>薄葬 觉醒</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"对自己或队友施放薄葬后，目标在薄葬持续期间获得<font color='#FFCC66'>黑皇杖</font>效果。"
 
+		// 巨牙海民 摔角行家觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_tusk_tag_team_awaken"					"<font color='#d000ff'>摔角行家 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_tusk_tag_team_awaken_Description"		"每次施放摔角行家时，巨牙海民会将本次持续期间实际受到伤害的%damage_taken_to_bonus_pct%%%累计为额外伤害。范围内敌人每次受到巨牙海民或友军造成的普攻、技能和装备主动伤害时，都会额外受到摔角行家当前基础伤害与累计伤害。普攻已包含摔角行家的基础伤害，因此只额外结算累计部分。追加伤害沿用原伤害类型，不受技能增强影响。生效期间再次施放会刷新持续时间并保留累计伤害，效果结束时清零。"
+		"DOTA_Tooltip_ability_special_bonus_unique_tusk_tag_team_awaken_SummaryDescription"	"摔角行家期间承受的伤害会转化为范围内所有友军伤害的固定追加伤害。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_tusk_tag_team_awaken"				"<font color='#d000ff'>摔角行家 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_tusk_tag_team_awaken_Description"		"摔角行家期间，将实际受到伤害的<font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%%%</b></font>累计为额外伤害。范围内敌人每次受到巨牙海民或友军造成的伤害时，都会额外受到摔角行家当前基础伤害与累计伤害，普攻只额外结算累计部分。追加伤害沿用原伤害类型，不受技能增强影响。<br>当前累计伤害：<font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP2%</b></font>"
+
 		// 斯拉克 精华侵蚀觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>精华侵蚀 觉醒</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"斯拉克击杀敌人时，将能量转移偷取属性总量的%permanent_steal_pct%%%永久偷走该英雄的全属性。<br>敌方英雄的基础属性最低保留<font color='#FFFFFF'><b>1</b></font>点。"

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -936,4 +936,19 @@
 			"spell_reduce"				"60"
 		}
 	}
+
+	// 巨牙海民 摔角行家-觉醒
+	"special_bonus_unique_tusk_tag_team_awaken"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/special_bonus_unique_tusk_tag_team_awaken"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"			"tusk_tag_team"
+		"MaxLevel"						"1"
+
+		"AbilityValues"
+		{
+			"damage_taken_to_bonus_pct"	"50"
+		}
+	}
 }

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,11 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_tusk',
+    abilityName: 'special_bonus_unique_tusk_tag_team_awaken',
+    freeTrial: true,
+  },
+  {
     heroName: 'npc_dota_hero_slark',
     abilityName: 'special_bonus_unique_slark_permanent_essence_awaken',
     freeTrial: true,

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_tusk_tag_team_awaken.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_tusk_tag_team_awaken.ts
@@ -103,6 +103,14 @@ export class modifier_special_bonus_unique_tusk_tag_team_awaken extends BaseModi
       return;
     }
 
+    this.applyBonusDamage(event, target, parent);
+  }
+
+  private applyBonusDamage(
+    event: ModifierInstanceEvent,
+    target: CDOTA_BaseNPC,
+    parent: CDOTA_BaseNPC,
+  ): void {
     if (event.damage <= 0) return;
 
     const attacker = event.attacker;

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_tusk_tag_team_awaken.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_tusk_tag_team_awaken.ts
@@ -1,0 +1,204 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+import { addTagTeamStoredDamage, calculateTagTeamExtraDamage } from './tusk-tag-team-awaken-math';
+
+const TAG_TEAM_ABILITY = 'tusk_tag_team';
+// Native caster modifier: owns Tag Team's duration, refreshes and removal lifecycle.
+const TAG_TEAM_AURA_MODIFIER = 'modifier_tusk_tag_team_aura';
+// Native enemy aura effect: its presence is the authoritative in-range/target check.
+const TAG_TEAM_DAMAGE_MODIFIER = 'modifier_tusk_tag_team';
+const NATIVE_AURA_CHECK_INTERVAL = 0.1;
+
+/** 巨牙海民 摔角行家觉醒 */
+@registerAbility('special_bonus_unique_tusk_tag_team_awaken')
+export class SpecialBonusUniqueTuskTagTeamAwaken extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return modifier_special_bonus_unique_tusk_tag_team_awaken.name;
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_tusk_tag_team_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_tusk_tag_team_awaken extends BaseModifier {
+  private conversionPct = 0;
+  private storedDamage = 0;
+  private resolvingBonusDamage = false;
+  private nativeAuraCheckRunning = false;
+
+  OnCreated(): void {
+    this.refreshValues();
+    if (IsServer()) this.clearStoredDamage();
+  }
+
+  OnRefresh(): void {
+    this.refreshValues();
+  }
+
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  IsBuff(): boolean {
+    return true;
+  }
+
+  GetTexture(): string {
+    return TAG_TEAM_ABILITY;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [
+      ModifierFunction.ON_ABILITY_START,
+      ModifierFunction.ON_TAKEDAMAGE,
+      ModifierFunction.ON_MODIFIER_REMOVED,
+      ModifierFunction.TOOLTIP,
+      ModifierFunction.TOOLTIP2,
+    ];
+  }
+
+  OnAbilityStart(event: ModifierAbilityEvent): void {
+    if (!IsServer()) return;
+    const parent = this.GetParent();
+    if (event.unit !== parent || event.ability.GetAbilityName() !== TAG_TEAM_ABILITY) return;
+
+    // Ability-start runs before the native aura is applied. Preserve the pool only when the
+    // previous native activation is genuinely still active.
+    if (!this.hasNativeTagTeamAura()) this.clearStoredDamage();
+  }
+
+  OnModifierRemoved(event: ModifierAddedEvent): void {
+    if (!IsServer()) return;
+    const parent = this.GetParent();
+    if (event.unit !== parent || event.added_buff.GetName() !== TAG_TEAM_AURA_MODIFIER) return;
+    this.clearStoredDamage();
+  }
+
+  OnIntervalThink(): void {
+    if (!IsServer()) return;
+    if (!this.hasNativeTagTeamAura()) this.clearStoredDamage();
+  }
+
+  OnTakeDamage(event: ModifierInstanceEvent): void {
+    if (!IsServer() || this.resolvingBonusDamage || !this.hasNativeTagTeamAura()) return;
+    if (this.hasExcludedDamageFlag(event.damage_flags ?? 0)) return;
+
+    const parent = this.GetParent();
+    const target = event.unit;
+    if (!target || target.IsNull()) return;
+
+    if (target === parent) {
+      this.storeDamageTaken(event);
+      return;
+    }
+
+    if (event.damage <= 0) return;
+
+    const attacker = event.attacker;
+    if (!attacker || attacker.IsNull() || attacker.GetTeamNumber() !== parent.GetTeamNumber())
+      return;
+    if (target.GetTeamNumber() === parent.GetTeamNumber() || !target.IsAlive()) return;
+
+    const nativeTagTeamModifier = this.findNativeTagTeamDamageModifier(target);
+    const nativeTagTeamAbility = nativeTagTeamModifier?.GetAbility();
+    if (!nativeTagTeamAbility || nativeTagTeamAbility.GetAbilityName() !== TAG_TEAM_ABILITY) return;
+
+    const extraDamage = calculateTagTeamExtraDamage(
+      nativeTagTeamAbility.GetSpecialValueFor('bonus_damage'),
+      this.storedDamage,
+      event.damage_category === DamageCategory.ATTACK,
+    );
+    const ability = this.GetAbility();
+    if (!ability || extraDamage <= 0) return;
+
+    this.resolvingBonusDamage = true;
+    ApplyDamage({
+      victim: target,
+      attacker,
+      damage: extraDamage,
+      damage_type: event.damage_type,
+      damage_flags: DamageFlag.NO_SPELL_AMPLIFICATION + DamageFlag.REFLECTION,
+      ability,
+    });
+    this.resolvingBonusDamage = false;
+  }
+
+  OnTooltip(): number {
+    return this.conversionPct;
+  }
+
+  OnTooltip2(): number {
+    return this.GetStackCount();
+  }
+
+  private refreshValues(): void {
+    const ability = this.GetAbility();
+    if (!ability) return;
+    this.conversionPct = ability.GetSpecialValueFor('damage_taken_to_bonus_pct');
+  }
+
+  private clearStoredDamage(): void {
+    this.storedDamage = 0;
+    this.SetStackCount(0);
+    this.SendBuffRefreshToClients();
+    if (this.nativeAuraCheckRunning) {
+      this.nativeAuraCheckRunning = false;
+      this.StartIntervalThink(-1);
+    }
+  }
+
+  private hasNativeTagTeamAura(): boolean {
+    const parent = this.GetParent();
+    return (
+      !parent.IsIllusion() &&
+      parent.IsAlive() &&
+      parent
+        .FindAllModifiersByName(TAG_TEAM_AURA_MODIFIER)
+        .some((modifier) => modifier.GetAbility()?.GetAbilityName() === TAG_TEAM_ABILITY)
+    );
+  }
+
+  private findNativeTagTeamDamageModifier(target: CDOTA_BaseNPC): CDOTA_Buff | undefined {
+    const parent = this.GetParent();
+    return target.FindAllModifiersByName(TAG_TEAM_DAMAGE_MODIFIER).find((modifier) => {
+      const nativeAbility = modifier.GetAbility();
+      if (!nativeAbility || nativeAbility.GetAbilityName() !== TAG_TEAM_ABILITY) return false;
+
+      // Aura recipients are owned by the native aura emitter. GetCaster() is not the
+      // authoritative association for native aura effects and can miss valid edge targets.
+      return modifier.GetAuraOwner() === parent || modifier.GetCaster() === parent;
+    });
+  }
+
+  private storeDamageTaken(event: ModifierInstanceEvent): void {
+    const parent = this.GetParent();
+    const attacker = event.attacker;
+    if (!attacker || attacker.IsNull() || attacker.GetTeamNumber() === parent.GetTeamNumber())
+      return;
+
+    this.storedDamage = addTagTeamStoredDamage(this.storedDamage, event.damage, this.conversionPct);
+    this.SetStackCount(Math.floor(this.storedDamage));
+    if (this.storedDamage > 0 && !this.nativeAuraCheckRunning) {
+      this.nativeAuraCheckRunning = true;
+      this.StartIntervalThink(NATIVE_AURA_CHECK_INTERVAL);
+    }
+  }
+
+  private hasExcludedDamageFlag(damageFlags: number): boolean {
+    return (
+      (damageFlags & DamageFlag.HPLOSS) === DamageFlag.HPLOSS ||
+      (damageFlags & DamageFlag.REFLECTION) === DamageFlag.REFLECTION
+    );
+  }
+}

--- a/src/vscripts/abilities/ts_abilities/tusk-tag-team-awaken-math.test.ts
+++ b/src/vscripts/abilities/ts_abilities/tusk-tag-team-awaken-math.test.ts
@@ -1,0 +1,25 @@
+import { addTagTeamStoredDamage, calculateTagTeamExtraDamage } from './tusk-tag-team-awaken-math';
+
+describe('addTagTeamStoredDamage', () => {
+  it('stores 50% of damage actually taken', () => {
+    expect(addTagTeamStoredDamage(0, 10000, 50)).toBe(5000);
+  });
+
+  it('accumulates damage across the current activation', () => {
+    expect(addTagTeamStoredDamage(250, 5000, 50)).toBe(2750);
+  });
+
+  it('does not reduce the pool for invalid negative inputs', () => {
+    expect(addTagTeamStoredDamage(250, -100, 50)).toBe(250);
+  });
+});
+
+describe('calculateTagTeamExtraDamage', () => {
+  it('adds only stored damage to attacks because native Tag Team already adds its base bonus', () => {
+    expect(calculateTagTeamExtraDamage(100, 1000, true)).toBe(1000);
+  });
+
+  it('adds native and stored damage to spell and item damage', () => {
+    expect(calculateTagTeamExtraDamage(100, 1000, false)).toBe(1100);
+  });
+});

--- a/src/vscripts/abilities/ts_abilities/tusk-tag-team-awaken-math.ts
+++ b/src/vscripts/abilities/ts_abilities/tusk-tag-team-awaken-math.ts
@@ -1,0 +1,15 @@
+export function addTagTeamStoredDamage(
+  currentBonus: number,
+  damageTaken: number,
+  conversionPct: number,
+): number {
+  return Math.max(0, currentBonus) + (Math.max(0, damageTaken) * Math.max(0, conversionPct)) / 100;
+}
+
+export function calculateTagTeamExtraDamage(
+  nativeBonusDamage: number,
+  storedDamage: number,
+  isAttackDamage: boolean,
+): number {
+  return Math.max(0, storedDamage) + (isAttackDamage ? 0 : Math.max(0, nativeBonusDamage));
+}

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,12 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 巨牙海民 觉醒
+  {
+    heroName: 'npc_dota_hero_tusk',
+    newAbility: 'special_bonus_unique_tusk_tag_team_awaken',
+    newLevel: 1,
+  },
   // 斯拉克 觉醒
   {
     heroName: 'npc_dota_hero_slark',
@@ -251,6 +257,7 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  * 新觉醒发布时加入，下次发版由 awaken-ability skill 流程确认移出。
  */
 export const FREE_TRIAL_HEROES: string[] = [
+  'npc_dota_hero_tusk', // 巨牙海民
   'npc_dota_hero_slark', // 斯拉克
   'npc_dota_hero_abaddon', // 亚巴顿
   'npc_dota_hero_skywrath_mage', // 天怒法师


### PR DESCRIPTION
## Summary

- Add a Tusk Tag Team awakening with a visible status modifier and full awaken-page wiring.
- Store 50% of post-mitigation damage taken during Tag Team and add it as fixed bonus damage to allied attacks, abilities, and active items against enemies in the native aura.
- Preserve stored damage when Tag Team is refreshed, clear it when the native effect ends, and keep the HUD value synchronized.

## Checklist

- [x] I have tested the changes works well.
- [x] `npm run build:vscripts`
- [x] `npm run build:panorama`
- [x] `npm run lint`
- [x] Focused Jest suites (21 tests)
