### PR TITLE
Add Slardar Corrosive Haze domain awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3586,5 +3586,19 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>The Quickening Awakened</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"Whenever a unit dies within <font color='#FFFFFF'><b>900</b></font> range, the current cooldowns of all Abaddon's abilities and items are reduced. Non-hero deaths reduce them by <font color='#FFFFFF'><b>0.2</b></font>s; hero deaths reduce them by <font color='#FFFFFF'><b>3</b></font>s."
 
+		// 斯拉达 侵蚀雾霭领域觉醒
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened"						"<font color='#d000ff'>Corrosive Haze Domain Awakened</font>"
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_Description"				"Reduces enemy armor, increasing the physical damage they take, while providing True Sight and revealing invisible units. Enemy units leave a trail of water behind them.\n\n<font color='#d000ff'>Awakening Bonus:</font> Slardar creates a field that continuously applies the current level of Corrosive Haze to enemies within it. The effect is reapplied after being dispelled and remains for its current duration after leaving the field. Armor reduction is additionally increased by %caster_armor_reduction_pct%%% of Slardar's current total armor."
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_armor_reduction"			"ARMOR REDUCTION:"
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_duration"				"DURATION:"
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_puddle_radius"			"WATER TRAIL RADIUS:"
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_puddle_duration"			"WATER TRAIL DURATION:"
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_field_radius"			"FIELD RADIUS:"
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_caster_armor_reduction_pct"	"%EXTRA ARMOR REDUCTION (TOTAL ARMOR):"
+		"DOTA_Tooltip_modifier_special_bonus_unique_slardar_amplify_damage_awaken"			"<font color='#d000ff'>Corrosive Haze Domain Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_slardar_amplify_damage_awaken_Description"	"Creates a Corrosive Haze domain that continuously applies the current level of the ultimate to enemies within it. Extra armor reduction is based on Slardar's current total armor.<br>Current extra armor reduction: <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font>."
+		"DOTA_Tooltip_modifier_slardar_amplify_damage_awakened_bonus"				"<font color='#d000ff'>Corrosive Haze Awakened</font>"
+		"DOTA_Tooltip_modifier_slardar_amplify_damage_awakened_bonus_Description"		"Reduces armor by <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font> in total and provides True Sight to Slardar.<br>Awakening extra armor reduction: <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP2%</b></font> (based on Slardar's current total armor)."
+
 	}
 }

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -707,5 +707,19 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>Ускорение · Пробуждение</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"Когда юнит погибает в радиусе <font color='#FFFFFF'><b>900</b></font> от Abaddon, текущее время перезарядки всех его способностей и предметов сокращается. Смерть не-героя сокращает его на <font color='#FFFFFF'><b>0.2</b></font> сек., а смерть героя — на <font color='#FFFFFF'><b>3</b></font> сек."
 
+		// 斯拉达 侵蚀雾霭领域觉醒
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened"						"<font color='#d000ff'>Поле Corrosive Haze · Пробуждение</font>"
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_Description"				"Снижает броню врага, увеличивая получаемый им физический урон, а также даёт True Sight и раскрывает невидимых существ. Вражеские существа оставляют за собой водный след.\n\n<font color='#d000ff'>Бонус пробуждения:</font> Slardar создаёт область, которая постоянно накладывает Corrosive Haze текущего уровня на врагов внутри неё. После развеивания эффект накладывается снова, а после выхода из области сохраняется на текущую длительность. Снижение брони дополнительно увеличивается на %caster_armor_reduction_pct%%% от текущей общей брони Slardar."
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_armor_reduction"			"СНИЖЕНИЕ БРОНИ:"
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_duration"				"ДЛИТЕЛЬНОСТЬ:"
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_puddle_radius"			"РАДИУС ВОДНОГО СЛЕДА:"
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_puddle_duration"			"ДЛИТЕЛЬНОСТЬ ВОДНОГО СЛЕДА:"
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_field_radius"			"РАДИУС ОБЛАСТИ:"
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_caster_armor_reduction_pct"	"%ДОП. СНИЖЕНИЕ БРОНИ (ОБЩАЯ БРОНЯ):"
+		"DOTA_Tooltip_modifier_special_bonus_unique_slardar_amplify_damage_awaken"			"<font color='#d000ff'>Поле Corrosive Haze · Пробуждение</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_slardar_amplify_damage_awaken_Description"	"Создаёт поле Corrosive Haze, непрерывно накладывающее текущий уровень ультимативной способности на врагов внутри. Дополнительное снижение брони зависит от текущей общей брони Slardar.<br>Текущее дополнительное снижение брони: <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font>."
+		"DOTA_Tooltip_modifier_slardar_amplify_damage_awakened_bonus"				"<font color='#d000ff'>Corrosive Haze · Пробуждение</font>"
+		"DOTA_Tooltip_modifier_slardar_amplify_damage_awakened_bonus_Description"		"Снижает броню всего на <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font> и даёт Slardar True Sight на цель.<br>Дополнительное снижение брони от пробуждения: <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP2%</b></font> (зависит от текущей общей брони Slardar)."
+
 	}
 }

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3595,5 +3595,19 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>畅快淋漓 觉醒</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"附近 <font color='#FFFFFF'><b>900</b></font> 范围内有单位阵亡时，亚巴顿所有技能和物品的当前冷却都会减少。非英雄单位阵亡减少 <font color='#FFFFFF'><b>0.2</b></font> 秒，英雄阵亡减少 <font color='#FFFFFF'><b>3</b></font> 秒。"
 
