### PR TITLE
Add Bounty Hunter item steal awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3572,6 +3572,17 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Shallow Grave Awakened</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"After casting Shallow Grave on yourself or an ally, the target gains the <font color='#FFCC66'>Black King Bar</font> effect for the duration of Shallow Grave."
 
+		// 赏金猎人 忍术觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken"					"<font color='#d000ff'>Jinada Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken_Description"		"When a Jinada attack hits a real enemy hero, it has a chance to steal one random sellable, non-stackable, non-recipe item from their inventory or backpack. The stolen item belongs to Bounty Hunter and can be sold.<br>After a successful theft, that enemy is protected from further thefts for %protection_duration% seconds. This effect does not trigger while Bounty Hunter has no empty item slot. The theft chance stops increasing after Jinada reaches level 4."
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken_SummaryDescription"	"Jinada attacks can steal an enemy hero's item; a successful theft temporarily protects that enemy."
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken_steal_chance_pct"		"ITEM STEAL CHANCE:"
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken_protection_duration"	"THEFT PROTECTION DURATION:"
+		"DOTA_Tooltip_modifier_special_bonus_unique_bounty_hunter_item_steal_awaken"				"<font color='#d000ff'>Jinada Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_bounty_hunter_item_steal_awaken_Description"			"When a Jinada attack hits a real enemy hero, it has a <font color='#FFFFFF'><b>5%%/10%%/15%%/20%%</b></font> chance to steal one sellable item. The stolen item belongs to Bounty Hunter and can be sold. After a successful theft, that enemy gains <font color='#FFFFFF'><b>60</b></font> seconds of theft protection. This effect does not trigger while Bounty Hunter has no empty item slot."
+		"DOTA_Tooltip_modifier_bounty_hunter_item_steal_protection"							"Theft Protection"
+		"DOTA_Tooltip_modifier_bounty_hunter_item_steal_protection_Description"					"An item was recently stolen by Bounty Hunter. Jinada Awakened cannot steal from this hero again for a short time."
+
 		// Slark Essence Erosion - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>Essence Erosion Awakened</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"When Slark kills an enemy hero, he permanently steals %permanent_steal_pct%%% of the total attributes his Essence Shift has taken from that hero.<br>An enemy hero's base attributes never fall below <font color='#FFFFFF'><b>1</b></font>."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -693,6 +693,17 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Пробуждение Shallow Grave</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"После применения Shallow Grave на себя или союзника цель получает эффект <font color='#FFCC66'>Black King Bar</font> на время действия Shallow Grave."
 
+		// 赏金猎人 忍术觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken"					"<font color='#d000ff'>Дзинада · Пробуждение</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken_Description"		"Когда атака с Jinada попадает по настоящему вражескому герою, она может похитить один случайный продаваемый, нескладываемый предмет, не являющийся рецептом, из инвентаря или ранца цели. Похищенный предмет принадлежит Bounty Hunter и может быть продан.<br>После успешной кражи этот враг получает защиту от новых краж на %protection_duration% сек. Эффект не срабатывает, если у Bounty Hunter нет свободной ячейки. После 4-го уровня Jinada шанс кражи больше не растёт."
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken_SummaryDescription"	"Атаки с Jinada могут похитить предмет вражеского героя; успешная кража временно защищает эту цель."
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken_steal_chance_pct"		"ШАНС КРАЖИ ПРЕДМЕТА:"
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken_protection_duration"	"ДЛИТЕЛЬНОСТЬ ЗАЩИТЫ ОТ КРАЖИ:"
+		"DOTA_Tooltip_modifier_special_bonus_unique_bounty_hunter_item_steal_awaken"				"<font color='#d000ff'>Дзинада · Пробуждение</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_bounty_hunter_item_steal_awaken_Description"			"Когда атака с Jinada попадает по настоящему вражескому герою, она с вероятностью <font color='#FFFFFF'><b>5%%/10%%/15%%/20%%</b></font> похищает один продаваемый предмет. Похищенный предмет принадлежит Bounty Hunter и может быть продан. После успешной кражи враг получает защиту на <font color='#FFFFFF'><b>60</b></font> сек. Эффект не срабатывает, если у Bounty Hunter нет свободной ячейки."
+		"DOTA_Tooltip_modifier_bounty_hunter_item_steal_protection"							"Защита от кражи"
+		"DOTA_Tooltip_modifier_bounty_hunter_item_steal_protection_Description"					"Bounty Hunter недавно похитил предмет этого героя. Некоторое время Jinada Awakened не может снова его обокрасть."
+
 		// Slark Essence Erosion - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>Разъедание сущности · Пробуждение</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"Когда Slark убивает вражеского героя, он навсегда забирает %permanent_steal_pct%%% от общего количества атрибутов, похищенных у этого героя его Essence Shift.<br>Базовые атрибуты вражеского героя не опускаются ниже <font color='#FFFFFF'><b>1</b></font>."

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3581,6 +3581,17 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>薄葬 觉醒</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"对自己或队友施放薄葬后，目标在薄葬持续期间获得<font color='#FFCC66'>黑皇杖</font>效果。"
 
