### PR TITLE
Add Terrorblade Sunder awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1260,6 +1260,14 @@
 		///////////////////////////////////////////////////
 // 					Awaken Abilities 觉醒技能
 
+		// 恐怖利刃 魂断觉醒
+		"DOTA_Tooltip_ability_terrorblade_sunder_awakened"						"<font color='#d000ff'>Sunder Awakened</font>"
+		"DOTA_Tooltip_ability_terrorblade_sunder_awakened_SummaryDescription"		"Automatically unleashes an area Sunder at low health, even while disabled."
+		"DOTA_Tooltip_ability_terrorblade_sunder_awakened_Description"			"Targets an area and exchanges Terrorblade's current health percentage with every real enemy hero inside it. All enemies are set to Terrorblade's pre-cast health percentage, while Terrorblade gains the highest pre-cast health percentage among affected enemies. Ignores <font color='#FFCC66'>debuff immunity</font> and does not trigger Spell Block or Spell Reflect. Has no minimum health limit or cast point.<br><br><font color='#00CED1'>Automatic Cast:</font> Automatically activates around Terrorblade below %auto_trigger_health_pct%%% health, even while stunned or otherwise disabled."
+		"DOTA_Tooltip_ability_terrorblade_sunder_awakened_radius"					"RADIUS:"
+		"DOTA_Tooltip_modifier_terrorblade_sunder_awakened"					"<font color='#d000ff'>Sunder Awakened</font>"
+		"DOTA_Tooltip_modifier_terrorblade_sunder_awakened_Description"		"Sunder is awakened. Below <font color='#FFFFFF'><b>20%%</b></font> health, it automatically activates when an enemy hero is nearby, even while disabled."
+
 		// 撼地者 余震觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade"						"<font color='#d000ff'>Aftershock Awakened</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade_Description"		"Each unit hit by Aftershock creates a small Aftershock at its position, dealing separate magical damage to nearby enemies. Multiple small Aftershocks can hit the same unit, but each batch stuns a unit only once. Small Aftershocks cannot trigger this effect again."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -668,6 +668,14 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Пробуждение Shallow Grave</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"После применения Shallow Grave на себя или союзника цель получает эффект <font color='#FFCC66'>Black King Bar</font> на время действия Shallow Grave."
 
+		// 恐怖利刃 魂断觉醒
+		"DOTA_Tooltip_ability_terrorblade_sunder_awakened"						"<font color='#d000ff'>Пробуждённый Sunder</font>"
+		"DOTA_Tooltip_ability_terrorblade_sunder_awakened_SummaryDescription"		"Автоматически применяет Sunder по области при низком здоровье, даже под контролем."
+		"DOTA_Tooltip_ability_terrorblade_sunder_awakened_Description"			"Выбирает область и обменивает текущий процент здоровья Terrorblade со всеми настоящими вражескими героями внутри неё. Все враги получают процент здоровья Terrorblade до применения, а Terrorblade получает наибольший процент здоровья среди затронутых врагов до применения. Игнорирует <font color='#FFCC66'>невосприимчивость к эффектам</font> и не активирует блокирование или отражение заклинаний. Не имеет минимального порога здоровья и времени применения.<br><br><font color='#00CED1'>Автоматическое применение:</font> При здоровье ниже %auto_trigger_health_pct%%% автоматически срабатывает вокруг Terrorblade, даже под оглушением или другим контролем."
+		"DOTA_Tooltip_ability_terrorblade_sunder_awakened_radius"					"РАДИУС:"
+		"DOTA_Tooltip_modifier_terrorblade_sunder_awakened"					"<font color='#d000ff'>Пробуждённый Sunder</font>"
+		"DOTA_Tooltip_modifier_terrorblade_sunder_awakened_Description"		"Sunder пробуждён. При здоровье ниже <font color='#FFFFFF'><b>20%%</b></font> он автоматически срабатывает, если рядом есть вражеский герой, даже под контролем."
+
 		// 撼地者 余震觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade"						"<font color='#d000ff'>Афтершок: пробуждение</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade_Description"		"Каждая цель, задетая Афтершоком, создаёт малый Афтершок в своей точке, наносящий отдельный магический урон врагам поблизости. Несколько малых Афтершоков могут поразить одну цель, но в каждой серии оглушают её только один раз. Малые Афтершоки не создают новые малые Афтершоки."

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1255,6 +1255,14 @@
 		///////////////////////////////////////////////////
 // 					Awaken Abilities 觉醒技能
 