+		// 斯拉达 侵蚀雾霭领域觉醒
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened"						"<font color='#d000ff'>侵蚀雾霭领域 觉醒</font>"
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_Description"				"削弱敌人的护甲，加深其受到的物理伤害，同时提供目标的真实视域，显示隐身单位。敌方单位将在身后留下水迹。\n\n<font color='#d000ff'>觉醒强化：</font>斯拉达形成领域，领域内的敌人持续受到当前等级的侵蚀雾霭；被驱散后会再次施加，离开领域后按当前持续时间保留。护甲削弱额外增加斯拉达当前总护甲的%caster_armor_reduction_pct%%%。"
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_armor_reduction"			"护甲削弱："
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_duration"				"持续时间："
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_puddle_radius"			"水迹作用范围："
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_puddle_duration"			"水迹持续时间："
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_field_radius"			"领域范围："
+		"DOTA_Tooltip_ability_slardar_amplify_damage_awakened_caster_armor_reduction_pct"	"%额外减甲（自身总护甲）："
+		"DOTA_Tooltip_modifier_special_bonus_unique_slardar_amplify_damage_awaken"			"<font color='#d000ff'>侵蚀雾霭领域 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_slardar_amplify_damage_awaken_Description"	"形成侵蚀雾霭领域，领域内的敌人持续受到当前等级的大招效果。额外减甲按斯拉达当前总护甲计算。<br>当前额外减甲：<font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font>点。"
+		"DOTA_Tooltip_modifier_slardar_amplify_damage_awakened_bonus"				"<font color='#d000ff'>侵蚀雾霭 觉醒</font>"
+		"DOTA_Tooltip_modifier_slardar_amplify_damage_awakened_bonus_Description"		"护甲共降低<font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font>点，并为斯拉达提供真实视域。<br>其中觉醒额外减甲：<font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP2%</b></font>点（按斯拉达当前总护甲计算）。"
+
 	}
 }

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -5,6 +5,51 @@
 	// 英雄专属强化/替换技能，通过抽奖池获得
 	//=================================================================================================================
 
