### PR TITLE
Teleport bots to fountain on safe retreat

### DIFF
--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -9188,7 +9188,7 @@
 			"slow_attack_speed"
 			{
 				"value" "-200 -300 -400 -500"	// -110 -160 -210 x2
-				"special_bonus_unique_enchantress_3" "-7666"		// -70
+				"special_bonus_unique_enchantress_3" "-766"		// -70
 			}
 		}
 	}

--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -2478,9 +2478,9 @@
 			"bonus_strength"				"180"
 			"bonus_agility"					"180"
 			"bonus_intellect"				"180"
-			"bonus_attack_speed"			"140"
+			"bonus_attack_speed"			"120"
 			"movement_speed_percent_bonus"	"40"
-			"status_resistance"				"50"
+			"status_resistance"				"46"
 			"hp_regen_amp"					"80"
 			"mana_regen_multiplier"			"120"
 			"spell_amp"						"60"
@@ -5278,8 +5278,8 @@
 		{
 				"bonus_strength"		"60"	// 16
 				"bonus_agility"			"60"	// 16
-				"status_resistance"		"35"	// 15
-				"bonus_attack_speed"	"50"	// 20
+				"status_resistance"		"30"	// 15
+				"bonus_attack_speed"	"40"	// 20
 				"movement_speed_percent_bonus"	"25" // 12
 				"hp_regen_amp"			"40"	// 25
 				"slow_resistance"		"50"	// 25
@@ -5314,7 +5314,7 @@
 		{
 				"bonus_agility"			"60"
 				"bonus_intellect"		"60"
-				"bonus_attack_speed"	"50" // 20
+				"bonus_attack_speed"	"40" // 20
 				"mana_regen_multiplier"	"60" // 30
 				"movement_speed_percent_bonus"	"25" // 12
 				"spell_amp"				"25" // 12

--- a/src/vscripts/ai/action/action-move.ts
+++ b/src/vscripts/ai/action/action-move.ts
@@ -44,15 +44,6 @@ export class ActionMove {
   }
 
   static GetAwayFromTower(hero: CDOTA_BaseNPC_Hero, enemyTower: CDOTA_BaseNPC): boolean {
-    // 如果英雄残血，return false
-    if (hero.GetHealthPercent() < 0.2) {
-      return false;
-    }
-    // const direction = hero
-    //   .GetAbsOrigin()
-    //   // 远离天辉泉水方向
-    //   .__sub(Vector(-7200, -6700, 386))
-    //   .Normalized();
     if (!enemyTower) {
       return false;
     }

--- a/src/vscripts/ai/hero/bot-base.ts
+++ b/src/vscripts/ai/hero/bot-base.ts
@@ -44,7 +44,7 @@ export class BotBaseAIModifier extends BaseModifier {
   protected readonly AttackRangePushHero: number = 900;
 
   // 撤退回泉水的血量上限：高于此值多半只是躲塔或让位，不值得消耗卷轴
-  protected readonly RetreatTeleportMaxHealthPercent: number = 50;
+  protected readonly RetreatTeleportMaxHealthPercent: number = 30;
   // 传送引导约 3 秒，塔攻击距离 700 之外再留一段缓冲，避免刚起手就被塔火力打断
   protected readonly RetreatTeleportTowerSafeRange: number = 1200;
 
@@ -258,6 +258,7 @@ export class BotBaseAIModifier extends BaseModifier {
     if (!fountain) {
       return false;
     }
+    print(`[AI] HeroBase Retreat TryTeleport ${this.hero.GetUnitName()} 回泉水`);
     this.hero.CastAbilityOnPosition(fountain, scroll, this.hero.GetPlayerOwnerID());
     return true;
   }

--- a/src/vscripts/ai/hero/bot-base.ts
+++ b/src/vscripts/ai/hero/bot-base.ts
@@ -16,8 +16,8 @@ import { HeroUtil } from './hero-util';
 
 @registerModifier('ai/hero/bot-base')
 export class BotBaseAIModifier extends BaseModifier {
-  protected readonly ThinkInterval: number = 0.4;
-  protected readonly ThinkIntervalTool: number = 0.4;
+  protected readonly ThinkInterval: number = 0.5;
+  protected readonly ThinkIntervalTool: number = 0.5;
 
   // 持续动作结束时间
   protected readonly continueActionTime: number = 8;
@@ -42,6 +42,9 @@ export class BotBaseAIModifier extends BaseModifier {
   // 推塔时贴上去的最小距离：近战在此距离内才走过去A，远程则用自身攻击范围
   protected readonly MinPushTowerRange: number = 300;
   protected readonly AttackRangePushHero: number = 900;
+
+  // 撤退回泉水的血量上限：高于此值多半只是躲塔或让位，不值得消耗卷轴
+  protected readonly RetreatTeleportMaxHealthPercent: number = 50;
 
   public PushLevel: number = 10;
 
@@ -115,6 +118,7 @@ export class BotBaseAIModifier extends BaseModifier {
     this.mode = GameRules.AI.FSA.GetMode(this);
     if (this.mode === ModeEnum.RETREAT) {
       GameRules.AI.BotTeam?.cancelJungleRecoveryMovement(this.hero);
+      GameRules.AI.BotTeam?.suppressLaneRecoveryForRetreat(this.hero);
     } else if (GameRules.AI.BotTeam?.isJungleRecoveryMovementActive(this.hero)) {
       return;
     }
@@ -198,6 +202,10 @@ export class BotBaseAIModifier extends BaseModifier {
       return true;
     }
 
+    if (this.TryTeleport()) {
+      return true;
+    }
+
     // 撤离动作持续
     const enemyTower = this.FindNearestEnemyTowerInvulnerable();
     if (enemyTower) {
@@ -207,6 +215,49 @@ export class BotBaseAIModifier extends BaseModifier {
     }
 
     return false;
+  }
+
+  /**
+   * 撤退且四下无追兵时，是否该直接传送回泉水而不是一路走回家。
+   */
+  protected ShouldRetreatTeleportToFountain(): boolean {
+    if (this.mode !== ModeEnum.RETREAT) {
+      return false;
+    }
+    if (
+      this.hero.IsMuted() ||
+      this.hero.GetHealthPercent() >= this.RetreatTeleportMaxHealthPercent
+    ) {
+      return false;
+    }
+    if (this.aroundEnemyHeroes.length > 0) {
+      return false;
+    }
+    // 敌方塔攻击范围内开引导会被打断
+    const enemyTower = this.FindNearestEnemyTowerInvulnerable();
+    if (enemyTower && HeroUtil.IsInAttackRange(enemyTower, this.hero)) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * 撤退无追兵时用 TP 卷轴传送回自家泉水。英雄自带更好的传送手段时覆盖此方法。
+   */
+  protected TryTeleport(): boolean {
+    if (!this.ShouldRetreatTeleportToFountain()) {
+      return false;
+    }
+    const scroll = this.hero.FindItemInInventory('item_tpscroll');
+    if (!scroll || !scroll.IsFullyCastable()) {
+      return false;
+    }
+    const fountain = HeroUtil.GetTeamFountainPosition(this.hero.GetTeamNumber());
+    if (!fountain) {
+      return false;
+    }
+    this.hero.CastAbilityOnPosition(fountain, scroll, this.hero.GetPlayerOwnerID());
+    return true;
   }
 
   ThinkRetreatGetAwayFromTower(): void {

--- a/src/vscripts/ai/hero/bot-base.ts
+++ b/src/vscripts/ai/hero/bot-base.ts
@@ -45,6 +45,8 @@ export class BotBaseAIModifier extends BaseModifier {
 
   // 撤退回泉水的血量上限：高于此值多半只是躲塔或让位，不值得消耗卷轴
   protected readonly RetreatTeleportMaxHealthPercent: number = 50;
+  // 传送引导约 3 秒，塔攻击距离 700 之外再留一段缓冲，避免刚起手就被塔火力打断
+  protected readonly RetreatTeleportTowerSafeRange: number = 1200;
 
   public PushLevel: number = 10;
 
@@ -233,9 +235,9 @@ export class BotBaseAIModifier extends BaseModifier {
     if (this.aroundEnemyHeroes.length > 0) {
       return false;
     }
-    // 敌方塔攻击范围内开引导会被打断
+    // 附近有敌方塔就不开引导，会被塔火力打断
     const enemyTower = this.FindNearestEnemyTowerInvulnerable();
-    if (enemyTower && HeroUtil.IsInAttackRange(enemyTower, this.hero)) {
+    if (enemyTower && this.hero.GetRangeToUnit(enemyTower) <= this.RetreatTeleportTowerSafeRange) {
       return false;
     }
     return true;

--- a/src/vscripts/ai/hero/hero-tinker.ts
+++ b/src/vscripts/ai/hero/hero-tinker.ts
@@ -2,6 +2,7 @@ import { registerModifier } from '../../utils/dota_ts_adapter';
 import { GetFullCastRange } from '../ability/ability-cast';
 import { ActionFind } from '../action/action-find';
 import { BotBaseAIModifier } from './bot-base';
+import { HeroUtil } from './hero-util';
 
 /** 修补匠专属 AI：跳刀切入与脱离、传送回泉水与归队，落点都要先算出来，AbilitySpec 表达不了。 */
 
@@ -36,9 +37,6 @@ const TELEPORT_ALLY_TARGET_HEALTH_PERCENT = 90;
 @registerModifier('ai/hero/hero-tinker')
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export class tinker_ai_modifier extends BotBaseAIModifier {
-  // 泉水位置全局固定，首次查到后不再变化
-  private fountainPosition: Vector | undefined;
-
   override ActionAttack(): boolean {
     if (this.TryBlinkInitiate()) {
       return true;
@@ -61,9 +59,6 @@ export class tinker_ai_modifier extends BotBaseAIModifier {
 
   override ActionRetreat(): boolean {
     if (this.TryBlinkEscape()) {
-      return true;
-    }
-    if (this.TryTeleport()) {
       return true;
     }
     return super.ActionRetreat();
@@ -167,19 +162,20 @@ export class tinker_ai_modifier extends BotBaseAIModifier {
   }
 
   /**
-   * 低蓝时传送回泉水补给，落单且状态健康时传送到最近的队友身边。
+   * 优先用热机传送：撤退无追兵或低蓝时回泉水，落单且状态健康时传送到最近的队友身边。
+   * 热机传送在冷却时回退到通用 TP 卷轴逻辑。
    *
-   * 与队伍的 TP 卷轴回线是两套机制：那边按所处位置判断、目标是己方塔，这里按周围有没有队友判断、目标是队友本人。
+   * 与队伍的 TP 卷轴回线是两套机制：那边按所处位置判断、目标是己方塔。
    */
-  private TryTeleport(): boolean {
+  protected override TryTeleport(): boolean {
     const hero = this.GetHero();
     const teleport = hero.FindAbilityByName('tinker_keen_teleport');
     if (!teleport || !teleport.IsFullyCastable()) {
-      return false;
+      return super.TryTeleport();
     }
 
-    if (this.NeedsFountainSupply(hero)) {
-      const fountain = this.GetFountainPosition(hero);
+    if (this.ShouldRetreatTeleportToFountain() || this.NeedsFountainSupply(hero)) {
+      const fountain = HeroUtil.GetTeamFountainPosition(hero.GetTeamNumber());
       if (!fountain) {
         return false;
       }
@@ -278,20 +274,6 @@ export class tinker_ai_modifier extends BotBaseAIModifier {
     for (const ally of allies) {
       if (ally.GetEntityIndex() !== hero.GetEntityIndex()) {
         return ally;
-      }
-    }
-    return undefined;
-  }
-
-  private GetFountainPosition(hero: CDOTA_BaseNPC_Hero): Vector | undefined {
-    if (this.fountainPosition) {
-      return this.fountainPosition;
-    }
-    const fountains = Entities.FindAllByClassname('ent_dota_fountain') as CDOTA_BaseNPC[];
-    for (const fountain of fountains) {
-      if (!fountain.IsNull() && fountain.GetTeamNumber() === hero.GetTeamNumber()) {
-        this.fountainPosition = fountain.GetAbsOrigin();
-        return this.fountainPosition;
       }
     }
     return undefined;

--- a/src/vscripts/ai/hero/hero-util.ts
+++ b/src/vscripts/ai/hero/hero-util.ts
@@ -9,6 +9,26 @@ export class HeroUtil {
     'modifier_necrolyte_reapers_scythe', // 死灵法师大招
   ];
 
+  // 泉水坐标全局固定，首次查到后按队伍缓存
+  private static readonly fountainPositionByTeam = new Map<DotaTeam, Vector>();
+
+  /** 返回指定队伍泉水的世界坐标。 */
+  static GetTeamFountainPosition(team: DotaTeam): Vector | undefined {
+    const cached = this.fountainPositionByTeam.get(team);
+    if (cached) {
+      return cached;
+    }
+    const fountains = Entities.FindAllByClassname('ent_dota_fountain') as CDOTA_BaseNPC[];
+    for (const fountain of fountains) {
+      if (!fountain.IsNull() && fountain.GetTeamNumber() === team) {
+        const position = fountain.GetAbsOrigin();
+        this.fountainPositionByTeam.set(team, position);
+        return position;
+      }
+    }
+    return undefined;
+  }
+
   static NotActionable(hero: CDOTA_BaseNPC): boolean {
     // 死亡
     if (hero.IsAlive() === false) {

--- a/src/vscripts/ai/mode/fsa.ts
+++ b/src/vscripts/ai/mode/fsa.ts
@@ -10,8 +10,6 @@ import { ModeRetreat } from './mode-retreat';
 @reloadable
 export class FSA {
   public static readonly MODE_SWITCH_THRESHOLD = 0.5;
-  private static readonly RETREAT_HP_THRESHOLD = 35;
-  private static readonly MID_ONLY_RETREAT_HP_THRESHOLD = 15;
 
   ModeList: ModeBase[] = [];
   constructor() {
@@ -23,19 +21,6 @@ export class FSA {
 
   GetMode(heroAI: BotBaseAIModifier): ModeEnum {
     const currentMode = heroAI.mode;
-
-    const hero = heroAI.GetHero();
-    const pid = hero.GetPlayerOwnerID();
-    if (
-      PlayerResource.IsValidPlayerID(pid) &&
-      PlayerResource.IsFakeClient(pid) &&
-      hero.GetHealthPercent() <
-        (GameRules.Option.midOnlyMode
-          ? FSA.MID_ONLY_RETREAT_HP_THRESHOLD
-          : FSA.RETREAT_HP_THRESHOLD)
-    ) {
-      return ModeEnum.RETREAT;
-    }
 
     let maxDesire = 0;
     let desireMode: ModeEnum | undefined;

--- a/src/vscripts/ai/mode/mode-retreat.ts
+++ b/src/vscripts/ai/mode/mode-retreat.ts
@@ -6,7 +6,24 @@ import { ModeEnum } from './mode-enum';
 export class ModeRetreat extends ModeBase {
   mode: ModeEnum = ModeEnum.RETREAT;
 
+  // 血量低于此百分比的 bot 直接强制撤退，跳过 desire 竞争
+  private static readonly FORCE_RETREAT_HP_PERCENT = 30;
+  private static readonly MID_ONLY_FORCE_RETREAT_HP_PERCENT = 15;
+
   GetDesire(heroAI: BotBaseAIModifier): number {
+    const hero = heroAI.GetHero();
+    const pid = hero.GetPlayerOwnerID();
+    const forceRetreatHpPercent = GameRules.Option.midOnlyMode
+      ? ModeRetreat.MID_ONLY_FORCE_RETREAT_HP_PERCENT
+      : ModeRetreat.FORCE_RETREAT_HP_PERCENT;
+    if (
+      PlayerResource.IsValidPlayerID(pid) &&
+      PlayerResource.IsFakeClient(pid) &&
+      hero.GetHealthPercent() < forceRetreatHpPercent
+    ) {
+      return 1;
+    }
+
     let desire = 0;
     if (heroAI.mode === ModeEnum.RETREAT) {
       desire += 0.4;

--- a/src/vscripts/ai/team/bot-lane-recovery.ts
+++ b/src/vscripts/ai/team/bot-lane-recovery.ts
@@ -25,6 +25,8 @@ const FOUNTAIN_RADIUS = 1600;
 // 与正常回城补给的分界线：低于此线属于还在补给，高于则视为无谓滞留
 const FOUNTAIN_EVICTION_STATE_PERCENT = 90;
 const FOUNTAIN_EVICTION_INTERVAL = 10;
+// 撤退英雄每个 think 刷新一次抑制，取一个能覆盖数个 think 间隔的窗口
+const RETREAT_SUPPRESS_DURATION = 1.5;
 
 // 时长从 TP 指令下达起算，含约 3 秒引导。TP 塔取候选中的最低层级，配合前排塔门槛只会是一塔或二塔
 const RECOVERY_TARGETS: Record<
@@ -63,9 +65,8 @@ interface RecoveryCandidate {
 export class BotLaneRecovery {
   private readonly jungleRecoveryTasks = new Map<EntityIndex, JungleRecoveryTask>();
   private readonly fountainEvictionNextTime = new Map<EntityIndex, number>();
+  private readonly retreatSuppressedUntil = new Map<EntityIndex, number>();
   private taskExecutorRunning = false;
-  // 构造时机不保证地图实体已加载，首次使用时才查询；泉水坐标此后不再变化
-  private fountainPosition: Vector | undefined;
 
   public Run(): void {
     const towers = this.FindFriendlyTowers();
@@ -107,6 +108,12 @@ export class BotLaneRecovery {
       return undefined;
     }
     if (this.jungleRecoveryTasks.has(hero.GetEntityIndex())) {
+      return undefined;
+    }
+    if (
+      GameRules.GetDOTATime(false, true) <
+      (this.retreatSuppressedUntil.get(hero.GetEntityIndex()) ?? 0)
+    ) {
       return undefined;
     }
 
@@ -210,25 +217,11 @@ export class BotLaneRecovery {
   }
 
   private IsAtFountain(hero: CDOTA_BaseNPC_Hero): boolean {
-    const fountainPosition = this.GetFountainPosition();
+    const fountainPosition = HeroUtil.GetTeamFountainPosition(DotaTeam.BADGUYS);
     if (!fountainPosition) {
       return false;
     }
     return hero.GetAbsOrigin().__sub(fountainPosition).Length2D() <= FOUNTAIN_RADIUS;
-  }
-
-  private GetFountainPosition(): Vector | undefined {
-    if (this.fountainPosition) {
-      return this.fountainPosition;
-    }
-    const fountains = Entities.FindAllByClassname('ent_dota_fountain') as CDOTA_BaseNPC[];
-    for (const fountain of fountains) {
-      if (!fountain.IsNull() && fountain.GetTeamNumber() === DotaTeam.BADGUYS) {
-        this.fountainPosition = fountain.GetAbsOrigin();
-        return this.fountainPosition;
-      }
-    }
-    return undefined;
   }
 
   private CastRecoveryTeleport(
@@ -261,6 +254,14 @@ export class BotLaneRecovery {
   /** Cancels the hero's post-teleport jungle recovery movement. */
   public CancelJungleRecoveryMovement(hero: CDOTA_BaseNPC_Hero): void {
     this.EndJungleRecoveryMovement(hero.GetEntityIndex(), 'retreat');
+  }
+
+  /** 撤退期间不把该英雄纳入团队回线候选。 */
+  public SuppressForRetreat(hero: CDOTA_BaseNPC_Hero): void {
+    this.retreatSuppressedUntil.set(
+      hero.GetEntityIndex(),
+      GameRules.GetDOTATime(false, true) + RETREAT_SUPPRESS_DURATION,
+    );
   }
 
   private CreateJungleRecoveryTask(

--- a/src/vscripts/ai/team/bot-team.ts
+++ b/src/vscripts/ai/team/bot-team.ts
@@ -268,6 +268,11 @@ export class BotTeam {
     this.laneRecovery.CancelJungleRecoveryMovement(hero);
   }
 
+  /** 撤退中的英雄改由自身 AI 决定去泉水还是继续走，暂时退出团队回线。 */
+  suppressLaneRecoveryForRetreat(hero: CDOTA_BaseNPC_Hero): void {
+    this.laneRecovery.SuppressForRetreat(hero);
+  }
+
   /**
    * 给Bot发钱
    * 每1秒调用一次(原Lua实现是2秒调用一次,现在金额减半以保持总量不变)


### PR DESCRIPTION
## Issue

无关联 issue。

## 改动说明

给所有 bot 英雄新增一条撤退行为：在 RETREAT 模式下，若血量偏低、周围没有敌方英雄、也不在敌方防御塔火力范围内，就直接用 TP 卷轴传送回自家泉水，而不是一路走回家。

### 主要改动

- **`bot-base.ts`**
  - 新增 `ShouldRetreatTeleportToFountain()`：撤退模式 + 血量 < 50% + 未被沉默 + 1800 内无敌方英雄 + 最近敌方塔在 1200 之外
  - 新增 `TryTeleport()`：满足条件时用 `item_tpscroll` 传送回 `hero.GetTeamNumber()` 对应的泉水，`ActionRetreat()` 在防御塔逻辑前调用
  - think 间隔 `0.4 → 0.5`
- **`hero-util.ts`**：新增静态 `GetTeamFountainPosition(team)`，按队伍缓存泉水坐标；tinker 与团队回线系统原本各有一份重复实现，一并合并到这里
- **`hero-tinker.ts`**：`TryTeleport` 改为 `override`，热机传送（keen teleport）优先，撤退无追兵或低蓝都回泉水；热机在冷却时 `super.TryTeleport()` 退回 TP 卷轴逻辑
- **`bot-lane-recovery.ts` / `bot-team.ts`**：撤退中的 bot 暂时退出夜魇团队回线候选（1.5s 抑制窗口，每次撤退 think 刷新），避免「撤退回泉水」和「回线回前排塔」抢同一个卷轴

### 数据流

`OnIntervalThink` 刷新 `mode` / `aroundEnemyHeroes` → 撤退分支记抑制时间戳 → `ActionRetreat()` → `TryTeleport()`（tinker 动态派发到自己的 override）→ `HeroUtil.GetTeamFountainPosition` → `CastAbilityOnPosition`。团队回线定时器在 `GetBotCandidate` 读抑制时间戳，撤退 bot 不参与回线。

## Checklist

- [ ] I have tested the changes works well.
- [ ] Dota Tools 验证：bot 撤退且无追兵时会 TP 回自家泉水，天辉 / 夜魇泉水位置都正确
- [ ] 验证夜魇团队回线系统不再把撤退中的 bot 拉去前排塔
- [ ] 验证 tinker 撤退优先用热机传送回泉水，热机冷却时改用 TP 卷轴

## Release Note

本次不写 Release Note：仅 bot AI 行为微调，玩法影响处于边界，不单独公告。
