### PR TITLE
Add Shadow Shaman Proxy Shackles awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1260,6 +1260,20 @@
 		///////////////////////////////////////////////////
 // 					Awaken Abilities 觉醒技能
 
+		// 暗影萨满 枷锁替身觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken"						"<font color='#d000ff'>Proxy Shackles Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_SummaryDescription"		"Ground targeted. A proxy Shackles every enemy in the area while Shadow Shaman remains free to act."
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_Description"				"Creates an invulnerable and unselectable proxy at Shadow Shaman's cast position. The proxy Shackles all enemy heroes and basic units around the target point, preventing them from acting and dealing <font color='#05CAFF'>magical damage</font> over time. Shadow Shaman remains free to act, and moving or casting does not interrupt the Shackles. Ground targeting neither triggers Spell Block nor allows Spell Reflection."
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_scepter_description"		"Increases cast range. Every %scepter_shock_interval% seconds, each Shackled enemy emits a radial Ether Shock that hits all other enemies within %scepter_shock_radius% for %scepter_shock_pct%%% of Ether Shock's normal damage."
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_total_damage"			"TOTAL DAMAGE PER TARGET:"
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_channel_time"			"DURATION:"
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_radius"				"RADIUS:"
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_AbilityCastRange"		"CAST RANGE:"
+		"DOTA_Tooltip_modifier_special_bonus_unique_shadow_shaman_shackles_awaken_status"				"<font color='#d000ff'>Proxy Shackles Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_shadow_shaman_shackles_awaken_status_Description"	"A proxy maintains the Shackles while Shadow Shaman remains free to move, attack, and cast. Ground targeting does not trigger Spell Block or Spell Reflection."
+		"DOTA_Tooltip_modifier_special_bonus_unique_shadow_shaman_shackles_awaken_debuff"				"Proxy Shackles"
+		"DOTA_Tooltip_modifier_special_bonus_unique_shadow_shaman_shackles_awaken_debuff_Description"	"Shackled by a proxy. Unable to act and taking magical damage over time."
+
 		// 撼地者 余震觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade"						"<font color='#d000ff'>Aftershock Awakened</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade_Description"		"Each unit hit by Aftershock creates a small Aftershock at its position, dealing separate magical damage to nearby enemies. Multiple small Aftershocks can hit the same unit, but each batch stuns a unit only once. Small Aftershocks cannot trigger this effect again."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -668,6 +668,20 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Пробуждение Shallow Grave</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"После применения Shallow Grave на себя или союзника цель получает эффект <font color='#FFCC66'>Black King Bar</font> на время действия Shallow Grave."
 
+		// 暗影萨满 枷锁替身觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken"						"<font color='#d000ff'>Оковы двойника: пробуждение</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_SummaryDescription"		"Применяется на точку. Двойник удерживает всех врагов в области, а Shadow Shaman может свободно действовать."
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_Description"				"Создаёт в месте применения Shadow Shaman неуязвимого двойника, которого нельзя выбрать целью. Двойник сковывает всех вражеских героев и обычных существ вокруг указанной точки, не позволяя им действовать и нанося периодический <font color='#05CAFF'>магический урон</font>. Shadow Shaman может свободно двигаться и применять способности, не прерывая Оковы. Применение на точку не активирует блокировку и отражение заклинаний."
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_scepter_description"		"Увеличивает дальность применения. Каждые %scepter_shock_interval% сек. каждый скованный враг выпускает радиальную волну Ether Shock, поражающую всех остальных врагов в радиусе %scepter_shock_radius% и наносящую %scepter_shock_pct%%% обычного урона Ether Shock."
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_total_damage"			"СУММАРНЫЙ УРОН КАЖДОЙ ЦЕЛИ:"
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_channel_time"			"ДЛИТЕЛЬНОСТЬ:"
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_radius"				"РАДИУС:"
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_AbilityCastRange"		"ДАЛЬНОСТЬ ПРИМЕНЕНИЯ:"
+		"DOTA_Tooltip_modifier_special_bonus_unique_shadow_shaman_shackles_awaken_status"				"<font color='#d000ff'>Оковы двойника: пробуждение</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_shadow_shaman_shackles_awaken_status_Description"	"Двойник поддерживает Оковы, а Shadow Shaman может свободно двигаться, атаковать и применять способности. Применение на точку не активирует блокировку или отражение заклинаний."
+		"DOTA_Tooltip_modifier_special_bonus_unique_shadow_shaman_shackles_awaken_debuff"				"Оковы двойника"
+		"DOTA_Tooltip_modifier_special_bonus_unique_shadow_shaman_shackles_awaken_debuff_Description"	"Скован двойником. Не может действовать и периодически получает магический урон."
+
 		// 撼地者 余震觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade"						"<font color='#d000ff'>Афтершок: пробуждение</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade_Description"		"Каждая цель, задетая Афтершоком, создаёт малый Афтершок в своей точке, наносящий отдельный магический урон врагам поблизости. Несколько малых Афтершоков могут поразить одну цель, но в каждой серии оглушают её только один раз. Малые Афтершоки не создают новые малые Афтершоки."

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1255,6 +1255,20 @@
 		///////////////////////////////////////////////////
 // 					Awaken Abilities 觉醒技能
 