+	// 斯拉达 觉醒
+	"slardar_amplify_damage_awakened"
+	{
+		"BaseClass"						"slardar_amplify_damage"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityType"					"ABILITY_TYPE_ULTIMATE"
+		"AbilityUnitTargetTeam"		"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"		"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"		"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"SpellImmunityType"			"SPELL_IMMUNITY_ENEMIES_YES"
+		"SpellDispellableType"		"SPELL_DISPELLABLE_YES"
+		"AbilityTextureName"			"slardar_amplify_damage"
+		"MaxLevel"						"4"
+		"RequiredLevel"				"6"
+		"AbilityCastRange"				"700"
+		"AbilityCastPoint"				"0.3"
+		"AbilityCooldown"				"5"
+		"AbilityManaCost"				"25"
+
+		"AbilityValues"
+		{
+			"armor_reduction"				"-10 -15 -20 -25"
+			"duration"						"18"
+			"puddle_radius"				"200"
+			"puddle_duration"				"12"
+			"field_radius"					"500"
+			"caster_armor_reduction_pct"	"50"
+		}
+	}
+
+	"special_bonus_unique_slardar_amplify_damage_awaken"
+	{
+		"BaseClass"					"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/special_bonus_unique_slardar_amplify_damage_awaken"
+		"AbilityBehavior"			"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_SKIP_FOR_KEYBINDS"
+		"AbilityTextureName"		"slardar_amplify_damage"
+		"IsOnCastBar"				"0"
+		"MaxLevel"					"1"
+
+		"precache"
+		{
+			"particle"		"particles/units/heroes/hero_slardar/slardar_crush_puddle.vpcf"
+		}
+	}
+
 	// 斯拉克 精华侵蚀觉醒
 	"special_bonus_unique_slark_permanent_essence_awaken"
 	{

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,11 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_slardar',
+    abilityName: 'slardar_amplify_damage_awakened',
+    freeTrial: true,
+  },
+  {
     heroName: 'npc_dota_hero_slark',
     abilityName: 'special_bonus_unique_slark_permanent_essence_awaken',
     freeTrial: true,

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_slardar_amplify_damage_awaken.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_slardar_amplify_damage_awaken.ts
@@ -1,0 +1,342 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+
+const CORROSIVE_HAZE_ABILITY = 'slardar_amplify_damage';
+const CORROSIVE_HAZE_AWAKENED_ABILITY = 'slardar_amplify_damage_awakened';
+const CORROSIVE_HAZE_MODIFIER = 'modifier_slardar_amplify_damage';
+const SLARDAR_UNDISPELLABLE_HAZE_TALENT = 'special_bonus_unique_slardar_3';
+const FIELD_PARTICLE = 'particles/units/heroes/hero_slardar/slardar_crush_puddle.vpcf';
+const FIELD_INTERVAL = 0.2;
+
+function hasLearnedTalent(caster: CDOTA_BaseNPC | undefined, talentName: string): boolean {
+  if (!caster || caster.IsNull()) return false;
+  const talent = caster.FindAbilityByName(talentName);
+  return !!talent && !talent.IsNull() && talent.GetLevel() > 0;
+}
+
+@registerAbility('special_bonus_unique_slardar_amplify_damage_awaken')
+export class SpecialBonusUniqueSlardarAmplifyDamageAwaken extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return modifier_special_bonus_unique_slardar_amplify_damage_awaken.name;
+  }
+}
+
+/** 斯拉达 侵蚀雾霭觉醒。 */
+@registerModifier('abilities/ts_abilities/special_bonus_unique_slardar_amplify_damage_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_slardar_amplify_damage_awaken extends BaseModifier {
+  private fieldParticle?: ParticleID;
+  private bonusArmorReduction = 0;
+
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsBuff(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return CORROSIVE_HAZE_ABILITY;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [
+      ModifierFunction.ON_DEATH,
+      ModifierFunction.ON_ABILITY_FULLY_CAST,
+      ModifierFunction.ON_RESPAWN,
+      ModifierFunction.TOOLTIP,
+    ];
+  }
+
+  OnTooltip(): number {
+    return this.bonusArmorReduction;
+  }
+
+  OnCreated(): void {
+    if (!IsServer()) return;
+
+    this.SetHasCustomTransmitterData(true);
+    this.updateBonusArmorReduction();
+    this.applyField();
+    this.StartIntervalThink(FIELD_INTERVAL);
+  }
+
+  OnRefresh(): void {
+    if (!IsServer()) return;
+
+    this.updateBonusArmorReduction();
+    this.applyField();
+    this.StartIntervalThink(FIELD_INTERVAL);
+  }
+
+  OnIntervalThink(): void {
+    this.updateBonusArmorReduction();
+    this.applyField();
+  }
+
+  OnDeath(event: ModifierInstanceEvent): void {
+    if (!IsServer() || event.unit !== this.GetParent()) return;
+    this.destroyFieldParticle();
+  }
+
+  OnRespawn(event: ModifierUnitEvent): void {
+    if (!IsServer() || event.unit !== this.GetParent()) return;
+    this.updateBonusArmorReduction();
+    this.applyField();
+  }
+
+  OnAbilityFullyCast(event: ModifierAbilityEvent): void {
+    const parent = this.GetParent();
+    const target = event.target;
+    if (!IsServer() || event.unit !== parent || !target || target.IsNull()) return;
+    if (!this.isCorrosiveHaze(event.ability)) return;
+
+    const nativeHaze = target.FindModifierByNameAndCaster(CORROSIVE_HAZE_MODIFIER, parent);
+    if (!nativeHaze || nativeHaze.IsNull()) return;
+
+    this.applyBonusArmorReduction(target, event.ability, nativeHaze.GetRemainingTime());
+  }
+
+  AddCustomTransmitterData(): { bonusArmorReduction: number } {
+    return { bonusArmorReduction: this.bonusArmorReduction };
+  }
+
+  HandleCustomTransmitterData(data: { bonusArmorReduction: number }): void {
+    this.bonusArmorReduction = data.bonusArmorReduction;
+  }
+
+  OnDestroy(): void {
+    if (!IsServer()) return;
+    this.destroyFieldParticle();
+  }
+
+  private getCorrosiveHaze(): CDOTABaseAbility | undefined {
+    const parent = this.GetParent();
+    if (parent.IsNull()) return undefined;
+
+    const ability =
+      parent.FindAbilityByName(CORROSIVE_HAZE_AWAKENED_ABILITY) ??
+      parent.FindAbilityByName(CORROSIVE_HAZE_ABILITY);
+    if (!ability || ability.IsNull()) return undefined;
+    return ability;
+  }
+
+  private isCorrosiveHaze(ability: CDOTABaseAbility): boolean {
+    const abilityName = ability.GetAbilityName();
+    return (
+      abilityName === CORROSIVE_HAZE_AWAKENED_ABILITY || abilityName === CORROSIVE_HAZE_ABILITY
+    );
+  }
+
+  private updateBonusArmorReduction(): void {
+    const parent = this.GetParent();
+    const corrosiveHaze = this.getCorrosiveHaze();
+    const previousValue = this.bonusArmorReduction;
+    if (parent.IsNull() || !corrosiveHaze || corrosiveHaze.IsNull()) {
+      this.bonusArmorReduction = 0;
+    } else {
+      const reductionPct = corrosiveHaze.GetSpecialValueFor('caster_armor_reduction_pct');
+      this.bonusArmorReduction = parent.PassivesDisabled()
+        ? 0
+        : Math.round(
+            Math.max(0, parent.GetPhysicalArmorValue(false)) *
+              Math.max(0, reductionPct / 100) *
+              100,
+          ) / 100;
+    }
+
+    if (this.bonusArmorReduction !== previousValue) {
+      this.SendBuffRefreshToClients();
+    }
+  }
+
+  private isFieldActive(): boolean {
+    const parent = this.GetParent();
+    if (parent.IsNull() || !parent.IsRealHero() || !parent.IsAlive()) return false;
+    if (parent.PassivesDisabled()) return false;
+
+    const corrosiveHaze = this.getCorrosiveHaze();
+    return !!corrosiveHaze && corrosiveHaze.GetLevel() > 0;
+  }
+
+  private applyField(): void {
+    if (!this.isFieldActive()) {
+      this.destroyFieldParticle();
+      return;
+    }
+
+    const parent = this.GetParent();
+    const corrosiveHaze = this.getCorrosiveHaze();
+    if (!corrosiveHaze) return;
+
+    const radius = corrosiveHaze.GetSpecialValueFor('field_radius');
+    if (radius <= 0) return;
+
+    this.ensureFieldParticle(radius);
+
+    const enemies = FindUnitsInRadius(
+      parent.GetTeamNumber(),
+      parent.GetAbsOrigin(),
+      undefined,
+      radius,
+      UnitTargetTeam.ENEMY,
+      UnitTargetType.HERO + UnitTargetType.BASIC,
+      UnitTargetFlags.MAGIC_IMMUNE_ENEMIES,
+      FindOrder.ANY,
+      false,
+    );
+
+    const baseDuration = corrosiveHaze.GetSpecialValueFor('duration');
+    for (const enemy of enemies) {
+      const duration = Math.max(0.01, baseDuration * (1 - enemy.GetStatusResistance()));
+      const existing = enemy.FindModifierByNameAndCaster(CORROSIVE_HAZE_MODIFIER, parent);
+      if (existing && !existing.IsNull()) {
+        existing.SetDuration(duration, true);
+        existing.ForceRefresh();
+      } else {
+        enemy.AddNewModifier(parent, corrosiveHaze, CORROSIVE_HAZE_MODIFIER, { duration });
+      }
+
+      this.applyBonusArmorReduction(enemy, corrosiveHaze, duration);
+    }
+  }
+
+  private applyBonusArmorReduction(
+    enemy: CDOTA_BaseNPC,
+    corrosiveHaze: CDOTABaseAbility,
+    duration: number,
+  ): void {
+    const parent = this.GetParent();
+    const modifierName = modifier_slardar_amplify_damage_awakened_bonus.name;
+    const existing = enemy.FindModifierByNameAndCaster(modifierName, parent);
+    if (existing && !existing.IsNull()) {
+      existing.SetDuration(Math.max(0.01, duration), true);
+      existing.ForceRefresh();
+      return;
+    }
+
+    enemy.AddNewModifier(parent, corrosiveHaze, modifierName, {
+      duration: Math.max(0.01, duration),
+    });
+  }
+
+  private ensureFieldParticle(radius: number): void {
+    const parent = this.GetParent();
+    if (parent.IsNull()) return;
+
+    if (this.fieldParticle === undefined) {
+      this.fieldParticle = ParticleManager.CreateParticle(
+        FIELD_PARTICLE,
+        ParticleAttachment.ABSORIGIN_FOLLOW,
+        parent,
+      );
+    }
+
+    ParticleManager.SetParticleControl(this.fieldParticle, 1, Vector(radius, radius, radius));
+  }
+
+  private destroyFieldParticle(): void {
+    if (this.fieldParticle === undefined) return;
+
+    ParticleManager.DestroyParticle(this.fieldParticle, false);
+    ParticleManager.ReleaseParticleIndex(this.fieldParticle);
+    this.fieldParticle = undefined;
+  }
+}
+
+/** 保持侵蚀雾霭的真实视域与水迹生命周期，仅承载觉醒护甲差值。 */
+@registerModifier('abilities/ts_abilities/special_bonus_unique_slardar_amplify_damage_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_slardar_amplify_damage_awakened_bonus extends BaseModifier {
+  private armorReduction = 0;
+
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsDebuff(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return !hasLearnedTalent(this.GetCaster(), SLARDAR_UNDISPELLABLE_HAZE_TALENT);
+  }
+
+  GetTexture(): string {
+    return CORROSIVE_HAZE_ABILITY;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [
+      ModifierFunction.PHYSICAL_ARMOR_BONUS,
+      ModifierFunction.TOOLTIP,
+      ModifierFunction.TOOLTIP2,
+    ];
+  }
+
+  GetModifierPhysicalArmorBonus(): number {
+    return -this.armorReduction;
+  }
+
+  OnTooltip(): number {
+    const ability = this.GetAbility();
+    const baseArmorReduction = ability
+      ? Math.abs(ability.GetSpecialValueFor('armor_reduction'))
+      : 0;
+    return baseArmorReduction + this.armorReduction;
+  }
+
+  OnTooltip2(): number {
+    return this.armorReduction;
+  }
+
+  OnCreated(): void {
+    if (!IsServer()) return;
+    this.SetHasCustomTransmitterData(true);
+    this.refreshArmorReduction();
+  }
+
+  OnRefresh(): void {
+    if (!IsServer()) return;
+    this.refreshArmorReduction();
+  }
+
+  AddCustomTransmitterData(): { armorReduction: number } {
+    return { armorReduction: this.armorReduction };
+  }
+
+  HandleCustomTransmitterData(data: { armorReduction: number }): void {
+    this.armorReduction = data.armorReduction;
+  }
+
+  private refreshArmorReduction(): void {
+    const caster = this.GetCaster();
+    const ability = this.GetAbility();
+    const previousValue = this.armorReduction;
+    if (!caster || caster.IsNull() || !ability || ability.IsNull() || caster.PassivesDisabled()) {
+      this.armorReduction = 0;
+    } else {
+      const reductionPct = Math.max(0, ability.GetSpecialValueFor('caster_armor_reduction_pct'));
+      this.armorReduction =
+        Math.round(Math.max(0, caster.GetPhysicalArmorValue(false)) * (reductionPct / 100) * 100) /
+        100;
+    }
+
+    if (this.armorReduction !== previousValue) {
+      this.SendBuffRefreshToClients();
+    }
+  }
+}

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,18 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 斯拉达 觉醒
+  {
+    heroName: 'npc_dota_hero_slardar',
+    targetAbility: 'slardar_amplify_damage',
+    newAbility: 'slardar_amplify_damage_awakened',
+    newLevel: 0,
+  },
+  {
+    heroName: 'npc_dota_hero_slardar',
+    newAbility: 'special_bonus_unique_slardar_amplify_damage_awaken',
+    newLevel: 1,
+  },
   // 斯拉克 觉醒
   {
     heroName: 'npc_dota_hero_slark',
@@ -251,6 +263,7 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  * 新觉醒发布时加入，下次发版由 awaken-ability skill 流程确认移出。
  */
 export const FREE_TRIAL_HEROES: string[] = [
+  'npc_dota_hero_slardar', // 斯拉达
   'npc_dota_hero_slark', // 斯拉克
   'npc_dota_hero_abaddon', // 亚巴顿
   'npc_dota_hero_skywrath_mage', // 天怒法师


### PR DESCRIPTION
## Summary

- Keep Corrosive Haze actively castable while adding a fixed 500-radius awakening domain.
- Continuously apply the current ultimate level in the domain, reapply it after dispels, and preserve its normal duration after enemies leave.
- Add armor reduction equal to 50% of Slardar's current total armor, with awakened ability and status tooltips in Simplified Chinese, English, and Russian.

## Checklist

- [x] User verified the final behavior in Dota Tools.
- [x] VScripts and Panorama builds pass.
- [x] Awakening replacement tests, targeted lint, KV/localization parsing, and image checks pass.
