### PR TITLE
Add Anti-Mage mana suppression awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1285,6 +1285,17 @@
 		///////////////////////////////////////////////////
 // 					Awaken Abilities 觉醒技能
 
+		// 敌法师 觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken"						"<font color='#d000ff'>Mana Suppression Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_Description"			"Casting Blink prevents nearby enemies from gaining or regenerating mana and causes enemy heroes to lose mana equal to a portion of their maximum mana. Casting Mana Void also simultaneously casts Mana Void on other enemy heroes near the selected hero. These simultaneous casts ignore Spell Block and Spell Reflection, and each hero is affected only once."
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_SummaryDescription"	"Blink suppresses nearby enemies' mana, while Mana Void is simultaneously cast on other enemy heroes near the selected hero."
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_blink_radius"			"BLINK EFFECT RADIUS:"
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_mana_lock_duration"		"MANA GAIN PREVENTION DURATION:"
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_max_mana_reduction_pct"	"MANA LOST BASED ON MAX MANA:"
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_mana_void_spread_radius"	"MANA VOID SIMULTANEOUS CAST RADIUS:"
+		"DOTA_Tooltip_modifier_special_bonus_unique_antimage_mana_suppression_awaken"					"<font color='#d000ff'>Mana Suppression Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_antimage_mana_suppression_awaken_Description"			"Casting Blink prevents enemies within <font color='#FFFFFF'><b>1000</b></font> of the destination from gaining or regenerating mana for <font color='#FFFFFF'><b>6</b></font> seconds and causes enemy heroes to lose mana equal to <font color='#FFFFFF'><b>50%%</b></font> of their maximum mana. Casting Mana Void also simultaneously casts Mana Void on other enemy heroes within <font color='#FFFFFF'><b>500</b></font> of the selected hero. These simultaneous casts ignore Spell Block and Spell Reflection, and each hero is affected only once."
+
 		// 炸弹人 觉醒
 		"DOTA_Tooltip_ability_techies_squees_scope"					"<font color='#d000ff'>Squee's Scope Awakened</font>"
 		"DOTA_Tooltip_ability_techies_squees_scope_Description"		"Techies gains %attack_range_tooltip% attack range and attack projectile speed for each point of attack speed."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -693,6 +693,17 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Пробуждение Shallow Grave</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"После применения Shallow Grave на себя или союзника цель получает эффект <font color='#FFCC66'>Black King Bar</font> на время действия Shallow Grave."
 
+		// 敌法师 觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken"						"<font color='#d000ff'>Подавление маны · Пробуждение</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_Description"			"Применение Blink запрещает ближайшим врагам получать и восстанавливать ману, а вражеские герои теряют ману в размере части от максимального запаса. Применение Mana Void также одновременно применяет Mana Void к другим вражеским героям рядом с выбранным героем. Эти применения игнорируют блокировку и отражение заклинаний, и каждый герой подвергается эффекту только один раз."
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_SummaryDescription"	"Blink подавляет ману ближайших врагов, а Mana Void одновременно применяется к другим вражеским героям рядом с выбранным героем."
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_blink_radius"			"РАДИУС ЭФФЕКТА BLINK:"
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_mana_lock_duration"		"ДЛИТЕЛЬНОСТЬ ЗАПРЕТА МАНЫ:"
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_max_mana_reduction_pct"	"ПОТЕРЯ МАНЫ ОТ МАКСИМУМА:"
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_mana_void_spread_radius"	"РАДИУС ОДНОВРЕМЕННОГО MANA VOID:"
+		"DOTA_Tooltip_modifier_special_bonus_unique_antimage_mana_suppression_awaken"					"<font color='#d000ff'>Подавление маны · Пробуждение</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_antimage_mana_suppression_awaken_Description"			"Применение Blink запрещает врагам в радиусе <font color='#FFFFFF'><b>1000</b></font> от точки назначения получать и восстанавливать ману в течение <font color='#FFFFFF'><b>6</b></font> сек. и заставляет вражеских героев потерять ману в размере <font color='#FFFFFF'><b>50%%</b></font> от максимального запаса. Применение Mana Void также одновременно применяет Mana Void к другим вражеским героям в радиусе <font color='#FFFFFF'><b>500</b></font> от выбранного героя. Эти применения игнорируют блокировку и отражение заклинаний, и каждый герой подвергается эффекту только один раз."
+
 		// Slark Essence Erosion - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>Разъедание сущности · Пробуждение</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"Когда Slark убивает вражеского героя, он навсегда забирает %permanent_steal_pct%%% от общего количества атрибутов, похищенных у этого героя его Essence Shift.<br>Базовые атрибуты вражеского героя не опускаются ниже <font color='#FFFFFF'><b>1</b></font>."

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1280,6 +1280,17 @@
 		///////////////////////////////////////////////////
 // 					Awaken Abilities 觉醒技能
 