+		// 暗影萨满 枷锁替身觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken"						"<font color='#d000ff'>替身枷锁 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_SummaryDescription"		"点地施放，由替身对范围内所有敌人维持枷锁，本体可自由行动。"
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_Description"				"在暗影萨满施法位置生成一个无敌且不可被选中的替身，由替身将目标地点范围内所有敌方英雄和普通单位铐牢，使其无法行动并持续受到<font color='#05CAFF'>魔法伤害</font>。本体可以自由行动，移动或施法不会中断枷锁。点地施法不会触发法术格挡，也不会被法术反射。"
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_scepter_description"		"提升施法距离。每隔%scepter_shock_interval%秒，每个被铐牢的敌人都会释放一次辐射状的苍穹震击，对其%scepter_shock_radius%范围内其他敌人造成%scepter_shock_pct%%%苍穹震击普通伤害。"
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_total_damage"			"每个目标总伤害："
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_channel_time"			"持续时间："
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_radius"				"作用范围："
+		"DOTA_Tooltip_ability_special_bonus_unique_shadow_shaman_shackles_awaken_AbilityCastRange"		"施法距离："
+		"DOTA_Tooltip_modifier_special_bonus_unique_shadow_shaman_shackles_awaken_status"				"<font color='#d000ff'>替身枷锁 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_shadow_shaman_shackles_awaken_status_Description"	"枷锁由替身维持，本体可以自由移动、攻击和施法。点地施放不会触发法术格挡或法术反射。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_shadow_shaman_shackles_awaken_debuff"				"替身枷锁"
+		"DOTA_Tooltip_modifier_special_bonus_unique_shadow_shaman_shackles_awaken_debuff_Description"	"被替身的枷锁铐牢，无法行动并持续受到魔法伤害。"
+
 		// 撼地者 余震觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade"						"<font color='#d000ff'>余震 觉醒</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade_Description"		"余震命中的每个单位都会在原地触发一次小余震，对附近敌人造成独立的魔法伤害。多个小余震可同时命中同一目标，每批小余震只会将同一目标眩晕一次。小余震不会再次触发此效果。"

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -5,6 +5,70 @@
 	// 英雄专属强化/替换技能，通过抽奖池获得
 	//=================================================================================================================
 
