### PR TITLE
Fix World Destruction against magic-immune enemies

### DIFF
--- a/game/scripts/npc/npc_items_artifact.txt
+++ b/game/scripts/npc/npc_items_artifact.txt
@@ -501,6 +501,7 @@
 		"ID"							"9627"
 		"AbilityTextureName"			"item_blessing_of_dragon_2"
 		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_IGNORE_BACKSWING"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
 		"AbilityCastPoint"				"0"
 		"AbilityHealthCost"				"0"
 		"AbilityCooldown"				"0"


### PR DESCRIPTION
## Summary

- Allow Dragon's Blessing of Destruction to affect magic-immune enemies, including heroes protected by Black King Bar.

## Testing

- `npm run build:vscripts`
- `npm run build:panorama`
- User verified World Destruction against an enemy protected by Black King Bar in Dota Tools.

## Checklist

- [x] I have tested the changes works well.