+		// 敌法师 觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken"						"<font color='#d000ff'>法力禁域 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_Description"			"施放闪烁时，使落点附近的敌人无法获得或恢复魔法，并使敌方英雄损失等同一部分最大魔法值的魔法。施放法力虚空时，还会对所选英雄附近的其他敌方英雄同步释放法力虚空。同步释放无视法术格挡和法术反弹，每个英雄只会受到一次。"
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_SummaryDescription"	"闪烁压制附近敌人的魔法，法力虚空会对所选英雄附近的其他敌方英雄同步释放。"
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_blink_radius"			"闪烁作用范围："
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_mana_lock_duration"		"无法获得或恢复魔法时间："
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_max_mana_reduction_pct"	"损失魔法（最大魔法值）："
+		"DOTA_Tooltip_ability_special_bonus_unique_antimage_mana_suppression_awaken_mana_void_spread_radius"	"法力虚空同步释放范围："
+		"DOTA_Tooltip_modifier_special_bonus_unique_antimage_mana_suppression_awaken"					"<font color='#d000ff'>法力禁域 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_antimage_mana_suppression_awaken_Description"			"施放闪烁时，使落点<font color='#FFFFFF'><b>1000</b></font>范围内的敌人在<font color='#FFFFFF'><b>6</b></font>秒内无法获得或恢复魔法，并使敌方英雄损失等同<font color='#FFFFFF'><b>50%%</b></font>最大魔法值的魔法。施放法力虚空时，还会对所选英雄<font color='#FFFFFF'><b>500</b></font>范围内的其他敌方英雄同步释放法力虚空。同步释放无视法术格挡和法术反弹，每个英雄只会受到一次。"
+
 		// 炸弹人 觉醒
 		"DOTA_Tooltip_ability_techies_squees_scope"					"<font color='#d000ff'>斯奎的瞄准镜 觉醒</font>"
 		"DOTA_Tooltip_ability_techies_squees_scope_Description"		"每点攻击速度都会让工程师获得%attack_range_tooltip%攻击距离和攻击弹道速度。"

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -5,6 +5,33 @@
 	// 英雄专属强化/替换技能，通过抽奖池获得
 	//=================================================================================================================
 