+	// 暗影萨满 枷锁替身觉醒
+	"special_bonus_unique_shadow_shaman_shackles_awaken"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/special_bonus_unique_shadow_shaman_shackles_awaken"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"			"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_MAGICAL"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_NO"
+		"SpellDispellableType"			"SPELL_DISPELLABLE_YES_STRONG"
+		"FightRecapLevel"				"1"
+		"HasScepterUpgrade"				"1"
+		"AbilityTextureName"			"shadow_shaman_shackles"
+		"MaxLevel"						"5"
+
+		"AbilityCastPoint"				"0.3 0.3 0.3 0.3 0.3"
+		"AbilityCooldown"				"14 13 12 11 10"
+		"AbilityManaCost"				"125 140 155 170 185"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_3"
+
+		"precache"
+		{
+			"particle"		"particles/units/heroes/hero_shadowshaman/shadowshaman_shackle.vpcf"
+			"particle"		"particles/units/heroes/hero_shadowshaman/shadowshaman_ether_shock.vpcf"
+		}
+
+		"AbilityValues"
+		{
+			"AbilityCastRange"
+			{
+				"value"					"600"
+				"special_bonus_scepter"	"+200"
+			}
+			"radius"
+			{
+				"value"					"350"
+				"affected_by_aoe_increase"	"1"
+			}
+			"total_damage"
+			{
+				"value"									"100 160 220 280 340"
+				"special_bonus_unique_shadow_shaman_6"	"+170"
+			}
+			"channel_time"
+			{
+				"value"									"3 4 5 6 7"
+				"special_bonus_unique_shadow_shaman_2"	"+1.0"
+			}
+			"scepter_shock_pct"
+			{
+				"special_bonus_scepter"	"100"
+			}
+			"scepter_shock_radius"
+			{
+				"special_bonus_scepter"	"600"
+			}
+			"scepter_shock_interval"
+			{
+				"special_bonus_scepter"	"0.6"
+			}
+		}
+	}
+
 	// 撼地者 余震觉醒
 	"special_bonus_unique_earthshaker_upgrade"
 	{

--- a/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
+++ b/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
@@ -168,6 +168,7 @@ EXCLUDED_ABILITIES_ALLBUTTER = {
     ["keeper_of_the_light_illuminate"] = true,                   -- 光之守卫 冲击波
     ["keeper_of_the_light_illuminate_end"] = true,               -- 光之守卫 冲击波 释放
     ["special_bonus_unique_keeper_of_the_light_upgrade"] = true, -- 光之守卫 冲击波 觉醒
+    ["special_bonus_unique_shadow_shaman_shackles_awaken"] = true, -- 暗影萨满 枷锁替身觉醒
 
     -- ========================================
     -- 取消/停止类技能

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,11 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_shadow_shaman',
+    abilityName: 'special_bonus_unique_shadow_shaman_shackles_awaken',
+    freeTrial: true,
+  },
+  {
     heroName: 'npc_dota_hero_earthshaker',
     abilityName: 'special_bonus_unique_earthshaker_upgrade',
     freeTrial: true,

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_shadow_shaman_shackles_awaken.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_shadow_shaman_shackles_awaken.ts
@@ -1,0 +1,435 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+
+const ETHER_SHOCK_ABILITY = 'shadow_shaman_ether_shock';
+const SHACKLE_PARTICLE = 'particles/units/heroes/hero_shadowshaman/shadowshaman_shackle.vpcf';
+const ETHER_SHOCK_PARTICLE =
+  'particles/units/heroes/hero_shadowshaman/shadowshaman_ether_shock.vpcf';
+const SHACKLE_SOUND = 'Hero_ShadowShaman.Shackles';
+const DAMAGE_TICK_INTERVAL = 0.1;
+
+interface ShackledTarget {
+  unit: CDOTA_BaseNPC;
+  modifier: CDOTA_Buff;
+  particle: ParticleID;
+  damagePerSecond: number;
+  lastDamageTime: number;
+  endTime: number;
+}
+
+@registerAbility('special_bonus_unique_shadow_shaman_shackles_awaken')
+export class SpecialBonusUniqueShadowShamanShacklesAwaken extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return modifier_special_bonus_unique_shadow_shaman_shackles_awaken_status.name;
+  }
+
+  GetAOERadius(): number {
+    return this.GetSpecialValueFor('radius');
+  }
+
+  OnSpellStart(): void {
+    if (!IsServer()) return;
+
+    const caster = this.GetCaster();
+    if (!caster.IsRealHero() || caster.IsIllusion()) return;
+
+    const castPosition = this.GetCursorPosition();
+    const targets = FindUnitsInRadius(
+      caster.GetTeamNumber(),
+      castPosition,
+      undefined,
+      this.GetSpecialValueFor('radius'),
+      UnitTargetTeam.ENEMY,
+      UnitTargetType.HERO + UnitTargetType.BASIC,
+      UnitTargetFlags.NONE,
+      FindOrder.ANY,
+      false,
+    );
+    const validTargets = targets.filter((target) => !target.IsMagicImmune());
+    if (validTargets.length === 0) return;
+
+    const duration = this.GetSpecialValueFor('channel_time');
+    if (duration <= 0) return;
+
+    const illusions = CreateIllusions(
+      caster as CDOTA_BaseNPC_Hero,
+      caster as CDOTA_BaseNPC_Hero,
+      {
+        outgoing_damage: 0,
+        incoming_damage: 0,
+        bounty_base: 0,
+        bounty_growth: 0,
+        outgoing_damage_structure: 0,
+        outgoing_damage_roshan: 0,
+      },
+      1,
+      0,
+      false,
+      false,
+    );
+    const proxy = illusions[0];
+    if (!proxy || proxy.IsNull()) return;
+
+    const casterPosition = caster.GetAbsOrigin();
+    proxy.SetAbsOrigin(casterPosition);
+    proxy.SetIdleAcquire(false);
+    proxy.SetAcquisitionRange(0);
+    this.facePosition(proxy, castPosition);
+
+    proxy.AddNewModifier(caster, this, 'modifier_kill', { duration: duration + 0.2 });
+    const controller = proxy.AddNewModifier(
+      caster,
+      this,
+      modifier_special_bonus_unique_shadow_shaman_shackles_awaken_proxy.name,
+      { duration },
+    ) as modifier_special_bonus_unique_shadow_shaman_shackles_awaken_proxy | undefined;
+    if (!controller || controller.IsNull()) {
+      UTIL_Remove(proxy);
+      return;
+    }
+
+    controller.InitializeTargets(validTargets, duration, this.GetSpecialValueFor('total_damage'));
+  }
+
+  private facePosition(proxy: CDOTA_BaseNPC_Hero, position: Vector): void {
+    const origin = proxy.GetAbsOrigin();
+    const x = position.x - origin.x;
+    const y = position.y - origin.y;
+    const length = Math.sqrt(x * x + y * y);
+    if (length <= 0) return;
+
+    proxy.SetForwardVector(Vector(x / length, y / length, 0));
+  }
+}
+
+/** 暗影萨满 枷锁替身觉醒。 */
+@registerModifier('abilities/ts_abilities/special_bonus_unique_shadow_shaman_shackles_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_shadow_shaman_shackles_awaken_proxy extends BaseModifier {
+  private targets: ShackledTarget[] = [];
+  private nextScepterShockTime?: number;
+
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  CheckState(): Partial<Record<ModifierState, boolean>> {
+    return {
+      [ModifierState.ROOTED]: true,
+      [ModifierState.DISARMED]: true,
+      [ModifierState.SILENCED]: true,
+      [ModifierState.MUTED]: true,
+      [ModifierState.PASSIVES_DISABLED]: true,
+      [ModifierState.COMMAND_RESTRICTED]: true,
+      [ModifierState.INVULNERABLE]: true,
+      [ModifierState.UNSELECTABLE]: true,
+      [ModifierState.NO_HEALTH_BAR]: true,
+      [ModifierState.NO_UNIT_COLLISION]: true,
+      [ModifierState.NOT_ON_MINIMAP]: true,
+    };
+  }
+
+  InitializeTargets(units: CDOTA_BaseNPC[], baseDuration: number, totalDamage: number): void {
+    if (!IsServer()) return;
+
+    const caster = this.GetCaster();
+    const ability = this.GetAbility();
+    if (!caster || !ability || caster.IsNull() || ability.IsNull()) return;
+
+    const now = GameRules.GetGameTime();
+    const damagePerSecond = totalDamage / baseDuration;
+    for (const unit of units) {
+      const effectiveDuration = baseDuration * (1 - unit.GetStatusResistance());
+      if (effectiveDuration <= 0) continue;
+
+      const modifier = unit.AddNewModifier(
+        caster,
+        ability,
+        modifier_special_bonus_unique_shadow_shaman_shackles_awaken_debuff.name,
+        { duration: effectiveDuration },
+      );
+      if (!modifier || modifier.IsNull()) continue;
+
+      this.targets.push({
+        unit,
+        modifier,
+        particle: this.createShackleParticle(unit),
+        damagePerSecond,
+        lastDamageTime: now,
+        endTime: now + effectiveDuration,
+      });
+    }
+
+    if (this.targets.length === 0) {
+      UTIL_Remove(this.GetParent());
+      return;
+    }
+
+    const shockInterval = ability.GetSpecialValueFor('scepter_shock_interval');
+    if (shockInterval > 0) this.nextScepterShockTime = now + shockInterval;
+
+    const proxy = this.GetParent();
+    proxy.StartGesture(GameActivity.DOTA_CHANNEL_ABILITY_3);
+    proxy.EmitSound(SHACKLE_SOUND);
+    this.StartIntervalThink(DAMAGE_TICK_INTERVAL);
+  }
+
+  OnIntervalThink(): void {
+    if (!IsServer()) return;
+
+    const caster = this.GetCaster();
+    const ability = this.GetAbility();
+    if (!caster || caster.IsNull() || !ability || ability.IsNull()) {
+      this.Destroy();
+      return;
+    }
+
+    const now = GameRules.GetGameTime();
+    const activeTargets: ShackledTarget[] = [];
+    for (const target of this.targets) {
+      if (target.unit.IsNull() || !target.unit.IsAlive() || target.modifier.IsNull()) {
+        this.destroyShackleParticle(target.particle);
+        continue;
+      }
+
+      const damageEndTime = Math.min(now, target.endTime);
+      const elapsed = Math.max(0, damageEndTime - target.lastDamageTime);
+      if (elapsed > 0) {
+        ApplyDamage({
+          victim: target.unit,
+          attacker: caster,
+          damage: target.damagePerSecond * elapsed,
+          damage_type: DamageTypes.MAGICAL,
+          ability,
+        });
+        target.lastDamageTime = damageEndTime;
+      }
+
+      if (now >= target.endTime) {
+        if (!target.modifier.IsNull()) target.modifier.Destroy();
+        this.destroyShackleParticle(target.particle);
+        continue;
+      }
+      activeTargets.push(target);
+    }
+    this.targets = activeTargets;
+
+    if (this.targets.length === 0) {
+      this.Destroy();
+      return;
+    }
+
+    this.tryEmitScepterShocks(now);
+  }
+
+  OnDestroy(): void {
+    if (!IsServer()) return;
+
+    const proxy = this.GetParent();
+    proxy.FadeGesture(GameActivity.DOTA_CHANNEL_ABILITY_3);
+    StopSoundOn(SHACKLE_SOUND, proxy);
+
+    for (const target of this.targets) {
+      if (!target.modifier.IsNull()) target.modifier.Destroy();
+      this.destroyShackleParticle(target.particle);
+    }
+    this.targets = [];
+  }
+
+  private createShackleParticle(target: CDOTA_BaseNPC): ParticleID {
+    const proxy = this.GetParent();
+    const particle = ParticleManager.CreateParticle(
+      SHACKLE_PARTICLE,
+      ParticleAttachment.CUSTOMORIGIN_FOLLOW,
+      proxy,
+    );
+    ParticleManager.SetParticleControlEnt(
+      particle,
+      0,
+      proxy,
+      ParticleAttachment.POINT_FOLLOW,
+      'attach_attack1',
+      proxy.GetAbsOrigin(),
+      true,
+    );
+    ParticleManager.SetParticleControlEnt(
+      particle,
+      1,
+      target,
+      ParticleAttachment.POINT_FOLLOW,
+      'attach_hitloc',
+      target.GetAbsOrigin(),
+      true,
+    );
+    ParticleManager.SetParticleControlEnt(
+      particle,
+      5,
+      proxy,
+      ParticleAttachment.POINT_FOLLOW,
+      'attach_attack2',
+      proxy.GetAbsOrigin(),
+      true,
+    );
+    ParticleManager.SetParticleControlEnt(
+      particle,
+      6,
+      target,
+      ParticleAttachment.POINT_FOLLOW,
+      'attach_hitloc',
+      target.GetAbsOrigin(),
+      true,
+    );
+    return particle;
+  }
+
+  private destroyShackleParticle(particle: ParticleID): void {
+    ParticleManager.DestroyParticle(particle, false);
+    ParticleManager.ReleaseParticleIndex(particle);
+  }
+
+  private tryEmitScepterShocks(now: number): void {
+    if (this.nextScepterShockTime === undefined || now < this.nextScepterShockTime) return;
+
+    const ability = this.GetAbility();
+    if (!ability || ability.IsNull()) return;
+
+    const shockInterval = ability.GetSpecialValueFor('scepter_shock_interval');
+    if (shockInterval <= 0) {
+      this.nextScepterShockTime = undefined;
+      return;
+    }
+    this.nextScepterShockTime = now + shockInterval;
+
+    const caster = this.GetCaster();
+    if (!caster || caster.IsNull()) return;
+    const etherShock = caster.FindAbilityByName(ETHER_SHOCK_ABILITY);
+    if (!etherShock || etherShock.IsNull() || etherShock.GetLevel() <= 0) return;
+
+    const damage =
+      etherShock.GetSpecialValueFor('damage') *
+      (ability.GetSpecialValueFor('scepter_shock_pct') / 100);
+    const radius = ability.GetSpecialValueFor('scepter_shock_radius');
+    if (damage <= 0 || radius <= 0) return;
+
+    for (const source of this.targets) {
+      if (source.unit.IsNull() || !source.unit.IsAlive()) continue;
+
+      const victims = FindUnitsInRadius(
+        caster.GetTeamNumber(),
+        source.unit.GetAbsOrigin(),
+        undefined,
+        radius,
+        UnitTargetTeam.ENEMY,
+        UnitTargetType.HERO + UnitTargetType.BASIC,
+        UnitTargetFlags.MAGIC_IMMUNE_ENEMIES,
+        FindOrder.ANY,
+        false,
+      );
+      for (const victim of victims) {
+        if (victim === source.unit) continue;
+
+        ApplyDamage({
+          victim,
+          attacker: caster,
+          damage,
+          damage_type: etherShock.GetAbilityDamageType(),
+          ability,
+        });
+        this.playEtherShockParticle(source.unit, victim);
+      }
+    }
+  }
+
+  private playEtherShockParticle(source: CDOTA_BaseNPC, target: CDOTA_BaseNPC): void {
+    const particle = ParticleManager.CreateParticle(
+      ETHER_SHOCK_PARTICLE,
+      ParticleAttachment.CUSTOMORIGIN,
+      source,
+    );
+    ParticleManager.SetParticleControlEnt(
+      particle,
+      0,
+      source,
+      ParticleAttachment.POINT_FOLLOW,
+      'attach_hitloc',
+      source.GetAbsOrigin(),
+      true,
+    );
+    ParticleManager.SetParticleControlEnt(
+      particle,
+      1,
+      target,
+      ParticleAttachment.POINT_FOLLOW,
+      'attach_hitloc',
+      target.GetAbsOrigin(),
+      true,
+    );
+    ParticleManager.ReleaseParticleIndex(particle);
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_shadow_shaman_shackles_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_shadow_shaman_shackles_awaken_status extends BaseModifier {
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return 'shadow_shaman_shackles';
+  }
+}
+
+@registerModifier('abilities/ts_abilities/special_bonus_unique_shadow_shaman_shackles_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_shadow_shaman_shackles_awaken_debuff extends BaseModifier {
+  GetAttributes(): ModifierAttribute {
+    return ModifierAttribute.MULTIPLE;
+  }
+
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsDebuff(): boolean {
+    return true;
+  }
+
+  IsStunDebuff(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  IsPurgeException(): boolean {
+    return true;
+  }
+
+  GetTexture(): string {
+    return 'shadow_shaman_shackles';
+  }
+
+  CheckState(): Partial<Record<ModifierState, boolean>> {
+    return {
+      [ModifierState.STUNNED]: true,
+    };
+  }
+}

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_shadow_shaman_shackles_awaken.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_shadow_shaman_shackles_awaken.ts
@@ -21,6 +21,14 @@ interface ShackledTarget {
   endTime: number;
 }
 
+interface ScepterShockContext {
+  caster: CDOTA_BaseNPC;
+  ability: CDOTABaseAbility;
+  etherShock: CDOTABaseAbility;
+  damage: number;
+  radius: number;
+}
+
 @registerAbility('special_bonus_unique_shadow_shaman_shackles_awaken')
 export class SpecialBonusUniqueShadowShamanShacklesAwaken extends BaseAbility {
   GetIntrinsicModifierName(): string {
@@ -296,55 +304,72 @@ export class modifier_special_bonus_unique_shadow_shaman_shackles_awaken_proxy e
   }
 
   private tryEmitScepterShocks(now: number): void {
-    if (this.nextScepterShockTime === undefined || now < this.nextScepterShockTime) return;
+    if (!this.consumeScepterShockTimer(now)) return;
+
+    const context = this.getScepterShockContext();
+    if (!context) return;
+
+    for (const source of this.targets) {
+      if (source.unit.IsNull() || !source.unit.IsAlive()) continue;
+      this.emitScepterShocksFrom(source.unit, context);
+    }
+  }
+
+  private consumeScepterShockTimer(now: number): boolean {
+    if (this.nextScepterShockTime === undefined || now < this.nextScepterShockTime) return false;
 
     const ability = this.GetAbility();
-    if (!ability || ability.IsNull()) return;
+    if (!ability || ability.IsNull()) return false;
 
     const shockInterval = ability.GetSpecialValueFor('scepter_shock_interval');
     if (shockInterval <= 0) {
       this.nextScepterShockTime = undefined;
-      return;
+      return false;
     }
     this.nextScepterShockTime = now + shockInterval;
+    return true;
+  }
 
+  private getScepterShockContext(): ScepterShockContext | undefined {
+    const ability = this.GetAbility();
     const caster = this.GetCaster();
-    if (!caster || caster.IsNull()) return;
+    if (!ability || ability.IsNull() || !caster || caster.IsNull()) return undefined;
+
     const etherShock = caster.FindAbilityByName(ETHER_SHOCK_ABILITY);
-    if (!etherShock || etherShock.IsNull() || etherShock.GetLevel() <= 0) return;
+    if (!etherShock || etherShock.IsNull() || etherShock.GetLevel() <= 0) return undefined;
 
     const damage =
       etherShock.GetSpecialValueFor('damage') *
       (ability.GetSpecialValueFor('scepter_shock_pct') / 100);
     const radius = ability.GetSpecialValueFor('scepter_shock_radius');
-    if (damage <= 0 || radius <= 0) return;
+    if (damage <= 0 || radius <= 0) return undefined;
 
-    for (const source of this.targets) {
-      if (source.unit.IsNull() || !source.unit.IsAlive()) continue;
+    return { caster, ability, etherShock, damage, radius };
+  }
 
-      const victims = FindUnitsInRadius(
-        caster.GetTeamNumber(),
-        source.unit.GetAbsOrigin(),
-        undefined,
-        radius,
-        UnitTargetTeam.ENEMY,
-        UnitTargetType.HERO + UnitTargetType.BASIC,
-        UnitTargetFlags.MAGIC_IMMUNE_ENEMIES,
-        FindOrder.ANY,
-        false,
-      );
-      for (const victim of victims) {
-        if (victim === source.unit) continue;
+  private emitScepterShocksFrom(source: CDOTA_BaseNPC, context: ScepterShockContext): void {
+    const victims = FindUnitsInRadius(
+      context.caster.GetTeamNumber(),
+      source.GetAbsOrigin(),
+      undefined,
+      context.radius,
+      UnitTargetTeam.ENEMY,
+      UnitTargetType.HERO + UnitTargetType.BASIC,
+      UnitTargetFlags.MAGIC_IMMUNE_ENEMIES,
+      FindOrder.ANY,
+      false,
+    );
+    for (const victim of victims) {
+      if (victim === source) continue;
 
-        ApplyDamage({
-          victim,
-          attacker: caster,
-          damage,
-          damage_type: etherShock.GetAbilityDamageType(),
-          ability,
-        });
-        this.playEtherShockParticle(source.unit, victim);
-      }
+      ApplyDamage({
+        victim,
+        attacker: context.caster,
+        damage: context.damage,
+        damage_type: context.etherShock.GetAbilityDamageType(),
+        ability: context.ability,
+      });
+      this.playEtherShockParticle(source, victim);
     }
   }
 

--- a/src/vscripts/ai/ability/specs/shadow_shaman_shackles.ts
+++ b/src/vscripts/ai/ability/specs/shadow_shaman_shackles.ts
@@ -1,13 +1,22 @@
 import { AbilitySpec, TargetSide } from '../ability-spec';
 
 /**
- * 暗影萨满 - 枷锁：UNIT_TARGET | CHANNELLED / ENEMY / HERO | BASIC。
+ * 暗影萨满 - 枷锁及觉醒替换：对敌方英雄施放控制。
  *
- * 跳过已被控制的目标，避免对眩晕中的敌人浪费 channeled 技能时间。
+ * 跳过已被控制的目标，避免浪费持续控制时间。
  */
 export const SPECS: AbilitySpec[] = [
   {
     abilityName: 'shadow_shaman_shackles',
+    targetSide: TargetSide.EnemyHero,
+    condition: {
+      target: {
+        unitCondition: { notActionable: true },
+      },
+    },
+  },
+  {
+    abilityName: 'special_bonus_unique_shadow_shaman_shackles_awaken',
     targetSide: TargetSide.EnemyHero,
     condition: {
       target: {

--- a/src/vscripts/items/ts_items/item_saint_orb.ts
+++ b/src/vscripts/items/ts_items/item_saint_orb.ts
@@ -226,6 +226,7 @@ export function GetAbsorbSpell(
 const reflectExceptions: string[] = [
   'rubick_spell_steal',
   'shadow_shaman_shackles',
+  'special_bonus_unique_shadow_shaman_shackles_awaken',
   'legion_commander_duel',
   'phantom_assassin_phantom_strike',
   'riki_blink_strike',

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,13 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 暗影萨满 觉醒
+  {
+    heroName: 'npc_dota_hero_shadow_shaman',
+    targetAbility: 'shadow_shaman_shackles',
+    newAbility: 'special_bonus_unique_shadow_shaman_shackles_awaken',
+    newLevel: 0,
+  },
   // 撼地者 觉醒
   {
     heroName: 'npc_dota_hero_earthshaker',
@@ -263,6 +270,7 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  * 新觉醒发布时加入，下次发版由 awaken-ability skill 流程确认移出。
  */
 export const FREE_TRIAL_HEROES: string[] = [
+  'npc_dota_hero_shadow_shaman', // 暗影萨满
   'npc_dota_hero_earthshaker', // 撼地者
   'npc_dota_hero_abyssal_underlord', // 孽主
   'npc_dota_hero_slark', // 斯拉克


### PR DESCRIPTION
## Summary

- Add Shadow Shaman's Proxy Shackles awakening as a true replacement for Shackles.
- Turn Shackles into a ground-targeted area disable with extended duration, maintained by an invulnerable and unselectable proxy while Shadow Shaman remains free to act.
- Preserve the project's Scepter shock behavior, add a visible awakening status, prevent spell reflection and Butterfly recursion, and bind all native shackle particle control points correctly.
- Add AI casting support, free-trial wiring, and Chinese, English, and Russian localization.

## Checklist

- [x] I have tested the changes works well.
- [x] User tested the final area Shackles, proxy behavior, status icon, and corrected particle rendering in Dota Tools.
- [x] VScripts and Panorama builds, full lint, Jest, KV/localization parsing, and diff checks pass on the latest `origin/develop`.
- [ ] Verify permanent purchase, random purchase, awakening stone activation, and persistence after re-entering a match.
- [ ] Verify English and Russian tooltips plus ability/status Ping output in game.

## Release Note

```
[b]游戏性更新 v5.52b[/b]

- 新增暗影萨满觉醒：替身对范围内敌人维持更长时间的枷锁，本体可以自由行动，且不会触发法术格挡或法术反射。
```

```
[b]Gameplay update v5.52b[/b]

- Added Shadow Shaman's Proxy Shackles Awakened: a proxy maintains longer area Shackles while Shadow Shaman remains free to act, without triggering Spell Block or Spell Reflection.
```