+		// 恐怖利刃 魂断觉醒
+		"DOTA_Tooltip_ability_terrorblade_sunder_awakened"						"<font color='#d000ff'>魂断 觉醒</font>"
+		"DOTA_Tooltip_ability_terrorblade_sunder_awakened_SummaryDescription"		"生命值过低时，即使受到控制也会自动发动范围魂断。"
+		"DOTA_Tooltip_ability_terrorblade_sunder_awakened_Description"			"选定一个区域，交换恐怖利刃与区域内所有敌方真实英雄的当前生命百分比。所有敌人变为恐怖利刃施放前的生命百分比，恐怖利刃则获得命中目标中最高的施放前生命百分比。无视<font color='#FFCC66'>减益免疫</font>，不会触发法术抵抗或法术反弹。没有最低生命值限制，也没有施法前摇。<br><br><font color='#00CED1'>自动施法：</font>生命值低于%auto_trigger_health_pct%%%时，即使受到眩晕等控制也会以自身为中心自动释放。"
+		"DOTA_Tooltip_ability_terrorblade_sunder_awakened_radius"					"作用范围："
+		"DOTA_Tooltip_modifier_terrorblade_sunder_awakened"					"<font color='#d000ff'>魂断 觉醒</font>"
+		"DOTA_Tooltip_modifier_terrorblade_sunder_awakened_Description"		"魂断已觉醒。生命值低于<font color='#FFFFFF'><b>20%%</b></font>且附近存在敌方英雄时，即使受到控制也会自动释放。"
+
 		// 撼地者 余震觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade"						"<font color='#d000ff'>余震 觉醒</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade_Description"		"余震命中的每个单位都会在原地触发一次小余震，对附近敌人造成独立的魔法伤害。多个小余震可同时命中同一目标，每批小余震只会将同一目标眩晕一次。小余震不会再次触发此效果。"

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -5,6 +5,48 @@
 	// 英雄专属强化/替换技能，通过抽奖池获得
 	//=================================================================================================================
 