+		// 赏金猎人 忍术觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken"					"<font color='#d000ff'>忍术 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken_Description"		"忍术攻击命中敌方真实英雄时，有一定几率随机偷取其主物品栏或背包中的一件可出售、不可叠加的非配方装备。偷来的装备归赏金猎人所有，可以出售。<br>成功后，该敌人会获得%protection_duration%秒防偷保护。赏金猎人没有空余物品栏时不会触发。忍术达到4级后偷取几率不再提高。"
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken_SummaryDescription"	"忍术攻击有几率偷取敌方英雄的一件装备；同一敌人被偷取后会暂时获得保护。"
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken_steal_chance_pct"		"装备偷取几率："
+		"DOTA_Tooltip_ability_special_bonus_unique_bounty_hunter_item_steal_awaken_protection_duration"	"防偷保护时间："
+		"DOTA_Tooltip_modifier_special_bonus_unique_bounty_hunter_item_steal_awaken"				"<font color='#d000ff'>忍术 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_bounty_hunter_item_steal_awaken_Description"			"忍术攻击命中敌方真实英雄时，有<font color='#FFFFFF'><b>5%%/10%%/15%%/20%%</b></font>几率偷取一件可出售装备。偷来的装备归赏金猎人所有，可以出售。成功后，该敌人获得<font color='#FFFFFF'><b>60</b></font>秒防偷保护。赏金猎人没有空余物品栏时不会触发。"
+		"DOTA_Tooltip_modifier_bounty_hunter_item_steal_protection"							"防偷保护"
+		"DOTA_Tooltip_modifier_bounty_hunter_item_steal_protection_Description"					"装备刚被赏金猎人偷取过，暂时不会再次受到忍术觉醒的装备偷取。"
+
 		// 斯拉克 精华侵蚀觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>精华侵蚀 觉醒</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"斯拉克击杀敌人时，将能量转移偷取属性总量的%permanent_steal_pct%%%永久偷走该英雄的全属性。<br>敌方英雄的基础属性最低保留<font color='#FFFFFF'><b>1</b></font>点。"

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -5,6 +5,23 @@
 	// 英雄专属强化/替换技能，通过抽奖池获得
 	//=================================================================================================================
 