+	// 敌法师 觉醒
+	"special_bonus_unique_antimage_mana_suppression_awaken"
+	{
+		"BaseClass"					"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/special_bonus_unique_antimage_mana_suppression_awaken"
+		"AbilityBehavior"			"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_SKIP_FOR_KEYBINDS"
+		"AbilityTextureName"		"antimage_blink"
+		"IsOnCastBar"				"0"
+		"MaxLevel"					"1"
+
+		"AbilityValues"
+		{
+			"blink_radius"					"1000"
+			"mana_lock_duration"
+			{
+				"value"						"6"
+				"display_type"				"kBuffDuration"
+			}
+			"max_mana_reduction_pct"
+			{
+				"value"						"50"
+				"display_type"				"kManaPercentage"
+			}
+			"mana_void_spread_radius"		"500"
+		}
+	}
+
 	// 斯拉克 精华侵蚀觉醒
 	"special_bonus_unique_slark_permanent_essence_awaken"
 	{

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,11 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_antimage',
+    abilityName: 'special_bonus_unique_antimage_mana_suppression_awaken',
+    freeTrial: true,
+  },
+  {
     heroName: 'npc_dota_hero_slark',
     abilityName: 'special_bonus_unique_slark_permanent_essence_awaken',
     freeTrial: true,

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_antimage_mana_suppression_awaken.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_antimage_mana_suppression_awaken.ts
@@ -1,0 +1,145 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+
+const BLINK_ABILITY = 'antimage_blink';
+const MANA_BREAK_ABILITY = 'antimage_mana_break';
+const MANA_VOID_ABILITY = 'antimage_mana_void';
+const NATIVE_MANA_LOCK_MODIFIER = 'modifier_antimage_empowered_mana_break_debuff';
+const MANA_VOID_PARTICLE = 'particles/units/heroes/hero_antimage/antimage_manavoid.vpcf';
+const MANA_VOID_SOUND = 'Hero_Antimage.ManaVoid';
+
+/** 敌法师觉醒：闪烁压制魔法，法力虚空向附近英雄同步释放。 */
+@registerAbility('special_bonus_unique_antimage_mana_suppression_awaken')
+export class SpecialBonusUniqueAntimageManaSuppressionAwaken extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return modifier_special_bonus_unique_antimage_mana_suppression_awaken.name;
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_antimage_mana_suppression_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_antimage_mana_suppression_awaken extends BaseModifier {
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return BLINK_ABILITY;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [ModifierFunction.ON_ABILITY_FULLY_CAST];
+  }
+
+  OnAbilityFullyCast(event: ModifierAbilityEvent): void {
+    if (!IsServer()) return;
+
+    const antiMage = this.GetParent();
+    if (event.unit !== antiMage) return;
+
+    const abilityName = event.ability.GetAbilityName();
+    if (abilityName === BLINK_ABILITY) {
+      this.applyBlinkEffects(antiMage);
+    } else if (abilityName === MANA_VOID_ABILITY) {
+      this.spreadManaVoid(antiMage, event.ability);
+    }
+  }
+
+  private applyBlinkEffects(antiMage: CDOTA_BaseNPC): void {
+    const awaken = this.GetAbility();
+    const manaBreak = antiMage.FindAbilityByName(MANA_BREAK_ABILITY);
+    if (!awaken || awaken.IsNull() || !manaBreak || manaBreak.IsNull()) return;
+
+    const radius = awaken.GetSpecialValueFor('blink_radius');
+    const duration = awaken.GetSpecialValueFor('mana_lock_duration');
+    const manaReductionPct = awaken.GetSpecialValueFor('max_mana_reduction_pct');
+    const enemies = FindUnitsInRadius(
+      antiMage.GetTeamNumber(),
+      antiMage.GetAbsOrigin(),
+      undefined,
+      radius,
+      UnitTargetTeam.ENEMY,
+      UnitTargetType.HERO + UnitTargetType.BASIC,
+      UnitTargetFlags.MAGIC_IMMUNE_ENEMIES,
+      FindOrder.ANY,
+      false,
+    );
+
+    for (const enemy of enemies) {
+      enemy.AddNewModifier(antiMage, manaBreak, NATIVE_MANA_LOCK_MODIFIER, { duration });
+
+      if (!enemy.IsRealHero() || enemy.IsIllusion()) continue;
+      const manaLoss = enemy.GetMaxMana() * (manaReductionPct / 100);
+      enemy.SetMana(Math.max(0, enemy.GetMana() - manaLoss));
+    }
+  }
+
+  private spreadManaVoid(antiMage: CDOTA_BaseNPC, manaVoid: CDOTABaseAbility): void {
+    const awaken = this.GetAbility();
+    const primaryTarget = manaVoid.GetCursorTarget();
+    if (!awaken || awaken.IsNull() || !primaryTarget || primaryTarget.IsNull()) return;
+
+    const spreadRadius = awaken.GetSpecialValueFor('mana_void_spread_radius');
+    const targets = FindUnitsInRadius(
+      antiMage.GetTeamNumber(),
+      primaryTarget.GetAbsOrigin(),
+      undefined,
+      spreadRadius,
+      UnitTargetTeam.ENEMY,
+      UnitTargetType.HERO,
+      UnitTargetFlags.MAGIC_IMMUNE_ENEMIES,
+      FindOrder.ANY,
+      false,
+    );
+
+    for (const target of targets) {
+      if (target === primaryTarget || !target.IsRealHero() || target.IsIllusion()) continue;
+      this.applyManaVoidToTarget(antiMage, manaVoid, target);
+    }
+  }
+
+  private applyManaVoidToTarget(
+    antiMage: CDOTA_BaseNPC,
+    manaVoid: CDOTABaseAbility,
+    target: CDOTA_BaseNPC,
+  ): void {
+    const missingMana = Math.max(0, target.GetMaxMana() - target.GetMana());
+    const damage = missingMana * manaVoid.GetSpecialValueFor('mana_void_damage_per_mana');
+    if (damage > 0) {
+      ApplyDamage({
+        victim: target,
+        attacker: antiMage,
+        damage,
+        damage_type: manaVoid.GetAbilityDamageType(),
+        ability: manaVoid,
+      });
+    }
+
+    const stunDuration = manaVoid.GetSpecialValueFor('mana_void_ministun');
+    if (target.IsAlive() && stunDuration > 0) {
+      target.AddNewModifier(antiMage, manaVoid, 'modifier_stunned', {
+        duration: stunDuration * (1 - target.GetStatusResistance()),
+      });
+    }
+
+    const particle = ParticleManager.CreateParticle(
+      MANA_VOID_PARTICLE,
+      ParticleAttachment.ABSORIGIN_FOLLOW,
+      target,
+    );
+    ParticleManager.ReleaseParticleIndex(particle);
+    EmitSoundOn(MANA_VOID_SOUND, target);
+  }
+}

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,12 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 敌法师 觉醒
+  {
+    heroName: 'npc_dota_hero_antimage',
+    newAbility: 'special_bonus_unique_antimage_mana_suppression_awaken',
+    newLevel: 1,
+  },
   // 斯拉克 觉醒
   {
     heroName: 'npc_dota_hero_slark',
@@ -251,6 +257,7 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  * 新觉醒发布时加入，下次发版由 awaken-ability skill 流程确认移出。
  */
 export const FREE_TRIAL_HEROES: string[] = [
+  'npc_dota_hero_antimage', // 敌法师
   'npc_dota_hero_slark', // 斯拉克
   'npc_dota_hero_abaddon', // 亚巴顿
   'npc_dota_hero_skywrath_mage', // 天怒法师


### PR DESCRIPTION
## Issue

N/A

## Changes

- Add Anti-Mage's `Mana Suppression Awakened` passive with a visible permanent status.
- Blink prevents enemies within 1000 range from gaining or regenerating mana for 6 seconds and removes 50% of maximum mana from enemy heroes.
- Mana Void is simultaneously applied once to each other enemy hero within 500 range of the selected hero, ignoring Spell Block and Spell Reflection.
- Add awakening configuration, free-trial wiring, KV values, and Simplified Chinese, English, and Russian localization.

## Checklist

- [x] User confirmed the final in-game behavior and wording work correctly.
- [x] `npm run build:vscripts`
- [x] `npm run build:panorama`
- [x] `npm run lint`
- [x] `npx jest awaken-replacer --runInBand` (16 tests passed)