+	// 恐怖利刃 魂断觉醒
+	"terrorblade_sunder_awakened"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/terrorblade_sunder_awakened"
+		"AbilityTextureName"			"terrorblade_sunder"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE | DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_IGNORE_BACKSWING"
+		"AbilityType"					"ABILITY_TYPE_ULTIMATE"
+		"AbilityUnitTargetTeam"			"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"		"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_NOT_ILLUSIONS"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
+		"SpellDispellableType"			"SPELL_DISPELLABLE_NO"
+		"AbilityCastPoint"				"0"
+		"AbilityCastRange"				"475"
+		"AbilityCooldown"				"60 50 40 30"
+		"AbilityManaCost"				"100 75 50 25"
+		"MaxLevel"						"4"
+		"RequiredLevel"					"6"
+		"LevelsBetweenUpgrades"			"6"
+
+		"AbilityValues"
+		{
+			"radius"
+			{
+				"value"						"300 367 433 500"
+				"affected_by_aoe_increase"	"1"
+			}
+			"auto_trigger_health_pct"		"20"
+		}
+	}
+
+	// 恐怖利刃 魂断觉醒状态
+	"terrorblade_sunder_awakened_status"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/terrorblade_sunder_awakened"
+		"AbilityTextureName"			"terrorblade_sunder"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_SKIP_FOR_KEYBINDS"
+		"MaxLevel"						"1"
+	}
+
 	// 撼地者 余震觉醒
 	"special_bonus_unique_earthshaker_upgrade"
 	{

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,11 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_terrorblade',
+    abilityName: 'terrorblade_sunder_awakened',
+    freeTrial: true,
+  },
+  {
     heroName: 'npc_dota_hero_earthshaker',
     abilityName: 'special_bonus_unique_earthshaker_upgrade',
     freeTrial: true,

--- a/src/vscripts/abilities/ts_abilities/terrorblade_sunder_awakened.ts
+++ b/src/vscripts/abilities/ts_abilities/terrorblade_sunder_awakened.ts
@@ -1,0 +1,146 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+
+const SCRIPT_PATH = 'abilities/ts_abilities/terrorblade_sunder_awakened';
+const SUNDER_ABILITY = 'terrorblade_sunder_awakened';
+const SUNDER_PARTICLE = 'particles/units/heroes/hero_terrorblade/terrorblade_sunder.vpcf';
+
+/** 恐怖利刃 魂断觉醒。 */
+@registerAbility('terrorblade_sunder_awakened')
+export class TerrorbladeSunderAwakened extends BaseAbility {
+  GetAOERadius(): number {
+    return this.GetSpecialValueFor('radius');
+  }
+
+  OnSpellStart(): void {
+    if (!IsServer()) return;
+    this.sunderEnemies(this.findEnemyHeroes(this.GetCursorPosition()));
+  }
+
+  tryAutomaticSunder(): void {
+    const caster = this.GetCaster();
+    if (!caster.IsRealHero() || !caster.IsAlive()) return;
+    if (!this.IsActivated() || this.GetLevel() <= 0) return;
+    if (caster.GetHealthPercent() >= this.GetSpecialValueFor('auto_trigger_health_pct')) return;
+    if (this.GetCooldownTimeRemaining() > 0 || caster.GetMana() < this.GetManaCost(-1)) return;
+
+    // 自动触发不依赖施法命令；被控制时直接以 TB 自身为范围中心结算。
+    const enemies = this.findEnemyHeroes(caster.GetAbsOrigin());
+    if (enemies.length === 0) return;
+
+    this.UseResources(true, false, false, true);
+    this.sunderEnemies(enemies);
+  }
+
+  private findEnemyHeroes(center: Vector): CDOTA_BaseNPC_Hero[] {
+    const caster = this.GetCaster();
+    return FindUnitsInRadius(
+      caster.GetTeamNumber(),
+      center,
+      undefined,
+      this.GetSpecialValueFor('radius'),
+      UnitTargetTeam.ENEMY,
+      UnitTargetType.HERO,
+      UnitTargetFlags.MAGIC_IMMUNE_ENEMIES + UnitTargetFlags.NOT_ILLUSIONS,
+      FindOrder.ANY,
+      false,
+    ).filter((unit): unit is CDOTA_BaseNPC_Hero => unit.IsRealHero() && unit.IsAlive());
+  }
+
+  private sunderEnemies(enemies: CDOTA_BaseNPC_Hero[]): void {
+    if (enemies.length === 0) return;
+
+    const caster = this.GetCaster();
+    const casterHealthRatio = caster.GetHealth() / caster.GetMaxHealth();
+    let highestEnemyHealthRatio = 0;
+
+    for (const enemy of enemies) {
+      highestEnemyHealthRatio = Math.max(
+        highestEnemyHealthRatio,
+        enemy.GetHealth() / enemy.GetMaxHealth(),
+      );
+    }
+
+    for (const enemy of enemies) {
+      enemy.SetHealth(Math.max(1, Math.floor(enemy.GetMaxHealth() * casterHealthRatio)));
+      this.playSunderEffect(caster, enemy);
+    }
+
+    caster.SetHealth(Math.max(1, Math.floor(caster.GetMaxHealth() * highestEnemyHealthRatio)));
+    caster.EmitSound('Hero_Terrorblade.Sunder.Cast');
+  }
+
+  private playSunderEffect(caster: CDOTA_BaseNPC, target: CDOTA_BaseNPC): void {
+    const particle = ParticleManager.CreateParticle(
+      SUNDER_PARTICLE,
+      ParticleAttachment.ABSORIGIN_FOLLOW,
+      target,
+    );
+    ParticleManager.SetParticleControlEnt(
+      particle,
+      0,
+      caster,
+      ParticleAttachment.POINT_FOLLOW,
+      'attach_hitloc',
+      caster.GetAbsOrigin(),
+      true,
+    );
+    ParticleManager.SetParticleControlEnt(
+      particle,
+      1,
+      target,
+      ParticleAttachment.POINT_FOLLOW,
+      'attach_hitloc',
+      target.GetAbsOrigin(),
+      true,
+    );
+    ParticleManager.ReleaseParticleIndex(particle);
+    target.EmitSound('Hero_Terrorblade.Sunder.Target');
+  }
+}
+
+/** 独立承载觉醒状态，避免终极技能等级限制 intrinsic modifier 的创建。 */
+@registerAbility('terrorblade_sunder_awakened_status')
+export class TerrorbladeSunderAwakenedStatus extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return modifier_terrorblade_sunder_awakened.name;
+  }
+}
+
+@registerModifier(SCRIPT_PATH)
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_terrorblade_sunder_awakened extends BaseModifier {
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return 'terrorblade_sunder';
+  }
+
+  OnCreated(): void {
+    if (!IsServer()) return;
+    this.StartIntervalThink(0.1);
+  }
+
+  OnIntervalThink(): void {
+    if (!IsServer()) return;
+    const ability = this.GetParent().FindAbilityByName(SUNDER_ABILITY) as
+      | TerrorbladeSunderAwakened
+      | undefined;
+    if (!ability || ability.IsNull()) return;
+    ability.tryAutomaticSunder();
+  }
+}

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,18 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 恐怖利刃 觉醒
+  {
+    heroName: 'npc_dota_hero_terrorblade',
+    targetAbility: 'terrorblade_sunder',
+    newAbility: 'terrorblade_sunder_awakened',
+    newLevel: 0,
+  },
+  {
+    heroName: 'npc_dota_hero_terrorblade',
+    newAbility: 'terrorblade_sunder_awakened_status',
+    newLevel: 1,
+  },
   // 撼地者 觉醒
   {
     heroName: 'npc_dota_hero_earthshaker',
@@ -263,6 +275,7 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  * 新觉醒发布时加入，下次发版由 awaken-ability skill 流程确认移出。
  */
 export const FREE_TRIAL_HEROES: string[] = [
+  'npc_dota_hero_terrorblade', // 恐怖利刃
   'npc_dota_hero_earthshaker', // 撼地者
   'npc_dota_hero_abyssal_underlord', // 孽主
   'npc_dota_hero_slark', // 斯拉克


### PR DESCRIPTION
## Summary

- Replace Terrorblade's Sunder with a point-targeted area health swap that affects real enemy heroes.
- Automatically trigger Sunder below 20% health even while Terrorblade is disabled, bypassing debuff immunity, Spell Block, and Spell Reflect.
- Add a persistent awakening status, profile preview, free-trial entry, and Chinese, English, and Russian localization.

## Issue

No linked issue.

## Checklist

- [x] The requester verified the final behavior in Dota Tools.
- [x] VScript and Panorama production builds pass.
- [x] Lint, image validation, awakening replacement tests, KV parsing, and localization consistency checks pass.

## Release Note

```
[b]游戏性更新 v5.52b[/b]

- 新增恐怖利刃觉醒：魂断改为范围换血，生命值低于20%时即使受到控制也会自动释放，并无视减益免疫、法术抵挡与法术反弹。
```

```
[b]Gameplay update v5.52b[/b]

- Added Terrorblade awakening: Sunder now swaps health in an area, automatically activates below 20% health even while disabled, and ignores debuff immunity, Spell Block, and Spell Reflect.
```