+	// 赏金猎人 忍术觉醒
+	"special_bonus_unique_bounty_hunter_item_steal_awaken"
+	{
+		"BaseClass"					"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/special_bonus_unique_bounty_hunter_item_steal_awaken"
+		"AbilityBehavior"			"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_SKIP_FOR_KEYBINDS"
+		"AbilityTextureName"		"bounty_hunter_jinada"
+		"IsOnCastBar"				"0"
+		"MaxLevel"					"4"
+
+		"AbilityValues"
+		{
+			"steal_chance_pct"			"5 10 15 20"
+			"protection_duration"		"60"
+		}
+	}
+
 	// 斯拉克 精华侵蚀觉醒
 	"special_bonus_unique_slark_permanent_essence_awaken"
 	{

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,11 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_bounty_hunter',
+    abilityName: 'special_bonus_unique_bounty_hunter_item_steal_awaken',
+    freeTrial: true,
+  },
+  {
     heroName: 'npc_dota_hero_slark',
     abilityName: 'special_bonus_unique_slark_permanent_essence_awaken',
     freeTrial: true,

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_bounty_hunter_item_steal_awaken.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_bounty_hunter_item_steal_awaken.ts
@@ -1,0 +1,190 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+
+const JINADA_ABILITY = 'bounty_hunter_jinada';
+const JINADA_ICON = 'bounty_hunter_jinada';
+const FIRST_ITEM_SLOT = InventorySlot.SLOT_1;
+const LAST_BACKPACK_SLOT = InventorySlot.SLOT_9;
+const MAX_STEAL_CHANCE_LEVEL = 4;
+
+@registerAbility('special_bonus_unique_bounty_hunter_item_steal_awaken')
+export class SpecialBonusUniqueBountyHunterItemStealAwaken extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return modifier_special_bonus_unique_bounty_hunter_item_steal_awaken.name;
+  }
+}
+
+/** 赏金猎人觉醒：忍术攻击有概率把敌方英雄的一件可出售装备转移给自己。 */
+@registerModifier('abilities/ts_abilities/special_bonus_unique_bounty_hunter_item_steal_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_bounty_hunter_item_steal_awaken extends BaseModifier {
+  private jinadaAttackRecords: Record<number, boolean> = {};
+
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return JINADA_ICON;
+  }
+
+  OnCreated(): void {
+    if (!IsServer()) return;
+    this.jinadaAttackRecords = {};
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [
+      ModifierFunction.ON_ATTACK_RECORD,
+      ModifierFunction.ON_ATTACK_LANDED,
+      ModifierFunction.ON_ATTACK_RECORD_DESTROY,
+    ];
+  }
+
+  OnAttackRecord(event: ModifierAttackEvent): void {
+    if (!IsServer()) return;
+
+    const parent = this.GetParent();
+    const target = event.target;
+    const awaken = this.GetAbility();
+    if (
+      event.attacker !== parent ||
+      event.no_attack_cooldown ||
+      !target ||
+      target.IsNull() ||
+      !target.IsRealHero() ||
+      target.IsIllusion() ||
+      target.GetTeamNumber() === parent.GetTeamNumber() ||
+      target.HasModifier(modifier_bounty_hunter_item_steal_protection.name) ||
+      !parent.IsRealHero() ||
+      parent.IsIllusion() ||
+      parent.PassivesDisabled() ||
+      !awaken ||
+      awaken.IsNull() ||
+      awaken.GetLevel() <= 0 ||
+      !awaken.IsActivated()
+    ) {
+      return;
+    }
+
+    const jinada = parent.FindAbilityByName(JINADA_ABILITY);
+    if (
+      !jinada ||
+      jinada.IsNull() ||
+      jinada.GetLevel() <= 0 ||
+      !jinada.IsActivated() ||
+      !jinada.IsCooldownReady()
+    ) {
+      return;
+    }
+
+    this.jinadaAttackRecords[event.record] = true;
+  }
+
+  OnAttackLanded(event: ModifierAttackEvent): void {
+    if (!IsServer() || !this.jinadaAttackRecords[event.record]) return;
+    delete this.jinadaAttackRecords[event.record];
+
+    const bountyHunter = this.GetParent();
+    const target = event.target;
+    const awaken = this.GetAbility();
+    if (
+      event.attacker !== bountyHunter ||
+      !target ||
+      target.IsNull() ||
+      !target.IsRealHero() ||
+      target.IsIllusion() ||
+      target.GetTeamNumber() === bountyHunter.GetTeamNumber() ||
+      target.HasModifier(modifier_bounty_hunter_item_steal_protection.name) ||
+      bountyHunter.PassivesDisabled() ||
+      !awaken ||
+      awaken.IsNull() ||
+      awaken.GetLevel() <= 0 ||
+      !awaken.IsActivated() ||
+      !this.hasEmptyInventorySlot(bountyHunter)
+    ) {
+      return;
+    }
+
+    const jinada = bountyHunter.FindAbilityByName(JINADA_ABILITY);
+    if (!jinada || jinada.IsNull() || jinada.GetLevel() <= 0) return;
+
+    const chanceLevel = Math.min(jinada.GetLevel(), MAX_STEAL_CHANCE_LEVEL) - 1;
+    const stealChance = awaken.GetLevelSpecialValueFor('steal_chance_pct', chanceLevel);
+    if (!RollPseudoRandomPercentage(stealChance, 0, bountyHunter)) return;
+
+    const items = this.getStealableItems(target);
+    if (items.length === 0) return;
+
+    const stolenItem = items[RandomInt(0, items.length - 1)];
+    target.TakeItem(stolenItem);
+    bountyHunter.AddItem(stolenItem);
+    stolenItem.SetPurchaser(bountyHunter);
+
+    target.AddNewModifier(bountyHunter, awaken, modifier_bounty_hunter_item_steal_protection.name, {
+      duration: awaken.GetSpecialValueFor('protection_duration'),
+    });
+  }
+
+  OnAttackRecordDestroy(event: ModifierAttackEvent): void {
+    if (!IsServer()) return;
+    delete this.jinadaAttackRecords[event.record];
+  }
+
+  private hasEmptyInventorySlot(hero: CDOTA_BaseNPC): boolean {
+    for (let slot = FIRST_ITEM_SLOT; slot <= LAST_BACKPACK_SLOT; slot++) {
+      if (!hero.GetItemInSlot(slot)) return true;
+    }
+    return false;
+  }
+
+  private getStealableItems(target: CDOTA_BaseNPC): CDOTA_Item[] {
+    const items: CDOTA_Item[] = [];
+    for (let slot = FIRST_ITEM_SLOT; slot <= LAST_BACKPACK_SLOT; slot++) {
+      const item = target.GetItemInSlot(slot);
+      if (
+        item &&
+        !item.IsNull() &&
+        item.GetCost() > 0 &&
+        item.IsSellable() &&
+        !item.IsRecipe() &&
+        !item.IsStackable()
+      ) {
+        items.push(item);
+      }
+    }
+    return items;
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_bounty_hunter_item_steal_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_bounty_hunter_item_steal_protection extends BaseModifier {
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return JINADA_ICON;
+  }
+}

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,12 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 赏金猎人 觉醒
+  {
+    heroName: 'npc_dota_hero_bounty_hunter',
+    newAbility: 'special_bonus_unique_bounty_hunter_item_steal_awaken',
+    newLevel: 1,
+  },
   // 斯拉克 觉醒
   {
     heroName: 'npc_dota_hero_slark',
@@ -251,6 +257,7 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  * 新觉醒发布时加入，下次发版由 awaken-ability skill 流程确认移出。
  */
 export const FREE_TRIAL_HEROES: string[] = [
+  'npc_dota_hero_bounty_hunter', // 赏金猎人
   'npc_dota_hero_slark', // 斯拉克
   'npc_dota_hero_abaddon', // 亚巴顿
   'npc_dota_hero_skywrath_mage', // 天怒法师


### PR DESCRIPTION
## Checklist

- [x] I have tested the changes works well.

## Release Note

```
[b]游戏性更新 v5.51a[/b]

- 新增赏金猎人觉醒：忍术有几率偷取敌方英雄的一件可出售装备，成功后该敌人获得1分钟防偷保护。
```

```
[b]Gameplay update v5.51a[/b]

- Added Bounty Hunter awakening: Jinada can steal one sellable item from an enemy hero, granting that enemy one minute of theft protection after a successful theft.
```
