### PR TITLE
Add Death Prophet AI possession awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1415,6 +1415,26 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield"			"Power Cogs Awakened"
 		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield_Description"	"Damage taken is reduced by %dMODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE%%%."
 
+		// Death Prophet Awakened
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession"					"<font color='#d000ff'>Spirit Possession</font>"
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_SummaryDescription"	"Take over a real enemy AI hero for %duration% seconds, temporarily turning it to Death Prophet's side under her player's control."
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_SummaryDescription_scepter"	"Scepter: Damage dealt by Death Prophet or the possessed hero to a non-building enemy calls at most one pursuing spirit every 0.75s, dealing bonus physical damage and healing its source."
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_Description"		"Death Prophet merges herself and her spirits into a real enemy AI hero. Her body leaves play while her player controls the target's movement, attacks, original abilities, and items. The target also inherits Death Prophet's <font color='#FFD700'>account progression bonuses and abilities selected this match</font>, then temporarily joins her team; all kills, damage, assists, and damage taken during possession are credited to Death Prophet. If the target takes lethal damage or the duration ends, Death Prophet kills it and reappears at its location.\n\nCan only target real enemy AI heroes and can be blocked by Spell Block. After learning Exorcism's duration talent, kills on current enemy heroes by the possessed unit extend this possession by the talent's value. After awakening, the original “+4 Exorcism Spirits” talent instead increases the possessed target's total damage by 25%%.\n\nWith <font color='#92acf5'>Aghanim's Scepter</font>, damage dealt by Death Prophet or the possessed hero to a non-building enemy calls a pursuing spirit that deals bonus physical damage and heals its source based on actual damage dealt."
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_duration"			"POSSESSION DURATION:"
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_scepter_proc_damage"	"SCEPTER SPIRIT DAMAGE:"
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_scepter_proc_cooldown"	"SCEPTER SPIRIT INTERVAL:"
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_scepter_proc_heal_pct"	"SCEPTER SPIRIT HEAL:"
+		"DOTA_Tooltip_ability_special_bonus_unique_death_prophet_ai_possession_power"	"+{s:value}% Possessed Target Total Damage"
+		"DOTA_Tooltip_ability_special_bonus_unique_death_prophet_ai_possession_duration_on_kill"	"Possessed Hero Kills Extend Possession by +{s:duration_increase_per_kill}s"
+		"DOTA_Tooltip_modifier_death_prophet_ai_possession_awakened"				"Spirit Possession Awakened"
+		"DOTA_Tooltip_modifier_death_prophet_ai_possession_awakened_Description"		"Exorcism has awakened into Spirit Possession."
+		"DOTA_Tooltip_modifier_death_prophet_exorcism_ai_possession_controller"		"Disembodied Spirits"
+		"DOTA_Tooltip_modifier_death_prophet_exorcism_ai_possession_controller_Description"	"Death Prophet's body is merged with the possessed hero. She reappears at the target's location when possession ends."
+		"DOTA_Tooltip_modifier_death_prophet_ai_possession_target"				"Spirit Possession"
+		"DOTA_Tooltip_modifier_death_prophet_ai_possession_target_Description"		"Controlled by Death Prophet's player, inheriting her account progression and selected abilities while fighting for her team. Death Prophet kills this hero when possession ends. Remaining time: %dMODIFIER_PROPERTY_TOOLTIP%s."
+		"dota_hud_error_death_prophet_ai_possession_ai_only"					"Must target a real enemy AI hero"
+		"dota_hud_error_death_prophet_ai_possession_active"					"Target is already possessed"
+
 		// Doom Awakened
 		"DOTA_Tooltip_ability_doom_bringer_doom_awakened"							"<font color='#d000ff'>Doom Awakened</font>"
 		"DOTA_Tooltip_ability_doom_bringer_doom_awakened_Description"			"Inflicts a curse that dispels an enemy and prevents them from casting spells or healing in any way, while taking damage over time.\n\nDISPEL TYPE: Basic Dispel\n\nWith <font color='#92acf5'>Aghanim's Scepter</font>, Doom also applies <font color='#DD621E'>Break</font> and may target the caster or an <font color='#FFFFFF'>allied hero</font> instead, continuously Dooming enemies within a %scepter_aura_radius% radius without affecting the target itself.\n\nAfter awakening, neutral abilities gained through <font color='#FFFFFF'>Devour</font> are automatically raised to their maximum level."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -638,6 +638,26 @@
 
 		// Сундук с сокровищами
 		"npc_treasure_chest"													"Сундук с сокровищами"
+		// Пробуждение Death Prophet
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession"					"<font color='#d000ff'>Одержимость духами</font>"
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_SummaryDescription"	"Подчиняет настоящего вражеского героя под управлением ИИ на %duration% сек., временно переводя его на сторону Death Prophet и под контроль её игрока."
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_SummaryDescription_scepter"	"Scepter: Урон Death Prophet или одержимого героя вражескому существу, не являющемуся строением, призывает не чаще раза в 0,75 сек. духа, который наносит физический урон и лечит источник эффекта."
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_Description"		"Death Prophet сливается со своими духами и вселяется в настоящего вражеского героя под управлением ИИ. Её тело покидает игру, а игрок получает контроль над передвижением, атаками, исходными способностями и предметами цели. Цель также получает <font color='#FFD700'>внешние бонусы развития и выбранные в этом матче способности</font> Death Prophet, после чего временно переходит в её команду; все убийства, урон, содействия и полученный урон засчитываются Death Prophet. При смертельном уроне или окончании времени Death Prophet убивает цель и появляется на её месте.\n\nМожно применить только к настоящему вражескому герою под управлением ИИ. Способность блокируется Spell Block. После изучения таланта длительности Exorcism убийства текущих вражеских героев одержимой целью продлевают эффект на значение таланта. После пробуждения исходный талант «+4 духа Exorcism» вместо этого увеличивает общий урон одержимой цели на 25%%.\n\nС <font color='#92acf5'>Aghanim's Scepter</font> урон Death Prophet или одержимого героя вражескому существу, не являющемуся строением, вызывает преследующего духа: он наносит дополнительный физический урон и лечит источник эффекта в зависимости от фактического урона."
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_duration"			"ДЛИТЕЛЬНОСТЬ ОДЕРЖИМОСТИ:"
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_scepter_proc_damage"	"УРОН ДУХА ОТ SCEPTER:"
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_scepter_proc_cooldown"	"ИНТЕРВАЛ ДУХА ОТ SCEPTER:"
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_scepter_proc_heal_pct"	"ЛЕЧЕНИЕ ДУХА ОТ SCEPTER:"
+		"DOTA_Tooltip_ability_special_bonus_unique_death_prophet_ai_possession_power"	"+{s:value}% к общему урону одержимой цели"
+		"DOTA_Tooltip_ability_special_bonus_unique_death_prophet_ai_possession_duration_on_kill"	"Убийства одержимого героя продлевают одержимость на +{s:duration_increase_per_kill} сек."
+		"DOTA_Tooltip_modifier_death_prophet_ai_possession_awakened"				"Пробуждение одержимости"
+		"DOTA_Tooltip_modifier_death_prophet_ai_possession_awakened_Description"		"Exorcism пробудился и стал Spirit Possession."
+		"DOTA_Tooltip_modifier_death_prophet_exorcism_ai_possession_controller"		"Дух вне тела"
+		"DOTA_Tooltip_modifier_death_prophet_exorcism_ai_possession_controller_Description"	"Тело Death Prophet слито с одержимым героем. После окончания эффекта она появляется на месте цели."
+		"DOTA_Tooltip_modifier_death_prophet_ai_possession_target"				"Одержимость духами"
+		"DOTA_Tooltip_modifier_death_prophet_ai_possession_target_Description"		"Управляется игроком Death Prophet, получает её внешние бонусы и выбранные способности и временно сражается за её команду. В конце одержимости Death Prophet убивает цель. Осталось: %dMODIFIER_PROPERTY_TOOLTIP% сек."
+		"dota_hud_error_death_prophet_ai_possession_ai_only"					"Нужен настоящий вражеский герой под управлением ИИ"
+		"dota_hud_error_death_prophet_ai_possession_active"					"Цель уже одержима"
+
 		// Doom Awakened
 		"DOTA_Tooltip_ability_doom_bringer_doom_awakened"							"<font color='#d000ff'>Пробуждённый Doom</font>"
 		"DOTA_Tooltip_ability_doom_bringer_doom_awakened_Description"			"Накладывает проклятие, которое развеивает врага и не позволяет ему использовать способности или лечиться, при этом враг постепенно получает урон.\n\nТИП РАЗВЕИВАНИЯ: Простое развеивание\n\nС <font color='#92acf5'>Aghanim's Scepter</font> Doom также накладывает <font color='#DD621E'>Разрушение</font> и может применяться к владельцу или <font color='#FFFFFF'>союзному герою</font>, который будет непрерывно накладывать Doom на врагов в радиусе %scepter_aura_radius%, сам не получая Doom.\n\nПосле пробуждения способности нейтральных крипов, полученные с помощью <font color='#FFFFFF'>Devour</font>, автоматически повышаются до максимального уровня."

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1413,6 +1413,26 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield"			"发条 觉醒"
 		"DOTA_Tooltip_modifier_special_bonus_unique_rattletrap_upgrade_shield_Description"	"受到的伤害降低%dMODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE%%%。"
 
+		// 死亡先知-觉醒
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession"					"<font color='#d000ff'>恶灵夺舍</font>"
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_SummaryDescription"	"接管一名敌方真实AI英雄%duration%秒，使其临时加入己方并由死亡先知的玩家操控。"
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_SummaryDescription_scepter"	"神杖：死亡先知或附身目标对敌方非建筑单位造成伤害时，每0.75秒最多召来一只恶灵，造成额外物理伤害并治疗触发者。"
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_Description"		"死亡先知将自身与恶灵融入一名敌方真实AI英雄，本体暂时离场，并在持续时间内接管目标的移动、攻击、原有技能和物品。目标同时继承死亡先知的<font color='#FFD700'>局外成长属性与本局自选技能</font>，并临时加入死亡先知阵营；控制期间产生的击杀、伤害、助攻和承受伤害均按死亡先知结算。目标受到致命伤害或持续时间结束时，会由死亡先知完成击杀，死亡先知随后在其位置现身。\n\n仅能对敌方真实AI英雄施放，可被法术抵挡。学习驱使恶灵的持续时间天赋后，被接管单位击杀当前敌方英雄时，按天赋数值延长本次夺舍。觉醒后，原“+4 驱使恶灵数量”天赋改为使附身目标总伤害提高25%%。\n\n持有<font color='#92acf5'>阿哈利姆神杖</font>时，死亡先知本人或附身目标对敌方非建筑单位造成伤害会召来恶灵追击，造成额外物理伤害并按实际伤害治疗触发者。"
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_duration"			"夺舍持续时间："
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_scepter_proc_damage"	"神杖恶灵伤害："
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_scepter_proc_cooldown"	"神杖恶灵触发间隔："
+		"DOTA_Tooltip_ability_death_prophet_exorcism_ai_possession_scepter_proc_heal_pct"	"神杖恶灵治疗："
+		"DOTA_Tooltip_ability_special_bonus_unique_death_prophet_ai_possession_power"	"附身目标总伤害 +{s:value}%"
+		"DOTA_Tooltip_ability_special_bonus_unique_death_prophet_ai_possession_duration_on_kill"	"附身期间击杀敌方英雄延长 +{s:duration_increase_per_kill}秒附身时间"
+		"DOTA_Tooltip_modifier_death_prophet_ai_possession_awakened"				"恶灵夺舍·觉醒"
+		"DOTA_Tooltip_modifier_death_prophet_ai_possession_awakened_Description"		"驱使恶灵已觉醒为恶灵夺舍。"
+		"DOTA_Tooltip_modifier_death_prophet_exorcism_ai_possession_controller"		"恶灵离体"
+		"DOTA_Tooltip_modifier_death_prophet_exorcism_ai_possession_controller_Description"	"死亡先知的本体已融入被接管的英雄；夺舍结束后会在目标位置现身。"
+		"DOTA_Tooltip_modifier_death_prophet_ai_possession_target"				"恶灵夺舍"
+		"DOTA_Tooltip_modifier_death_prophet_ai_possession_target_Description"		"由死亡先知的玩家操控，继承其局外成长与自选技能，并临时为死亡先知阵营作战；结束时由死亡先知完成击杀。剩余时间：%dMODIFIER_PROPERTY_TOOLTIP%秒。"
+		"dota_hud_error_death_prophet_ai_possession_ai_only"					"只能接管敌方真实AI英雄"
+		"dota_hud_error_death_prophet_ai_possession_active"					"目标已被恶灵夺舍"
+
 		// 末日使者-觉醒
 		"DOTA_Tooltip_ability_doom_bringer_doom_awakened"							"<font color='#d000ff'>末日 觉醒</font>"
 		"DOTA_Tooltip_ability_doom_bringer_doom_awakened_Description"			"对敌人施加末日诅咒，对其进行驱散，并且使其<font color='#6db6e9'>无法施放技能</font>或获得任何<font color='#07d738'>治疗</font>效果，同时造成持续伤害。\n\n驱散类型：弱驱散\n\n持有<font color='#92acf5'>阿哈利姆神杖</font>时，末日额外施加<font color='#DD621E'>破坏</font>效果，并可对自己或<font color='#FFFFFF'>友方英雄</font>释放，持续对周围%scepter_aura_radius%范围内的敌人造成末日效果，自身不受影响。\n\n觉醒后，<font color='#FFFFFF'>吞噬</font>获得的野怪技能会自动提升至最高等级。"

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -5,6 +5,91 @@
 	// 英雄专属强化/替换技能，通过抽奖池获得
 	//=================================================================================================================
 
+	// 死亡先知 觉醒
+	"death_prophet_exorcism_ai_possession"
+	{
+		"BaseClass"						"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/death_prophet_exorcism_ai_possession"
+		"AbilityTextureName"			"death_prophet_exorcism"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityType"					"ABILITY_TYPE_ULTIMATE"
+		"AbilityUnitTargetTeam"			"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"		"DOTA_UNIT_TARGET_FLAG_NOT_ILLUSIONS"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_NO"
+		"SpellDispellableType"			"SPELL_DISPELLABLE_NO"
+		"MaxLevel"						"4"
+		"RequiredLevel"					"6"
+		"LevelsBetweenUpgrades"			"6"
+		"AbilityCastPoint"				"0.5"
+		"AbilityCastRange"				"700"
+		"AbilityCooldown"				"150"
+		"AbilityManaCost"				"200 300 400 500"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_4"
+		"HasScepterUpgrade"				"1"
+
+		"precache"
+		{
+			"particle"		"particles/units/heroes/hero_death_prophet/death_prophet_spirit_model.vpcf"
+		}
+
+		"AbilityValues"
+		{
+			"duration"
+			{
+				"value"					"40"
+				"IsDuration"				"1"
+			}
+			"scepter_proc_damage"
+			{
+				"value"					"160 260 360 460"
+				"RequiresScepter"			"1"
+			}
+			"scepter_proc_cooldown"
+			{
+				"value"					"0.75"
+				"RequiresScepter"			"1"
+			}
+			"scepter_proc_heal_pct"
+			{
+				"value"					"25"
+				"RequiresScepter"			"1"
+			}
+		}
+	}
+
+	"special_bonus_unique_death_prophet_ai_possession_power"
+	{
+		"BaseClass"						"special_bonus_base"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityType"					"ABILITY_TYPE_ATTRIBUTES"
+		"AbilityTextureName"			"death_prophet_exorcism"
+		"MaxLevel"						"1"
+
+		"AbilityValues"
+		{
+			"value"							"25"
+		}
+	}
+
+	"special_bonus_unique_death_prophet_ai_possession_duration_on_kill"
+	{
+		"BaseClass"						"special_bonus_base"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityType"					"ABILITY_TYPE_ATTRIBUTES"
+		"AbilityTextureName"			"death_prophet_exorcism"
+		"MaxLevel"						"1"
+
+		"AbilityValues"
+		{
+			"duration_increase_per_kill"
+			{
+				"value"						"8"
+				"IsDuration"					"1"
+			}
+		}
+	}
+
 	// 撼地者 余震觉醒
 	"special_bonus_unique_earthshaker_upgrade"
 	{

--- a/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
+++ b/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
@@ -228,6 +228,7 @@ EXCLUDED_ABILITIES_ALLBUTTER = {
     ["doom_bringer_doom"] = true,          -- 末日
     ["doom_bringer_devour"] = true,        -- 末日 吞噬
     ["doom_bringer_doom_awakened"] = true, -- 末日 觉醒
+    ["death_prophet_exorcism_ai_possession"] = true, -- 死亡先知 恶灵夺舍（切换队伍与玩家归属）
     -- ========================================
     -- 玛西技能组
     -- 原因:玛西的技能组有特殊的联动机制,随机触发会破坏技能连招

--- a/game/scripts/vscripts/util.lua
+++ b/game/scripts/vscripts/util.lua
@@ -180,6 +180,8 @@ end
 --------------------------------------------------------------------------------
 function IsHeroUncontrollable(hHero)
 	if hHero:IsNull() then return true end
+	-- 与 TS AI 共用同一附身标记：玩家接管期间旧 Lua 物品 AI 不再发出动作。
+	if hHero:HasModifier("modifier_death_prophet_ai_possession_target") then return true end
 	-- if hero is dead, do nothing
 	if hHero:IsAlive() == false then return true end
 	-- 眩晕

--- a/src/common/events.d.ts
+++ b/src/common/events.d.ts
@@ -36,6 +36,7 @@ interface CustomGameEventDeclarations {
   alipay_order_clear: Record<string, never>;
 
   hud_open_page: HudOpenPageEventData;
+  death_prophet_possession_select: DeathProphetPossessionSelectEventData;
 
   player_conduct: PlayerConductEventData;
 
@@ -120,6 +121,11 @@ interface HudOpenPageEventData {
   page: string;
   param?: string;
   playerId: PlayerID;
+}
+
+interface DeathProphetPossessionSelectEventData {
+  entindex: EntityIndex;
+  active: 0 | 1;
 }
 
 interface AwakenUnlockHeroEventData {

--- a/src/panorama/react/hud_lottery/hotkey.ts
+++ b/src/panorama/react/hud_lottery/hotkey.ts
@@ -3,14 +3,28 @@ import { AddKeyBind, FindDotaHudElement } from '@utils/utils';
 const notTargetAbilityNames = ['earthshaker_enchant_totem'];
 // 拥有unit target，但是只能对友军释放的技能（特殊情况）
 const unitTargetOnlyFriendlyAbilityNames = ['abyssal_underlord_firestorm'];
+let abilityKeyUnitOverride: EntityIndex | undefined;
+
+export function setAbilityKeyUnitOverride(entindex: EntityIndex | undefined): void {
+  abilityKeyUnitOverride = entindex;
+}
+
+function getAbilityKeyUnit(): EntityIndex {
+  if (abilityKeyUnitOverride !== undefined && Entities.IsValidEntity(abilityKeyUnitOverride)) {
+    return abilityKeyUnitOverride;
+  }
+  return Players.GetPlayerHeroEntityIndex(Game.GetLocalPlayerID());
+}
 
 export function bindAbilityKey(abilityname: string, key: string, isQuickCast: boolean) {
-  const heroID = Players.GetPlayerHeroEntityIndex(Game.GetLocalPlayerID());
-  const abilityID = Entities.GetAbilityByName(heroID, abilityname);
-  // 绑定施法
+  // 每次按键重新解析当前载体与技能实体；夺舍会把自选技能临时复制到另一名英雄上。
   AddKeyBind(
     key,
-    () => executeAbilityCast(heroID, abilityID, isQuickCast),
+    () => {
+      const abilityUnit = getAbilityKeyUnit();
+      const abilityID = Entities.GetAbilityByName(abilityUnit, abilityname);
+      if (abilityID !== -1) executeAbilityCast(abilityUnit, abilityID, isQuickCast);
+    },
     () => {},
   );
 }
@@ -42,7 +56,7 @@ export function bindInventorySlotKey(inventorySlot: number, key: string, isQuick
   AddKeyBind(
     key,
     () => {
-      const heroID = Players.GetPlayerHeroEntityIndex(Game.GetLocalPlayerID());
+      const heroID = getAbilityKeyUnit();
       if (heroID === -1) {
         return;
       }
@@ -62,7 +76,7 @@ const INVENTORY_HOTKEY_LABEL_ID = 'InventorySlotHotkeyTextCustom';
 
 /** Keep custom key labels attached to the native backpack slot panels. */
 export function saveInventorySlotHotkeys(slot7Key: string, slot8Key: string, slot9Key: string) {
-  const heroID = Players.GetPlayerHeroEntityIndex(Game.GetLocalPlayerID());
+  const heroID = getAbilityKeyUnit();
   const portraitUnitID = Players.GetLocalPlayerPortraitUnit();
   const showHeroHotkeys = heroID !== -1 && portraitUnitID === heroID;
   const keys = [slot7Key, slot8Key, slot9Key];
@@ -119,7 +133,7 @@ function executeAbilityCast(
   }
   if (GameUI.IsAltDown() === true) {
     // alt切换自动施法
-    const castSuccess = castAbilityWhenAltDown(abilityID, Abilities.GetBehavior(abilityID));
+    const castSuccess = castAbilityWhenAltDown(heroID, abilityID, Abilities.GetBehavior(abilityID));
     if (castSuccess) {
       return;
     }
@@ -186,6 +200,7 @@ function isValidTargetTeam(
  * 按住Alt键时，切换自动施法，对自己施法
  */
 function castAbilityWhenAltDown(
+  abilityUnit: EntityIndex,
   abilityID: AbilityEntityIndex,
   behavior: DOTA_ABILITY_BEHAVIOR,
 ): boolean {
@@ -193,7 +208,7 @@ function castAbilityWhenAltDown(
   if (Abilities.IsAutocast(abilityID)) {
     Game.PrepareUnitOrders({
       OrderType: dotaunitorder_t.DOTA_UNIT_ORDER_CAST_TOGGLE_AUTO,
-      TargetIndex: Players.GetLocalPlayerPortraitUnit(),
+      TargetIndex: abilityUnit,
       AbilityIndex: abilityID,
       ShowEffects: true,
     });
@@ -209,7 +224,7 @@ function castAbilityWhenAltDown(
     ) {
       Game.PrepareUnitOrders({
         OrderType: dotaunitorder_t.DOTA_UNIT_ORDER_CAST_TARGET,
-        TargetIndex: Players.GetLocalPlayerPortraitUnit(),
+        TargetIndex: abilityUnit,
         AbilityIndex: abilityID,
         ShowEffects: true,
       });
@@ -291,7 +306,7 @@ function castUnitTargetAbility(
   }
 
   // 检测目标队伍，如果目标不符合技能的目标队伍要求，跳过处理
-  const heroID = Players.GetPlayerHeroEntityIndex(Game.GetLocalPlayerID());
+  const heroID = getAbilityKeyUnit();
   if (!isValidTargetTeam(abilityID, abilityName, target.entityIndex, heroID)) {
     return false;
   }
@@ -461,7 +476,7 @@ export function saveInputKeyborard(
   const passiveKeyText = bindKeyToText(passiveKey);
   const passiveKeyText2 = bindKeyToText(passiveKey2);
 
-  const heroID = Players.GetPlayerHeroEntityIndex(Game.GetLocalPlayerID());
+  const heroID = getAbilityKeyUnit();
   const portraitUnitID = Players.GetLocalPlayerPortraitUnit();
   if (portraitUnitID !== heroID) {
     return;

--- a/src/panorama/react/hud_lottery/script.tsx
+++ b/src/panorama/react/hud_lottery/script.tsx
@@ -7,6 +7,11 @@ import KeyBind from './KeyBind';
 import ItemLottery from './ItemLottery';
 import PassiveTomeLottery from './PassiveTomeLottery';
 import WardSlot from './WardSlot';
+import { setAbilityKeyUnitOverride } from './hotkey';
+
+GameEvents.Subscribe('death_prophet_possession_select', ({ entindex, active }) => {
+  setAbilityKeyUnitOverride(active === 1 ? entindex : undefined);
+});
 
 function Root() {
   return (

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,11 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_death_prophet',
+    abilityName: 'death_prophet_exorcism_ai_possession',
+    freeTrial: true,
+  },
+  {
     heroName: 'npc_dota_hero_earthshaker',
     abilityName: 'special_bonus_unique_earthshaker_upgrade',
     freeTrial: true,

--- a/src/panorama/react/hud_main/script.tsx
+++ b/src/panorama/react/hud_main/script.tsx
@@ -4,4 +4,43 @@ import React from 'react';
 import { render } from 'react-panorama-x';
 import HudMain from './HudMain';
 
+const MAX_POSSESSION_SELECT_ATTEMPTS = 30;
+let possessionSelectionRevision = 0;
+
+function selectPossessionEntityWhenControllable(
+  entindex: EntityIndex,
+  revision: number,
+  attempt = 0,
+): void {
+  if (revision !== possessionSelectionRevision) return;
+
+  const localPlayerId = Game.GetLocalPlayerID();
+  if (
+    Entities.IsValidEntity(entindex) &&
+    Entities.IsControllableByPlayer(entindex, localPlayerId) &&
+    !Entities.IsOutOfGame(entindex)
+  ) {
+    // 不建立服务器 override；等待客户端确认选择成功后就停止重试，之后仍可自由查看其他英雄。
+    GameUI.SelectUnit(entindex, false);
+    if (
+      Players.GetLocalPlayerPortraitUnit() !== entindex &&
+      attempt < MAX_POSSESSION_SELECT_ATTEMPTS
+    ) {
+      $.Schedule(0.03, () =>
+        selectPossessionEntityWhenControllable(entindex, revision, attempt + 1),
+      );
+    }
+    return;
+  }
+
+  if (attempt < MAX_POSSESSION_SELECT_ATTEMPTS) {
+    $.Schedule(0.03, () => selectPossessionEntityWhenControllable(entindex, revision, attempt + 1));
+  }
+}
+
+GameEvents.Subscribe('death_prophet_possession_select', ({ entindex }) => {
+  possessionSelectionRevision++;
+  selectPossessionEntityWhenControllable(entindex, possessionSelectionRevision);
+});
+
 render(<HudMain />, $.GetContextPanel());

--- a/src/vscripts/abilities/ts_abilities/death-prophet-ai-possession-constants.ts
+++ b/src/vscripts/abilities/ts_abilities/death-prophet-ai-possession-constants.ts
@@ -1,0 +1,2 @@
+export const DEATH_PROPHET_POSSESSION_TARGET_MODIFIER =
+  'modifier_death_prophet_ai_possession_target';

--- a/src/vscripts/abilities/ts_abilities/death-prophet-ai-possession-logic.test.ts
+++ b/src/vscripts/abilities/ts_abilities/death-prophet-ai-possession-logic.test.ts
@@ -1,0 +1,91 @@
+import {
+  extendPossessionDuration,
+  runBestEffortCleanup,
+  shouldExtendPossession,
+  uniqueAbilityNames,
+} from './death-prophet-ai-possession-logic';
+
+describe('Death Prophet possession logic', () => {
+  const baseKillContext = {
+    extension: 8,
+    victimIsRealHero: true,
+    victimIsIllusion: false,
+    victimIsReincarnating: false,
+    victimTeam: 3,
+    casterTeam: 2,
+    attackerIsTarget: true,
+    attackerIsCaster: false,
+    attackerPlayerId: 6,
+    casterPlayerId: 0,
+    attackerOwnerIsTargetOrCaster: false,
+  };
+
+  it('被附身目标击杀当前敌方真实英雄时延长持续时间', () => {
+    expect(shouldExtendPossession(baseKillContext)).toBe(true);
+    expect(extendPossessionDuration(11.5, 8)).toBe(19.5);
+  });
+
+  it.each([
+    { extension: 0 },
+    { victimIsRealHero: false },
+    { victimIsIllusion: true },
+    { victimIsReincarnating: true },
+    { victimTeam: 2 },
+    {
+      attackerIsTarget: false,
+      attackerIsCaster: false,
+      attackerPlayerId: 6,
+      casterPlayerId: 0,
+      attackerOwnerIsTargetOrCaster: false,
+    },
+  ])('不满足击杀条件时不延长：%o', (override) => {
+    expect(shouldExtendPossession({ ...baseKillContext, ...override })).toBe(false);
+  });
+
+  it('同一玩家控制的召唤物或附身目标所有者也计为附身击杀', () => {
+    expect(
+      shouldExtendPossession({
+        ...baseKillContext,
+        attackerIsTarget: false,
+        attackerPlayerId: 0,
+      }),
+    ).toBe(true);
+    expect(
+      shouldExtendPossession({
+        ...baseKillContext,
+        attackerIsTarget: false,
+        attackerOwnerIsTargetOrCaster: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('借用技能去重并保持首次出现顺序', () => {
+    expect(uniqueAbilityNames(['active', 'passive', 'active', '', 'passive2'])).toEqual([
+      'active',
+      'passive',
+      'passive2',
+    ]);
+  });
+
+  it('某个退出阶段报错后仍继续执行其余恢复阶段', () => {
+    const completed: string[] = [];
+    const errors: string[] = [];
+    runBestEffortCleanup(
+      [
+        { name: 'abilities', run: () => completed.push('abilities') },
+        {
+          name: 'identity',
+          run: () => {
+            throw new Error('identity failed');
+          },
+        },
+        { name: 'status', run: () => completed.push('status') },
+        { name: 'items', run: () => completed.push('items') },
+      ],
+      (name) => errors.push(name),
+    );
+
+    expect(completed).toEqual(['abilities', 'status', 'items']);
+    expect(errors).toEqual(['identity']);
+  });
+});

--- a/src/vscripts/abilities/ts_abilities/death-prophet-ai-possession-logic.ts
+++ b/src/vscripts/abilities/ts_abilities/death-prophet-ai-possession-logic.ts
@@ -1,0 +1,60 @@
+export interface PossessionKillContext {
+  extension: number;
+  victimIsRealHero: boolean;
+  victimIsIllusion: boolean;
+  victimIsReincarnating: boolean;
+  victimTeam: number;
+  casterTeam: number;
+  attackerIsTarget: boolean;
+  attackerIsCaster: boolean;
+  attackerPlayerId: number;
+  casterPlayerId?: number;
+  attackerOwnerIsTargetOrCaster: boolean;
+}
+
+export interface CleanupStage {
+  name: string;
+  run: () => void;
+}
+
+export function shouldExtendPossession(context: PossessionKillContext): boolean {
+  return (
+    context.extension > 0 &&
+    context.victimIsRealHero &&
+    !context.victimIsIllusion &&
+    !context.victimIsReincarnating &&
+    context.victimTeam !== context.casterTeam &&
+    (context.attackerIsTarget ||
+      context.attackerIsCaster ||
+      context.attackerPlayerId === context.casterPlayerId ||
+      context.attackerOwnerIsTargetOrCaster)
+  );
+}
+
+export function extendPossessionDuration(remaining: number, extension: number): number {
+  return Math.max(0, remaining) + Math.max(0, extension);
+}
+
+export function uniqueAbilityNames(names: Array<string | undefined>): string[] {
+  const seen: Record<string, true> = {};
+  const result: string[] = [];
+  for (const name of names) {
+    if (!name || seen[name]) continue;
+    seen[name] = true;
+    result.push(name);
+  }
+  return result;
+}
+
+export function runBestEffortCleanup(
+  stages: CleanupStage[],
+  onError: (stageName: string, error: unknown) => void,
+): void {
+  for (const stage of stages) {
+    try {
+      stage.run();
+    } catch (error) {
+      onError(stage.name, error);
+    }
+  }
+}

--- a/src/vscripts/abilities/ts_abilities/death-prophet-ai-possession-target.ts
+++ b/src/vscripts/abilities/ts_abilities/death-prophet-ai-possession-target.ts
@@ -1,0 +1,458 @@
+import { BaseModifier, registerModifier } from '../../utils/dota_ts_adapter';
+import { DEATH_PROPHET_POSSESSION_TARGET_MODIFIER } from './death-prophet-ai-possession-constants';
+import { runBestEffortCleanup } from './death-prophet-ai-possession-logic';
+
+const CONTROLLER_MODIFIER = 'modifier_death_prophet_exorcism_ai_possession_controller';
+const POSSESSION_DAMAGE_TALENT_AWAKENED = 'special_bonus_unique_death_prophet_ai_possession_power';
+const POSSESSION_VISION_REFRESH_INTERVAL = 0.5;
+const POSSESSION_VISION_DURATION = 0.6;
+
+interface PossessionController {
+  finishPossession(killTarget: boolean): void;
+  extendDurationForKill(attacker: CDOTA_BaseNPC, victim: CDOTA_BaseNPC): void;
+}
+
+interface PossessionAbility extends CDOTABaseAbility {
+  tryLaunchScepterSpiritFromDamage?(
+    event: ModifierInstanceEvent,
+    source: CDOTA_BaseNPC_Hero,
+    scepterEnabled: boolean,
+  ): void;
+}
+
+interface PossessionTargetParams {
+  death_prophet_entindex?: EntityIndex;
+  original_owner_entindex?: EntityIndex;
+  original_player_id?: PlayerID;
+  original_team?: DOTATeam_t;
+  had_scepter?: 0 | 1;
+  had_shard?: 0 | 1;
+  caster_had_scepter?: 0 | 1;
+  cooldownPercentage?: number;
+  castRangeBonus?: number;
+  aoeBonus?: number;
+  spellAmplifyPercentage?: number;
+  statusResistance?: number;
+  evasion?: number;
+  magicalResistance?: number;
+  incomingDamagePercentage?: number;
+  attackRangeBonus?: number;
+  physicalArmor?: number;
+  preattackDamage?: number;
+  attackSpeed?: number;
+  strength?: number;
+  agility?: number;
+  intellect?: number;
+  healthRegenPercentage?: number;
+  manaRegenPercentage?: number;
+  lifesteal?: number;
+  spellLifesteal?: number;
+  moveSpeed?: number;
+  bonusVision?: number;
+  ignoreMoveSpeedLimit?: 0 | 1;
+  cannotMiss?: 0 | 1;
+  slowImmune?: 0 | 1;
+  flying?: 0 | 1;
+}
+
+type PossessionProgressionValues = Required<
+  Omit<
+    PossessionTargetParams,
+    | 'death_prophet_entindex'
+    | 'original_owner_entindex'
+    | 'original_player_id'
+    | 'original_team'
+    | 'had_scepter'
+    | 'had_shard'
+    | 'caster_had_scepter'
+    | 'ignoreMoveSpeedLimit'
+    | 'cannotMiss'
+    | 'slowImmune'
+    | 'flying'
+  >
+> & {
+  ignoreMoveSpeedLimit: number;
+  cannotMiss: number;
+  slowImmune: number;
+  flying: number;
+};
+
+/** 可见标记兼作所有 Bot action owner 的统一暂停条件。 */
+@registerModifier(
+  'abilities/ts_abilities/death-prophet-ai-possession-target',
+  DEATH_PROPHET_POSSESSION_TARGET_MODIFIER,
+)
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_death_prophet_ai_possession_target extends BaseModifier {
+  private resolvingLethalDamage = false;
+  private preserveScepter = false;
+  private preserveShard = false;
+  private casterHadScepterAtCast = false;
+  private deathProphetEntindex?: EntityIndex;
+  private originalOwnerEntindex?: EntityIndex;
+  private originalPlayerId?: PlayerID;
+  private originalTeam?: DOTATeam_t;
+  private progression: PossessionProgressionValues = {
+    cooldownPercentage: 0,
+    castRangeBonus: 0,
+    aoeBonus: 0,
+    spellAmplifyPercentage: 0,
+    statusResistance: 0,
+    evasion: 0,
+    magicalResistance: 0,
+    incomingDamagePercentage: 0,
+    attackRangeBonus: 0,
+    physicalArmor: 0,
+    preattackDamage: 0,
+    attackSpeed: 0,
+    strength: 0,
+    agility: 0,
+    intellect: 0,
+    healthRegenPercentage: 0,
+    manaRegenPercentage: 0,
+    lifesteal: 0,
+    spellLifesteal: 0,
+    moveSpeed: 0,
+    bonusVision: 0,
+    ignoreMoveSpeedLimit: 0,
+    cannotMiss: 0,
+    slowImmune: 0,
+    flying: 0,
+  };
+
+  OnCreated(params: PossessionTargetParams): void {
+    this.deathProphetEntindex = params.death_prophet_entindex;
+    this.originalOwnerEntindex = params.original_owner_entindex;
+    this.originalPlayerId = params.original_player_id;
+    this.originalTeam = params.original_team;
+    this.preserveScepter = params.had_scepter === 1;
+    this.preserveShard = params.had_shard === 1;
+    this.casterHadScepterAtCast = params.caster_had_scepter === 1;
+    for (const [key, value] of Object.entries(params)) {
+      if (key in this.progression && typeof value === 'number') {
+        this.progression[key as keyof typeof this.progression] = value;
+      }
+    }
+    if (IsServer()) {
+      this.updateRemainingTimeStack();
+      this.providePossessionVision();
+      this.StartIntervalThink(POSSESSION_VISION_REFRESH_INTERVAL);
+      print(
+        `[DeathProphetPossession] target status created parent=${this.GetParent().GetUnitName()} duration=${this.GetRemainingTime()} caster_scepter=${this.casterHadScepterAtCast}`,
+      );
+    }
+  }
+
+  OnIntervalThink(): void {
+    if (!IsServer()) return;
+    this.updateRemainingTimeStack();
+    this.providePossessionVision();
+  }
+
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  IsPurgeException(): boolean {
+    return false;
+  }
+
+  IsDebuff(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return true;
+  }
+
+  GetTexture(): string {
+    return 'death_prophet_exorcism';
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [
+      ModifierFunction.MIN_HEALTH,
+      ModifierFunction.ON_TAKEDAMAGE,
+      ModifierFunction.ON_DEATH,
+      ModifierFunction.TOTALDAMAGEOUTGOING_PERCENTAGE,
+      ModifierFunction.IS_SCEPTER,
+      ModifierFunction.IS_SHARD,
+      ModifierFunction.TOOLTIP,
+      ModifierFunction.COOLDOWN_PERCENTAGE,
+      ModifierFunction.CAST_RANGE_BONUS_STACKING,
+      ModifierFunction.AOE_BONUS_CONSTANT_STACKING,
+      ModifierFunction.SPELL_AMPLIFY_PERCENTAGE,
+      ModifierFunction.STATUS_RESISTANCE_STACKING,
+      ModifierFunction.EVASION_CONSTANT,
+      ModifierFunction.MAGICAL_RESISTANCE_BONUS,
+      ModifierFunction.INCOMING_DAMAGE_PERCENTAGE,
+      ModifierFunction.ATTACK_RANGE_BONUS,
+      ModifierFunction.PHYSICAL_ARMOR_BONUS,
+      ModifierFunction.PREATTACK_BONUS_DAMAGE,
+      ModifierFunction.ATTACKSPEED_BONUS_CONSTANT,
+      ModifierFunction.STATS_STRENGTH_BONUS,
+      ModifierFunction.STATS_AGILITY_BONUS,
+      ModifierFunction.STATS_INTELLECT_BONUS,
+      ModifierFunction.HEALTH_REGEN_PERCENTAGE,
+      ModifierFunction.MANA_REGEN_TOTAL_PERCENTAGE,
+      ModifierFunction.MOVESPEED_BONUS_CONSTANT,
+      ModifierFunction.BONUS_DAY_VISION,
+      ModifierFunction.BONUS_NIGHT_VISION,
+      ModifierFunction.IGNORE_MOVESPEED_LIMIT,
+    ];
+  }
+
+  CheckState(): Partial<Record<ModifierState, boolean>> {
+    const states: Partial<Record<ModifierState, boolean>> = {};
+    if (this.progression.cannotMiss === 1) states[ModifierState.CANNOT_MISS] = true;
+    if (this.progression.slowImmune === 1) states[ModifierState.UNSLOWABLE] = true;
+    if (this.progression.flying === 1) {
+      states[ModifierState.FLYING] = true;
+      states[ModifierState.FORCED_FLYING_VISION] = true;
+    }
+    return states;
+  }
+
+  GetModifierPercentageCooldown(): number {
+    return this.progression.cooldownPercentage;
+  }
+
+  GetModifierCastRangeBonusStacking(): number {
+    return this.progression.castRangeBonus;
+  }
+
+  GetModifierAoEBonusConstantStacking(): number {
+    return this.progression.aoeBonus;
+  }
+
+  GetModifierSpellAmplify_Percentage(): number {
+    return this.progression.spellAmplifyPercentage;
+  }
+
+  GetModifierStatusResistanceStacking(): number {
+    return this.progression.statusResistance;
+  }
+
+  GetModifierEvasion_Constant(): number {
+    return this.progression.evasion;
+  }
+
+  GetModifierMagicalResistanceBonus(): number {
+    return this.progression.magicalResistance;
+  }
+
+  GetModifierIncomingDamage_Percentage(): number {
+    return this.progression.incomingDamagePercentage;
+  }
+
+  GetModifierAttackRangeBonus(): number {
+    return this.GetParent().IsRangedAttacker() ? this.progression.attackRangeBonus : 0;
+  }
+
+  GetModifierPhysicalArmorBonus(): number {
+    return this.progression.physicalArmor;
+  }
+
+  GetModifierPreAttack_BonusDamage(): number {
+    return this.progression.preattackDamage;
+  }
+
+  GetModifierAttackSpeedBonus_Constant(): number {
+    return this.progression.attackSpeed;
+  }
+
+  GetModifierBonusStats_Strength(): number {
+    return this.progression.strength;
+  }
+
+  GetModifierBonusStats_Agility(): number {
+    return this.progression.agility;
+  }
+
+  GetModifierBonusStats_Intellect(): number {
+    return this.progression.intellect;
+  }
+
+  GetModifierHealthRegenPercentage(): number {
+    return this.progression.healthRegenPercentage;
+  }
+
+  GetModifierTotalPercentageManaRegen(): number {
+    return this.progression.manaRegenPercentage;
+  }
+
+  GetModifierMoveSpeedBonus_Constant(): number {
+    return this.progression.moveSpeed;
+  }
+
+  GetModifierBonusDayVision(): number {
+    return this.progression.bonusVision;
+  }
+
+  GetModifierBonusNightVision(): number {
+    return this.progression.bonusVision;
+  }
+
+  GetModifierIgnoreMovespeedLimit(): 0 | 1 {
+    return this.progression.ignoreMoveSpeedLimit === 1 ? 1 : 0;
+  }
+
+  GetModifierScepter(): 0 | 1 {
+    return this.preserveScepter ? 1 : 0;
+  }
+
+  GetModifierShard(): 0 | 1 {
+    return this.preserveShard ? 1 : 0;
+  }
+
+  GetModifierTotalDamageOutgoing_Percentage(event: ModifierAttackEvent): number {
+    if (event.attacker !== this.GetParent()) return 0;
+
+    const caster = this.getDeathProphet();
+    const awakenedTalent = caster?.FindAbilityByName(POSSESSION_DAMAGE_TALENT_AWAKENED);
+    return awakenedTalent && awakenedTalent.GetLevel() > 0
+      ? awakenedTalent.GetSpecialValueFor('value')
+      : 0;
+  }
+
+  OnTooltip(): number {
+    return this.GetStackCount();
+  }
+
+  /**
+   * 附身目标不会以死亡先知玩家的单位身份正常死亡。
+   * 致命伤先保留 1 点生命，再交给 controller 恢复敌方身份并由死亡先知击杀。
+   */
+  GetMinHealth(): number {
+    return 1;
+  }
+
+  OnTakeDamage(event: ModifierInstanceEvent): void {
+    if (!IsServer()) return;
+
+    const parent = this.GetParent() as CDOTA_BaseNPC_Hero;
+    if (event.attacker === parent) {
+      if (this.progression.lifesteal > 0) {
+        TsLifeStealOnAttackLanded(event, this.progression.lifesteal, parent);
+      }
+      if (this.progression.spellLifesteal > 0) {
+        TsSpellLifeSteal(event, this.progression.spellLifesteal, parent);
+      }
+      this.tryScepterStrike(event, parent);
+    }
+
+    if (this.resolvingLethalDamage) return;
+    if (event.unit !== parent || parent.GetHealth() > 1) return;
+
+    this.resolvingLethalDamage = true;
+    const caster = this.getDeathProphet();
+    const controller = caster?.FindModifierByName(CONTROLLER_MODIFIER) as
+      | (CDOTA_Buff & PossessionController)
+      | undefined;
+    if (controller && !controller.IsNull()) {
+      controller.finishPossession(true);
+      return;
+    }
+
+    this.emergencyFinish(parent, caster);
+  }
+
+  OnDeath(event: ModifierInstanceEvent): void {
+    if (!IsServer()) return;
+
+    const victim = event.unit;
+    const attacker = event.attacker;
+    if (!victim || victim.IsNull() || !attacker || attacker.IsNull()) return;
+
+    const caster = this.getDeathProphet();
+    const controller = caster?.FindModifierByName(CONTROLLER_MODIFIER) as
+      | (CDOTA_Buff & PossessionController)
+      | undefined;
+    if (controller && !controller.IsNull()) {
+      controller.extendDurationForKill(attacker, victim);
+    }
+  }
+
+  private tryScepterStrike(event: ModifierInstanceEvent, parent: CDOTA_BaseNPC_Hero): void {
+    const ability = this.GetAbility() as PossessionAbility | undefined;
+    const caster = this.getDeathProphet();
+    const casterHasScepter = this.casterHadScepterAtCast || (caster?.HasScepter() ?? false);
+    ability?.tryLaunchScepterSpiritFromDamage?.(event, parent, casterHasScepter);
+  }
+
+  private updateRemainingTimeStack(): void {
+    const remainingSeconds = Math.max(0, Math.ceil(this.GetRemainingTime()));
+    if (this.GetStackCount() !== remainingSeconds) this.SetStackCount(remainingSeconds);
+  }
+
+  private providePossessionVision(): void {
+    const parent = this.GetParent();
+    const caster = this.getDeathProphet();
+    if (!caster || caster.IsNull() || !parent.IsAlive()) return;
+
+    AddFOWViewer(
+      caster.GetTeamNumber(),
+      parent.GetAbsOrigin(),
+      Math.max(1, parent.GetCurrentVisionRange()),
+      POSSESSION_VISION_DURATION,
+      true,
+    );
+  }
+
+  private getDeathProphet(): CDOTA_BaseNPC_Hero | undefined {
+    if (this.deathProphetEntindex === undefined) return undefined;
+    const entity = EntIndexToHScript(this.deathProphetEntindex);
+    return entity && !entity.IsNull() ? (entity as CDOTA_BaseNPC_Hero) : undefined;
+  }
+
+  private emergencyFinish(
+    parent: CDOTA_BaseNPC_Hero,
+    caster: CDOTA_BaseNPC_Hero | undefined,
+  ): void {
+    print('[DeathProphetPossession] controller missing; running emergency identity cleanup');
+    const originalOwner =
+      this.originalOwnerEntindex !== undefined
+        ? EntIndexToHScript(this.originalOwnerEntindex)
+        : undefined;
+    runBestEffortCleanup(
+      [
+        {
+          name: 'emergency_team',
+          run: () => {
+            if (this.originalTeam !== undefined) parent.SetTeam(this.originalTeam);
+          },
+        },
+        {
+          name: 'emergency_owner',
+          run: () => {
+            if (originalOwner && !originalOwner.IsNull()) parent.SetOwner(originalOwner);
+          },
+        },
+        {
+          name: 'emergency_control',
+          run: () => {
+            if (this.originalPlayerId !== undefined) {
+              parent.SetControllableByPlayer(this.originalPlayerId, false);
+            }
+          },
+        },
+        { name: 'emergency_status', run: () => parent.RemoveModifierByName(this.GetName()) },
+        { name: 'emergency_kill', run: () => parent.Kill(this.GetAbility(), caster) },
+      ],
+      (stage, error) =>
+        print(`[DeathProphetPossession] emergency cleanup failed stage=${stage} error=${error}`),
+    );
+  }
+
+  OnDestroy(): void {
+    if (IsServer()) {
+      print(
+        `[DeathProphetPossession] target status destroyed parent=${this.GetParent().GetUnitName()}`,
+      );
+    }
+  }
+}

--- a/src/vscripts/abilities/ts_abilities/death_prophet_exorcism_ai_possession.ts
+++ b/src/vscripts/abilities/ts_abilities/death_prophet_exorcism_ai_possession.ts
@@ -1,0 +1,700 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+import { PlayerPropertyApi } from '../../api/player-property';
+import { NetTableHelper } from '../../modules/helper/net-table-helper';
+import { DEATH_PROPHET_POSSESSION_TARGET_MODIFIER } from './death-prophet-ai-possession-constants';
+import {
+  extendPossessionDuration,
+  runBestEffortCleanup,
+  shouldExtendPossession,
+  uniqueAbilityNames,
+} from './death-prophet-ai-possession-logic';
+import './death-prophet-ai-possession-target';
+
+const SCRIPT_PATH = 'abilities/ts_abilities/death_prophet_exorcism_ai_possession';
+const ABILITY_NAME = 'death_prophet_exorcism_ai_possession';
+const CONTROLLER_MODIFIER = 'modifier_death_prophet_exorcism_ai_possession_controller';
+const AWAKENED_STATUS_MODIFIER = 'modifier_death_prophet_ai_possession_awakened';
+const DURATION_ON_KILL_TALENT = 'special_bonus_unique_death_prophet_ai_possession_duration_on_kill';
+const DURATION_ON_KILL_SPECIAL_VALUE = 'duration_increase_per_kill';
+const SCEPTER_SPIRIT_PROJECTILE =
+  'particles/units/heroes/hero_death_prophet/death_prophet_spirit_model.vpcf';
+
+function selectEntityForPlayer(
+  player: CDOTAPlayerController,
+  entity: CDOTA_BaseNPC,
+  possessionActive: boolean,
+): void {
+  // 客户端只执行一次真实选择；不使用 OverrideSelection，之后仍可自由查看其他英雄。
+  CustomGameEventManager.Send_ServerToPlayer(player, 'death_prophet_possession_select', {
+    entindex: entity.GetEntityIndex(),
+    active: possessionActive ? 1 : 0,
+  });
+}
+
+function isUnitReincarnating(unit: CDOTA_BaseNPC): boolean {
+  const optionalReincarnationCheck = unit as unknown as {
+    IsReincarnating?: () => boolean;
+  };
+  return optionalReincarnationCheck.IsReincarnating?.() ?? false;
+}
+
+function isPossessableEnemyBot(caster: CDOTA_BaseNPC, target: CDOTA_BaseNPC): boolean {
+  if (target.IsNull()) return false;
+
+  // 部分 Dota 运行时版本没有 IsClone；只在 API 实际存在时调用，避免施法直接 Lua 报错。
+  const optionalCloneChecks = target as unknown as {
+    IsAlive?: () => boolean;
+    IsClone?: () => boolean;
+    IsTempestDouble?: () => boolean;
+  };
+  const isRealHero = target.IsRealHero();
+  const isIllusion = target.IsIllusion();
+  const isAlive = optionalCloneChecks.IsAlive?.() ?? true;
+  const isClone = optionalCloneChecks.IsClone?.() ?? false;
+  const isTempestDouble = optionalCloneChecks.IsTempestDouble?.() ?? false;
+  if (
+    !isAlive ||
+    !isRealHero ||
+    isIllusion ||
+    isClone ||
+    isTempestDouble ||
+    isUnitReincarnating(target) ||
+    target.GetTeamNumber() === caster.GetTeamNumber() ||
+    target.HasModifier(DEATH_PROPHET_POSSESSION_TARGET_MODIFIER)
+  ) {
+    return false;
+  }
+
+  // PlayerResource 只在服务端完整可用；客户端先通过基础单位条件，最终 AI 校验由服务端完成。
+  if (!IsServer()) return true;
+
+  const playerId = target.GetPlayerOwnerID();
+  return PlayerResource.IsValidPlayerID(playerId) && PlayerResource.IsFakeClient(playerId);
+}
+
+@registerAbility(ABILITY_NAME)
+export class DeathProphetExorcismAiPossession extends BaseAbility {
+  private nextScepterStrikeTime = 0;
+
+  GetIntrinsicModifierName(): string {
+    return AWAKENED_STATUS_MODIFIER;
+  }
+
+  CastFilterResultTarget(target: CDOTA_BaseNPC): UnitFilterResult {
+    const caster = this.GetCaster();
+    if (!isPossessableEnemyBot(caster, target)) return UnitFilterResult.FAIL_CUSTOM;
+
+    return UnitFilter(
+      target,
+      UnitTargetTeam.ENEMY,
+      UnitTargetType.HERO,
+      UnitTargetFlags.NOT_ILLUSIONS,
+      caster.GetTeamNumber(),
+    );
+  }
+
+  GetCustomCastErrorTarget(target: CDOTA_BaseNPC): string {
+    if (target.HasModifier(DEATH_PROPHET_POSSESSION_TARGET_MODIFIER)) {
+      return '#dota_hud_error_death_prophet_ai_possession_active';
+    }
+    return '#dota_hud_error_death_prophet_ai_possession_ai_only';
+  }
+
+  OnSpellStart(): void {
+    if (!IsServer()) return;
+
+    const caster = this.GetCaster() as CDOTA_BaseNPC_Hero;
+    const target = this.GetCursorTarget();
+    if (!target || target.IsNull() || !isPossessableEnemyBot(caster, target)) {
+      this.refundFailedCast(caster);
+      return;
+    }
+    if (target.TriggerSpellAbsorb(this)) return;
+
+    const duration = this.GetSpecialValueFor('duration');
+    const controller = caster.AddNewModifier(caster, this, CONTROLLER_MODIFIER, {
+      duration,
+      target_entindex: target.GetEntityIndex(),
+      caster_had_scepter: caster.HasScepter() ? 1 : 0,
+    }) as (CDOTA_Buff & { isPossessionReady?: () => boolean }) | undefined;
+    if (!controller || controller.IsNull() || controller.isPossessionReady?.() !== true) {
+      this.refundFailedCast(caster);
+    }
+  }
+
+  private refundFailedCast(caster: CDOTA_BaseNPC_Hero): void {
+    this.EndCooldown();
+    caster.GiveMana(this.GetManaCost(-1));
+    print('[DeathProphetPossession] cast setup failed; resources refunded');
+  }
+
+  launchScepterSpirit(source: CDOTA_BaseNPC_Hero, target: CDOTA_BaseNPC): void {
+    if (!IsServer() || source.IsNull() || target.IsNull() || !target.IsAlive()) return;
+
+    ProjectileManager.CreateTrackingProjectile({
+      Target: target,
+      Source: source,
+      Ability: this,
+      EffectName: SCEPTER_SPIRIT_PROJECTILE,
+      iMoveSpeed: 900,
+      bDodgeable: false,
+      bProvidesVision: false,
+      ExtraData: {
+        source_entindex: source.GetEntityIndex(),
+      },
+    });
+  }
+
+  tryLaunchScepterSpiritFromDamage(
+    event: ModifierInstanceEvent,
+    source: CDOTA_BaseNPC_Hero,
+    scepterEnabled: boolean,
+  ): void {
+    if (
+      !IsServer() ||
+      !scepterEnabled ||
+      event.attacker !== source ||
+      event.damage <= 0 ||
+      event.inflictor === this
+    ) {
+      return;
+    }
+
+    const victim = event.unit;
+    if (
+      !victim ||
+      victim.IsNull() ||
+      !victim.IsAlive() ||
+      victim.IsBuilding() ||
+      victim.IsOther() ||
+      victim.GetTeamNumber() === source.GetTeamNumber()
+    ) {
+      return;
+    }
+
+    const now = GameRules.GetGameTime();
+    if (now < this.nextScepterStrikeTime) return;
+
+    const cooldown = this.GetSpecialValueFor('scepter_proc_cooldown');
+    const damage = this.GetSpecialValueFor('scepter_proc_damage');
+    if (damage <= 0) return;
+
+    this.nextScepterStrikeTime = now + cooldown;
+    this.launchScepterSpirit(source, victim);
+  }
+
+  OnProjectileHit_ExtraData(
+    target: CDOTA_BaseNPC | undefined,
+    _location: Vector,
+    extraData: { source_entindex?: EntityIndex },
+  ): boolean {
+    if (!IsServer() || !target || target.IsNull() || !target.IsAlive()) return true;
+
+    const caster = this.GetCaster() as CDOTA_BaseNPC_Hero;
+    const source =
+      extraData.source_entindex !== undefined
+        ? (EntIndexToHScript(extraData.source_entindex) as CDOTA_BaseNPC_Hero | undefined)
+        : undefined;
+    const damage = this.GetSpecialValueFor('scepter_proc_damage');
+    if (damage <= 0 || caster.IsNull()) return true;
+
+    const actualDamage = ApplyDamage({
+      victim: target,
+      attacker: caster,
+      damage,
+      damage_type: DamageTypes.PHYSICAL,
+      damage_flags: DamageFlag.NO_SPELL_AMPLIFICATION + DamageFlag.NO_REFLECTION,
+      ability: this,
+    });
+    if (actualDamage > 0) {
+      SendOverheadEventMessage(
+        undefined,
+        OverheadAlert.BONUS_SPELL_DAMAGE,
+        target,
+        actualDamage,
+        undefined,
+      );
+    }
+    if (actualDamage > 0 && source && !source.IsNull() && source.IsAlive()) {
+      source.Heal(actualDamage * this.GetSpecialValueFor('scepter_proc_heal_pct') * 0.01, this);
+    }
+    return true;
+  }
+}
+
+@registerModifier(SCRIPT_PATH)
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_death_prophet_ai_possession_awakened extends BaseModifier {
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  IsPurgeException(): boolean {
+    return false;
+  }
+
+  IsDebuff(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return 'death_prophet_exorcism';
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [ModifierFunction.ON_TAKEDAMAGE];
+  }
+
+  OnTakeDamage(event: ModifierInstanceEvent): void {
+    if (!IsServer()) return;
+
+    const parent = this.GetParent() as CDOTA_BaseNPC_Hero;
+    const ability = this.GetAbility() as DeathProphetExorcismAiPossession | undefined;
+    if (!ability || ability.IsNull()) return;
+
+    ability.tryLaunchScepterSpiritFromDamage(event, parent, parent.HasScepter());
+  }
+}
+
+interface PossessionParams {
+  target_entindex?: EntityIndex;
+  caster_had_scepter?: 0 | 1;
+}
+
+interface BorrowedAbilityState {
+  name: string;
+  existedOnTarget: boolean;
+  originalLevel: number;
+  originalActivated: boolean;
+  originalHidden: boolean;
+  originalCharges: number;
+  originalAutoCast: boolean;
+  originalCooldown: number;
+}
+
+/**
+ * 唯一生命周期 owner：保存并切换目标身份、隐藏本体、延长持续时间，并在所有出口恢复双方。
+ * 目标 modifier 只承担可见状态与 AI 暂停标记，不拥有恢复逻辑。
+ */
+@registerModifier(SCRIPT_PATH)
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_death_prophet_exorcism_ai_possession_controller extends BaseModifier {
+  private target?: CDOTA_BaseNPC_Hero;
+  private originalTargetOwner?: CBaseEntity;
+  private originalTargetPlayerId?: PlayerID;
+  private originalTargetTeam?: DOTATeam_t;
+  private casterPlayerId?: PlayerID;
+  private casterHadScepterAtCast = false;
+  private possessionStarted = false;
+  private possessionReady = false;
+  private killTargetOnEnd = false;
+  private borrowedAbilityStates: BorrowedAbilityState[] = [];
+
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  IsPurgeException(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return 'death_prophet_exorcism';
+  }
+
+  CheckState(): Partial<Record<ModifierState, boolean>> {
+    return {
+      [ModifierState.INVULNERABLE]: true,
+      [ModifierState.OUT_OF_GAME]: true,
+      [ModifierState.UNSELECTABLE]: true,
+      [ModifierState.NO_HEALTH_BAR]: true,
+      [ModifierState.NO_UNIT_COLLISION]: true,
+      [ModifierState.COMMAND_RESTRICTED]: true,
+      [ModifierState.DISARMED]: true,
+      [ModifierState.ROOTED]: true,
+    };
+  }
+
+  OnCreated(params: PossessionParams): void {
+    if (!IsServer()) return;
+    const lifecycleStartedAt = Time();
+
+    const caster = this.GetParent() as CDOTA_BaseNPC_Hero;
+    const target = params.target_entindex
+      ? (EntIndexToHScript(params.target_entindex) as CDOTA_BaseNPC_Hero | undefined)
+      : undefined;
+    if (!target || target.IsNull() || !isPossessableEnemyBot(caster, target)) {
+      this.Destroy();
+      return;
+    }
+
+    const ability = this.GetAbility();
+    if (!ability || ability.IsNull()) {
+      this.Destroy();
+      return;
+    }
+
+    const casterPlayerId = caster.GetPlayerOwnerID();
+    const casterPlayer = caster.GetPlayerOwner();
+    if (!PlayerResource.IsValidPlayerID(casterPlayerId) || !casterPlayer || casterPlayer.IsNull()) {
+      this.Destroy();
+      return;
+    }
+
+    this.target = target;
+    this.originalTargetOwner = target.GetOwnerEntity();
+    this.originalTargetPlayerId = target.GetPlayerID();
+    this.originalTargetTeam = target.GetTeamNumber();
+    this.casterPlayerId = casterPlayerId;
+    this.casterHadScepterAtCast = params.caster_had_scepter === 1;
+    this.possessionStarted = true;
+
+    const durationTalent = caster.FindAbilityByName(DURATION_ON_KILL_TALENT);
+    print(
+      `[DeathProphetPossession] duration talent level=${durationTalent?.GetLevel() ?? 0} value=${durationTalent?.GetSpecialValueFor(DURATION_ON_KILL_SPECIAL_VALUE) ?? 0}`,
+    );
+
+    try {
+      const targetHadScepter = target.HasScepter();
+      const targetHadShard = target.HasModifier('modifier_item_aghanims_shard');
+      GameRules.AI.BotTeam?.cancelJungleRecoveryMovement(target);
+      target.Interrupt();
+      target.Stop();
+
+      // 真实英雄的 PlayerID 属于 PlayerResource 全局身份。临时改写再恢复会同步重建整队数据，
+      // 在 10v10 中可阻塞主线程数秒；控制权只需要 Team、Owner 与 controllable 映射。
+      target.SetTeam(caster.GetTeamNumber());
+      target.SetOwner(casterPlayer);
+      target.SetControllableByPlayer(casterPlayerId, false);
+      const steamId = PlayerResource.GetSteamAccountID(casterPlayerId);
+      const progression = PlayerPropertyApi.GetTemporaryPlayerPropertyValuesForHero(
+        caster,
+        steamId,
+      );
+      const targetModifier = target.AddNewModifier(
+        target,
+        ability,
+        DEATH_PROPHET_POSSESSION_TARGET_MODIFIER,
+        {
+          duration: this.GetRemainingTime(),
+          death_prophet_entindex: caster.GetEntityIndex(),
+          original_owner_entindex: this.originalTargetOwner?.GetEntityIndex(),
+          original_player_id: this.originalTargetPlayerId,
+          original_team: this.originalTargetTeam,
+          had_scepter: targetHadScepter ? 1 : 0,
+          had_shard: targetHadShard ? 1 : 0,
+          caster_had_scepter: this.casterHadScepterAtCast ? 1 : 0,
+          ...progression,
+        },
+      );
+      if (!targetModifier || targetModifier.IsNull()) {
+        print('[DeathProphetPossession] target status creation failed');
+        this.Destroy();
+        return;
+      }
+
+      this.applyCasterAbilities(caster, target, casterPlayerId);
+      this.killTargetOnEnd = true;
+      this.possessionReady = true;
+      selectEntityForPlayer(casterPlayer, target, true);
+      print(
+        `[DeathProphetPossession] entered target=${target.GetUnitName()} elapsed_ms=${(Time() - lifecycleStartedAt) * 1000}`,
+      );
+      this.StartIntervalThink(0.2);
+    } catch (error) {
+      print(`[DeathProphetPossession] enter failed error=${error}`);
+      this.Destroy();
+    }
+  }
+
+  isPossessionReady(): boolean {
+    return this.possessionReady;
+  }
+
+  OnIntervalThink(): void {
+    if (!IsServer() || !this.possessionReady) return;
+
+    const caster = this.GetParent() as CDOTA_BaseNPC_Hero;
+    const target = this.target;
+    if (
+      !target ||
+      target.IsNull() ||
+      !target.HasModifier(DEATH_PROPHET_POSSESSION_TARGET_MODIFIER) ||
+      target.GetTeamNumber() !== caster.GetTeamNumber()
+    ) {
+      this.Destroy();
+    }
+  }
+
+  /** 由目标的致命伤保护调用；先退出附身，再以死亡先知为攻击者处决目标。 */
+  finishPossession(killTarget: boolean): void {
+    if (!IsServer() || !this.possessionReady) return;
+    this.killTargetOnEnd = killTarget;
+    this.Destroy();
+  }
+
+  /** 由仍在场的目标状态监听击杀；本体 OUT_OF_GAME 时 controller 自身收不到全局死亡事件。 */
+  extendDurationForKill(attacker: CDOTA_BaseNPC, victim: CDOTA_BaseNPC): void {
+    if (!IsServer() || !this.possessionReady) return;
+
+    const caster = this.GetParent() as CDOTA_BaseNPC_Hero;
+    const target = this.target;
+    const durationOnKillExtension = this.getDurationOnKillExtension(caster);
+    if (!target || target.IsNull()) {
+      return;
+    }
+
+    const owner = attacker.GetOwnerEntity();
+    if (
+      !shouldExtendPossession({
+        extension: durationOnKillExtension,
+        victimIsRealHero: victim.IsRealHero(),
+        victimIsIllusion: victim.IsIllusion(),
+        victimIsReincarnating: isUnitReincarnating(victim),
+        victimTeam: victim.GetTeamNumber(),
+        casterTeam: caster.GetTeamNumber(),
+        attackerIsTarget: attacker === target,
+        attackerIsCaster: attacker === caster,
+        attackerPlayerId: attacker.GetPlayerOwnerID(),
+        casterPlayerId: this.casterPlayerId,
+        attackerOwnerIsTargetOrCaster: owner === target || owner === caster,
+      })
+    ) {
+      return;
+    }
+
+    const newDuration = extendPossessionDuration(this.GetRemainingTime(), durationOnKillExtension);
+    this.SetDuration(newDuration, true);
+    const targetModifier = target.FindModifierByNameAndCaster(
+      DEATH_PROPHET_POSSESSION_TARGET_MODIFIER,
+      target,
+    );
+    if (targetModifier && !targetModifier.IsNull()) {
+      targetModifier.SetDuration(newDuration, true);
+    }
+    print(
+      `[DeathProphetPossession] kill extension +${durationOnKillExtension}s remaining=${newDuration} attacker=${attacker.GetUnitName()} victim=${victim.GetUnitName()}`,
+    );
+  }
+
+  private getDurationOnKillExtension(caster: CDOTA_BaseNPC_Hero): number {
+    const durationTalent = caster.FindAbilityByName(DURATION_ON_KILL_TALENT);
+    if (!durationTalent || durationTalent.IsNull() || durationTalent.GetLevel() <= 0) return 0;
+    return Math.max(0, durationTalent.GetSpecialValueFor(DURATION_ON_KILL_SPECIAL_VALUE));
+  }
+
+  private applyCasterAbilities(
+    caster: CDOTA_BaseNPC_Hero,
+    target: CDOTA_BaseNPC_Hero,
+    casterPlayerId: PlayerID,
+  ): void {
+    const steamId = PlayerResource.GetSteamAccountID(casterPlayerId);
+    const lotteryStatus = NetTableHelper.GetLotteryStatus(steamId.toString());
+    const selectedAbilityNames = uniqueAbilityNames([
+      lotteryStatus.activeAbilityName ?? '',
+      lotteryStatus.passiveAbilityName ?? '',
+      lotteryStatus.passiveAbilityName2 ?? '',
+    ]);
+
+    for (const abilityName of selectedAbilityNames) {
+      if (!abilityName) continue;
+
+      const sourceAbility = caster.FindAbilityByName(abilityName);
+      if (!sourceAbility || sourceAbility.IsNull()) continue;
+
+      const existingAbility = target.FindAbilityByName(abilityName);
+      const borrowedAbility = existingAbility ?? target.AddAbility(abilityName);
+      if (!borrowedAbility || borrowedAbility.IsNull()) continue;
+
+      this.borrowedAbilityStates.push({
+        name: abilityName,
+        existedOnTarget: existingAbility !== undefined,
+        originalLevel: borrowedAbility.GetLevel(),
+        originalActivated: borrowedAbility.IsActivated(),
+        originalHidden: borrowedAbility.IsHidden(),
+        originalCharges: borrowedAbility.GetCurrentAbilityCharges(),
+        originalAutoCast: borrowedAbility.GetAutoCastState(),
+        originalCooldown: borrowedAbility.GetCooldownTimeRemaining(),
+      });
+
+      borrowedAbility.SetLevel(sourceAbility.GetLevel());
+      borrowedAbility.SetActivated(sourceAbility.IsActivated());
+      borrowedAbility.SetHidden(sourceAbility.IsHidden());
+      borrowedAbility.SetCurrentAbilityCharges(sourceAbility.GetCurrentAbilityCharges());
+      if (sourceAbility.GetAutoCastState() !== borrowedAbility.GetAutoCastState()) {
+        borrowedAbility.ToggleAutoCast();
+      }
+
+      const cooldown = sourceAbility.GetCooldownTimeRemaining();
+      borrowedAbility.EndCooldown();
+      if (cooldown > 0) borrowedAbility.StartCooldown(cooldown);
+      print(
+        `[DeathProphetPossession] sync ability ${abilityName}: ${sourceAbility.GetLevel()} -> ${borrowedAbility.GetLevel()} (existing=${existingAbility !== undefined})`,
+      );
+    }
+  }
+
+  private removeCasterAbilities(caster: CDOTA_BaseNPC_Hero, target: CDOTA_BaseNPC_Hero): void {
+    const states = this.borrowedAbilityStates;
+    this.borrowedAbilityStates = [];
+    runBestEffortCleanup(
+      states.map((state) => ({
+        name: `ability_${state.name}`,
+        run: () => {
+          const borrowedAbility = target.FindAbilityByName(state.name);
+          const sourceAbility = caster.FindAbilityByName(state.name);
+          if (
+            borrowedAbility &&
+            !borrowedAbility.IsNull() &&
+            sourceAbility &&
+            !sourceAbility.IsNull()
+          ) {
+            sourceAbility.EndCooldown();
+            const remainingCooldown = borrowedAbility.GetCooldownTimeRemaining();
+            if (remainingCooldown > 0) sourceAbility.StartCooldown(remainingCooldown);
+            sourceAbility.SetCurrentAbilityCharges(borrowedAbility.GetCurrentAbilityCharges());
+          }
+
+          if (!borrowedAbility || borrowedAbility.IsNull()) return;
+          if (!state.existedOnTarget) {
+            target.RemoveAbility(state.name);
+            return;
+          }
+
+          borrowedAbility.SetLevel(state.originalLevel);
+          borrowedAbility.SetActivated(state.originalActivated);
+          borrowedAbility.SetHidden(state.originalHidden);
+          borrowedAbility.SetCurrentAbilityCharges(state.originalCharges);
+          if (borrowedAbility.GetAutoCastState() !== state.originalAutoCast) {
+            borrowedAbility.ToggleAutoCast();
+          }
+          borrowedAbility.EndCooldown();
+          if (state.originalCooldown > 0) borrowedAbility.StartCooldown(state.originalCooldown);
+        },
+      })),
+      (stage, error) => this.logCleanupError(stage, error),
+    );
+  }
+
+  private restoreTargetIdentity(target: CDOTA_BaseNPC_Hero): void {
+    runBestEffortCleanup(
+      [
+        {
+          name: 'identity_team',
+          run: () => {
+            if (this.originalTargetTeam !== undefined) target.SetTeam(this.originalTargetTeam);
+          },
+        },
+        {
+          name: 'identity_owner',
+          run: () => {
+            if (this.originalTargetOwner && !this.originalTargetOwner.IsNull()) {
+              target.SetOwner(this.originalTargetOwner);
+            }
+          },
+        },
+        {
+          name: 'identity_control',
+          run: () => {
+            if (this.originalTargetPlayerId !== undefined) {
+              target.SetControllableByPlayer(this.originalTargetPlayerId, false);
+            }
+          },
+        },
+      ],
+      (stage, error) => this.logCleanupError(stage, error),
+    );
+  }
+
+  private logCleanupError(stage: string, error: unknown): void {
+    print(`[DeathProphetPossession] cleanup failed stage=${stage} error=${error}`);
+  }
+
+  OnDestroy(): void {
+    if (!IsServer() || !this.possessionStarted) return;
+    const exitStartedAt = Time();
+    this.possessionStarted = false;
+    this.possessionReady = false;
+
+    const caster = this.GetParent() as CDOTA_BaseNPC_Hero;
+    const target = this.target;
+    const ability = this.GetAbility();
+    let returnPosition = caster.GetAbsOrigin();
+
+    if (target && !target.IsNull()) {
+      print(`[DeathProphetPossession] exit stage=begin target=${target.GetUnitName()}`);
+      returnPosition = target.GetAbsOrigin();
+      runBestEffortCleanup(
+        [
+          { name: 'target_interrupt', run: () => target.Interrupt() },
+          { name: 'target_stop', run: () => target.Stop() },
+          { name: 'abilities', run: () => this.removeCasterAbilities(caster, target) },
+        ],
+        (stage, error) => this.logCleanupError(stage, error),
+      );
+
+      runBestEffortCleanup(
+        [
+          { name: 'identity', run: () => this.restoreTargetIdentity(target) },
+          {
+            name: 'status',
+            run: () => target.RemoveModifierByName(DEATH_PROPHET_POSSESSION_TARGET_MODIFIER),
+          },
+          {
+            name: 'kill',
+            run: () => {
+              if (this.killTargetOnEnd && target.IsAlive()) target.Kill(ability, caster);
+            },
+          },
+        ],
+        (stage, error) => this.logCleanupError(stage, error),
+      );
+    }
+
+    runBestEffortCleanup(
+      [
+        {
+          name: 'caster_return',
+          run: () => {
+            if (!caster.IsNull()) FindClearSpaceForUnit(caster, returnPosition, false);
+          },
+        },
+        {
+          name: 'caster_select',
+          run: () => {
+            if (caster.IsNull()) return;
+            const casterPlayer = caster.GetPlayerOwner();
+            if (casterPlayer && !casterPlayer.IsNull()) {
+              selectEntityForPlayer(casterPlayer, caster, false);
+            }
+          },
+        },
+      ],
+      (stage, error) => this.logCleanupError(stage, error),
+    );
+    print(
+      `[DeathProphetPossession] exit stage=complete elapsed_ms=${(Time() - exitStartedAt) * 1000}`,
+    );
+  }
+}

--- a/src/vscripts/abilities/ts_abilities/death_prophet_exorcism_ai_possession.ts
+++ b/src/vscripts/abilities/ts_abilities/death_prophet_exorcism_ai_possession.ts
@@ -285,6 +285,14 @@ interface BorrowedAbilityState {
   originalCooldown: number;
 }
 
+interface PossessionContext {
+  caster: CDOTA_BaseNPC_Hero;
+  target: CDOTA_BaseNPC_Hero;
+  ability: CDOTABaseAbility;
+  casterPlayerId: PlayerID;
+  casterPlayer: CDOTAPlayerController;
+}
+
 /**
  * 唯一生命周期 owner：保存并切换目标身份、隐藏本体、延长持续时间，并在所有出口恢复双方。
  * 目标 modifier 只承担可见状态与 AI 暂停标记，不拥有恢复逻辑。
@@ -340,28 +348,46 @@ export class modifier_death_prophet_exorcism_ai_possession_controller extends Ba
     if (!IsServer()) return;
     const lifecycleStartedAt = Time();
 
+    const context = this.resolvePossessionContext(params);
+    if (!context) {
+      this.Destroy();
+      return;
+    }
+
+    this.startPossession(context, params, lifecycleStartedAt);
+  }
+
+  private resolvePossessionContext(params: PossessionParams): PossessionContext | undefined {
     const caster = this.GetParent() as CDOTA_BaseNPC_Hero;
     const target = params.target_entindex
       ? (EntIndexToHScript(params.target_entindex) as CDOTA_BaseNPC_Hero | undefined)
       : undefined;
-    if (!target || target.IsNull() || !isPossessableEnemyBot(caster, target)) {
-      this.Destroy();
-      return;
-    }
-
     const ability = this.GetAbility();
-    if (!ability || ability.IsNull()) {
-      this.Destroy();
-      return;
-    }
-
     const casterPlayerId = caster.GetPlayerOwnerID();
     const casterPlayer = caster.GetPlayerOwner();
-    if (!PlayerResource.IsValidPlayerID(casterPlayerId) || !casterPlayer || casterPlayer.IsNull()) {
-      this.Destroy();
-      return;
+
+    if (
+      !target ||
+      target.IsNull() ||
+      !isPossessableEnemyBot(caster, target) ||
+      !ability ||
+      ability.IsNull() ||
+      !PlayerResource.IsValidPlayerID(casterPlayerId) ||
+      !casterPlayer ||
+      casterPlayer.IsNull()
+    ) {
+      return undefined;
     }
 
+    return { caster, target, ability, casterPlayerId, casterPlayer };
+  }
+
+  private startPossession(
+    context: PossessionContext,
+    params: PossessionParams,
+    lifecycleStartedAt: number,
+  ): void {
+    const { caster, target, ability, casterPlayerId, casterPlayer } = context;
     this.target = target;
     this.originalTargetOwner = target.GetOwnerEntity();
     this.originalTargetPlayerId = target.GetPlayerID();

--- a/src/vscripts/ai/hero/hero-util.ts
+++ b/src/vscripts/ai/hero/hero-util.ts
@@ -1,3 +1,5 @@
+import { DEATH_PROPHET_POSSESSION_TARGET_MODIFIER } from '../../abilities/ts_abilities/death-prophet-ai-possession-constants';
+
 export class HeroUtil {
   static stunModifiers = [
     'modifier_axe_berserkers_call', // 战吼
@@ -30,6 +32,10 @@ export class HeroUtil {
   }
 
   static NotActionable(hero: CDOTA_BaseNPC): boolean {
+    // 死亡先知附身期间，玩家是唯一 action owner，暂停 TS Bot 的全部动作。
+    if (hero.HasModifier(DEATH_PROPHET_POSSESSION_TARGET_MODIFIER)) {
+      return true;
+    }
     // 死亡
     if (hero.IsAlive() === false) {
       return true;

--- a/src/vscripts/ai/team/bot-team.ts
+++ b/src/vscripts/ai/team/bot-team.ts
@@ -1,4 +1,5 @@
 import { Player } from '../../api/player';
+import { DEATH_PROPHET_POSSESSION_TARGET_MODIFIER } from '../../abilities/ts_abilities/death-prophet-ai-possession-constants';
 import { TowerPushStatus } from '../../modules/event/event-entity-killed';
 import { PlayerHelper } from '../../modules/helper/player-helper';
 import { reloadable } from '../../utils/tstl-utils';
@@ -288,6 +289,8 @@ export class BotTeam {
 
       const hero = PlayerResource.GetSelectedHeroEntity(playerId);
       if (!hero) return;
+      // 附身期间目标的 PlayerID 临时归死亡先知，不能再从原 Bot 槽位重复领取周期金币。
+      if (hero.HasModifier(DEATH_PROPHET_POSSESSION_TARGET_MODIFIER)) return;
 
       // 根据队伍选择倍率
       const multiplier = GameRules.GoldXPFilter.getPlayerGoldXpMultiplier(playerId);

--- a/src/vscripts/api/player-property.ts
+++ b/src/vscripts/api/player-property.ts
@@ -1,4 +1,7 @@
-import { PropertyController } from '../modules/property/property_controller';
+import {
+  PropertyController,
+  TemporaryHeroPropertyValues,
+} from '../modules/property/property_controller';
 import { ApiClient, HttpMethod } from './api-client';
 import { Player, PlayerInfoDto } from './player';
 
@@ -23,12 +26,33 @@ export class PlayerPropertyApi {
     }
     const steamId = PlayerResource.GetSteamAccountID(hero.GetPlayerOwnerID());
     const playerInfo = Player.playerInfoMap.get(steamId.toString());
-
     if (playerInfo?.properties) {
       for (const property of playerInfo.properties) {
         PropertyController.LevelupHeroProperty(hero, property);
       }
     }
+  }
+
+  /** 英雄升级时只刷新实际跨档的属性，避免连续升级重复重建整套 modifier。 */
+  public static RefreshPlayerPropertyOnHeroLevelUp(hero: CDOTA_BaseNPC_Hero): number {
+    if (!hero) return 0;
+
+    const steamId = PlayerResource.GetSteamAccountID(hero.GetPlayerOwnerID());
+    const playerInfo = Player.playerInfoMap.get(steamId.toString());
+    let refreshedCount = 0;
+    for (const property of playerInfo?.properties ?? []) {
+      if (PropertyController.RefreshHeroPropertyOnLevelUp(hero, property)) refreshedCount++;
+    }
+    return refreshedCount;
+  }
+
+  /** 临时载体专用：返回单 modifier 可直接使用的玩家成长数值。 */
+  public static GetTemporaryPlayerPropertyValuesForHero(
+    hero: CDOTA_BaseNPC_Hero,
+    steamId: number,
+  ): TemporaryHeroPropertyValues {
+    const playerInfo = Player.playerInfoMap.get(steamId.toString());
+    return PropertyController.BuildTemporaryHeroPropertyValues(hero, playerInfo?.properties ?? []);
   }
 
   /**

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,25 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 死亡先知 觉醒
+  {
+    heroName: 'npc_dota_hero_death_prophet',
+    targetAbility: 'death_prophet_exorcism',
+    newAbility: 'death_prophet_exorcism_ai_possession',
+    newLevel: 0,
+  },
+  {
+    heroName: 'npc_dota_hero_death_prophet',
+    targetAbility: 'special_bonus_unique_death_prophet',
+    newAbility: 'special_bonus_unique_death_prophet_ai_possession_power',
+    newLevel: 0,
+  },
+  {
+    heroName: 'npc_dota_hero_death_prophet',
+    targetAbility: 'special_bonus_unique_death_prophet_exorcism_duration_on_kill',
+    newAbility: 'special_bonus_unique_death_prophet_ai_possession_duration_on_kill',
+    newLevel: 0,
+  },
   // 撼地者 觉醒
   {
     heroName: 'npc_dota_hero_earthshaker',
@@ -263,6 +282,7 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  * 新觉醒发布时加入，下次发版由 awaken-ability skill 流程确认移出。
  */
 export const FREE_TRIAL_HEROES: string[] = [
+  'npc_dota_hero_death_prophet', // 死亡先知
   'npc_dota_hero_earthshaker', // 撼地者
   'npc_dota_hero_abyssal_underlord', // 孽主
   'npc_dota_hero_slark', // 斯拉克

--- a/src/vscripts/modules/awaken/awaken-replacer.test.ts
+++ b/src/vscripts/modules/awaken/awaken-replacer.test.ts
@@ -6,10 +6,12 @@ function createFakeHero(opts: {
   unitName?: string;
   abilities?: { name: string; level: number; hidden?: boolean }[];
   abilityPoints?: number;
+  failAddNames?: string[];
 }) {
   const abilities: { name: string; level: number; hidden?: boolean }[] = opts.abilities ?? [];
   let abilityPoints = opts.abilityPoints ?? 0;
   const addOrder: string[] = [];
+  const swaps: [string, string, boolean, boolean][] = [];
 
   const makeAbility = (entry: { name: string; level: number; hidden?: boolean }) => ({
     GetAbilityName: () => entry.name,
@@ -45,14 +47,18 @@ function createFakeHero(opts: {
       if (idx >= 0) abilities.splice(idx, 1);
     },
     AddAbility: (name: string) => {
+      if (opts.failAddNames?.includes(name)) return undefined;
       const entry = { name, level: 0 };
       abilities.push(entry);
       addOrder.push(name);
       return makeAbility(entry);
     },
+    SwapAbilities: (first: string, second: string, enableFirst: boolean, enableSecond: boolean) => {
+      swaps.push([first, second, enableFirst, enableSecond]);
+    },
   };
 
-  return { hero, abilities, addOrder, getPoints: () => abilityPoints };
+  return { hero, abilities, addOrder, swaps, getPoints: () => abilityPoints };
 }
 
 describe('executeReplacement', () => {
@@ -150,9 +156,102 @@ describe('executeReplacement', () => {
     });
     expect(f.abilities.find((a) => a.name === 'newPassive')?.level).toBe(4);
   });
+
+  it('替换技能添加失败时恢复旧技能且返回 false', () => {
+    const f = createFakeHero({
+      abilities: [{ name: 'oldAbility', level: 3 }],
+      failAddNames: ['newAbility'],
+    });
+
+    expect(
+      executeReplacement(f.hero, {
+        heroName: 'npc_dota_hero_pudge',
+        targetAbility: 'oldAbility',
+        newAbility: 'newAbility',
+        newLevel: 0,
+      }),
+    ).toBe(false);
+    expect(f.abilities).toEqual([{ name: 'oldAbility', level: 3 }]);
+  });
+
+  it('插入任一步骤失败时恢复旧技能与技能点', () => {
+    const f = createFakeHero({
+      abilities: [{ name: 'oldAbility', level: 2 }],
+      abilityPoints: 1,
+      failAddNames: ['newAbility'],
+    });
+
+    expect(
+      executeReplacement(f.hero, {
+        heroName: 'npc_dota_hero_pudge',
+        targetSlot: 0,
+        newAbility: 'newAbility',
+        newLevel: 0,
+      }),
+    ).toBe(false);
+    expect(f.abilities).toEqual([{ name: 'oldAbility', level: 2 }]);
+    expect(f.getPoints()).toBe(1);
+  });
 });
 
 describe('applyAwakenByHero', () => {
+  it('死亡先知替换大招和两项原天赋后仍严格保持八个天赋', () => {
+    const f = createFakeHero({
+      unitName: 'npc_dota_hero_death_prophet',
+      abilities: [
+        { name: 'death_prophet_exorcism', level: 3 },
+        { name: 'special_bonus_hp_200', level: 1 },
+        { name: 'special_bonus_unique_death_prophet_2', level: 1 },
+        { name: 'special_bonus_unique_death_prophet', level: 1 },
+        { name: 'special_bonus_unique_death_prophet_3', level: 1 },
+        { name: 'special_bonus_unique_death_prophet_5', level: 1 },
+        {
+          name: 'special_bonus_unique_death_prophet_exorcism_duration_on_kill',
+          level: 1,
+        },
+        { name: 'special_bonus_unique_death_prophet_silence_aoe', level: 1 },
+        { name: 'special_bonus_attack_speed_50', level: 1 },
+      ],
+    });
+
+    expect(applyAwakenByHero(f.hero)).toBe(true);
+    expect(f.abilities).toHaveLength(9);
+    expect(f.abilities.filter((ability) => ability.name.startsWith('special_bonus_'))).toHaveLength(
+      8,
+    );
+    expect(
+      f.abilities.find((ability) => ability.name === 'death_prophet_exorcism'),
+    ).toBeUndefined();
+    expect(
+      f.abilities.find((ability) => ability.name === 'death_prophet_exorcism_ai_possession'),
+    ).toEqual({ name: 'death_prophet_exorcism_ai_possession', level: 3 });
+    expect(
+      f.abilities.find((ability) => ability.name === 'special_bonus_unique_death_prophet'),
+    ).toBeUndefined();
+    expect(
+      f.abilities.find(
+        (ability) => ability.name === 'special_bonus_unique_death_prophet_ai_possession_power',
+      ),
+    ).toEqual({ name: 'special_bonus_unique_death_prophet_ai_possession_power', level: 1 });
+    expect(
+      f.abilities.find(
+        (ability) =>
+          ability.name === 'special_bonus_unique_death_prophet_exorcism_duration_on_kill',
+      ),
+    ).toBeUndefined();
+    expect(
+      f.abilities.find(
+        (ability) =>
+          ability.name === 'special_bonus_unique_death_prophet_ai_possession_duration_on_kill',
+      ),
+    ).toEqual({
+      name: 'special_bonus_unique_death_prophet_ai_possession_duration_on_kill',
+      level: 1,
+    });
+    expect(f.swaps).toEqual([]);
+    expect(isAwakened(f.hero)).toBe(true);
+  });
+
   it('上古巨神觉醒替换二技能并继承原等级', () => {
     const f = createFakeHero({
       unitName: 'npc_dota_hero_elder_titan',

--- a/src/vscripts/modules/awaken/awaken-replacer.ts
+++ b/src/vscripts/modules/awaken/awaken-replacer.ts
@@ -8,11 +8,16 @@ function addAbilityAtLevel(
   abilityName: string,
   level: number,
 ): CDOTABaseAbility | undefined {
-  const added = hero.AddAbility(abilityName);
-  if (added !== undefined) {
-    added.SetLevel(Math.min(level, added.GetMaxLevel()));
+  try {
+    const added = hero.AddAbility(abilityName);
+    if (added !== undefined) {
+      added.SetLevel(Math.min(level, added.GetMaxLevel()));
+    }
+    return added;
+  } catch (error) {
+    print(`[AwakenReplacer] AddAbility failed ability=${abilityName} error=${error}`);
+    return undefined;
   }
-  return added;
 }
 
 /** 解析替换目标技能名：优先 targetAbility，其次 targetSlot 当前占用的技能 */
@@ -55,12 +60,20 @@ function insertAbility(
     return false;
   }
   const savedLevel = oldAbility.GetLevel();
+  const originalAbilityPoints = hero.GetAbilityPoints();
   // 继承等级须在移除关联技能前求值（inheritLevelFrom 可能正是被插入槽位的技能）
   const newAbilityLevel = resolveNewLevel(hero, replacement, replacement.newLevel);
   hero.RemoveAbility(targetAbilityName);
-  hero.SetAbilityPoints(hero.GetAbilityPoints() + savedLevel);
-  addAbilityAtLevel(hero, replacement.newAbility, newAbilityLevel);
-  addAbilityAtLevel(hero, targetAbilityName, savedLevel);
+  hero.SetAbilityPoints(originalAbilityPoints + savedLevel);
+  const addedNewAbility = addAbilityAtLevel(hero, replacement.newAbility, newAbilityLevel);
+  const restoredOldAbility = addAbilityAtLevel(hero, targetAbilityName, savedLevel);
+  if (!addedNewAbility || !restoredOldAbility) {
+    if (hero.FindAbilityByName(replacement.newAbility)) hero.RemoveAbility(replacement.newAbility);
+    if (hero.FindAbilityByName(targetAbilityName)) hero.RemoveAbility(targetAbilityName);
+    addAbilityAtLevel(hero, targetAbilityName, savedLevel);
+    hero.SetAbilityPoints(originalAbilityPoints);
+    return false;
+  }
   return true;
 }
 
@@ -86,6 +99,7 @@ function replaceAbility(
   targetAbilityName: string | undefined,
 ): boolean {
   let savedLevel = 0;
+  let removedTarget = false;
   if (targetAbilityName !== undefined) {
     const oldAbility = hero.FindAbilityByName(targetAbilityName);
     if (oldAbility !== undefined) {
@@ -101,8 +115,15 @@ function replaceAbility(
     hero.FindAbilityByName(targetAbilityName) !== undefined
   ) {
     hero.RemoveAbility(targetAbilityName);
+    removedTarget = true;
   }
   const added = addAbilityAtLevel(hero, replacement.newAbility, newAbilityLevel);
+  if (added === undefined) {
+    if (removedTarget && targetAbilityName !== undefined) {
+      addAbilityAtLevel(hero, targetAbilityName, savedLevel);
+    }
+    return false;
+  }
   // 解除隐藏由标记技能自身的状态机负责（如 restoreWrapperAfterReturn 里的 SwapAbilities）
   if (keepHidden && added !== undefined) {
     added.SetHidden(true);
@@ -122,12 +143,13 @@ export function executeReplacement(
 
   // 纯新增
   if (replacement.targetAbility === undefined && replacement.targetSlot === undefined) {
-    addAbilityAtLevel(
-      hero,
-      replacement.newAbility,
-      resolveNewLevel(hero, replacement, replacement.newLevel),
+    return (
+      addAbilityAtLevel(
+        hero,
+        replacement.newAbility,
+        resolveNewLevel(hero, replacement, replacement.newLevel),
+      ) !== undefined
     );
-    return true;
   }
 
   const targetAbilityName = resolveTargetAbility(hero, replacement);
@@ -172,5 +194,5 @@ export function applyAwakenByHero(hero: CDOTA_BaseNPC_Hero): boolean {
       applied = true;
     }
   }
-  return applied;
+  return applied && isAwakened(hero);
 }

--- a/src/vscripts/modules/event/event-player-level-up.ts
+++ b/src/vscripts/modules/event/event-player-level-up.ts
@@ -27,8 +27,10 @@ export class EventPlayerLevelUp {
    */
   private UpdatePlayerAndBot(hero: CDOTA_BaseNPC_Hero): void {
     if (PlayerHelper.IsHumanPlayer(hero)) {
-      print(`[Event] OnPlayerLevelUp SetPlayerProperty ${hero.GetUnitName()}`);
-      PlayerPropertyApi.SetPlayerProperty(hero);
+      const refreshedCount = PlayerPropertyApi.RefreshPlayerPropertyOnHeroLevelUp(hero);
+      print(
+        `[Event] OnPlayerLevelUp RefreshPlayerProperty ${hero.GetUnitName()} refreshed=${refreshedCount}`,
+      );
     }
     if (PlayerHelper.IsBotPlayer(hero)) {
       BotAbility.LevelUpBotAbility(hero);

--- a/src/vscripts/modules/property/property-controller-level-refresh.test.ts
+++ b/src/vscripts/modules/property/property-controller-level-refresh.test.ts
@@ -1,0 +1,92 @@
+jest.mock('../../utils/tstl-utils', () => ({
+  reloadable: <T>(target: T) => target,
+}));
+
+jest.mock('../helper/player-helper', () => ({
+  PlayerHelper: {},
+}));
+
+jest.mock('../../abilities/ts_abilities/death-prophet-ai-possession-constants', () => ({
+  DEATH_PROPHET_POSSESSION_TARGET_MODIFIER: 'modifier_death_prophet_ai_possession_target',
+}));
+
+jest.mock('../../modifiers/property/property_declare', () => {
+  const property = (name: string) => ({ name });
+  return {
+    property_aoe_bonus_constant_stacking: property('property_aoe_bonus_constant_stacking'),
+    property_attack_range_bonus: property('property_attack_range_bonus'),
+    property_attackspeed_bonus_constant: property('property_attackspeed_bonus_constant'),
+    property_bonus_vision: property('property_bonus_vision'),
+    property_cannot_miss: property('property_cannot_miss'),
+    property_cast_range_bonus_stacking: property('property_cast_range_bonus_stacking'),
+    property_cooldown_percentage: property('property_cooldown_percentage'),
+    property_evasion_constant: property('property_evasion_constant'),
+    property_flying: property('property_flying'),
+    property_health_regen_percentage: property('property_health_regen_percentage'),
+    property_ignore_movespeed_limit: property('property_ignore_movespeed_limit'),
+    property_incoming_damage_percentage: property('property_incoming_damage_percentage'),
+    property_lifesteal: property('property_lifesteal'),
+    property_magical_resistance_bonus: property('property_magical_resistance_bonus'),
+    property_mana_regen_total_percentage: property('property_mana_regen_total_percentage'),
+    property_movespeed_bonus_constant: property('property_movespeed_bonus_constant'),
+    property_physical_armor_bonus: property('property_physical_armor_bonus'),
+    property_preattack_bonus_damage: property('property_preattack_bonus_damage'),
+    property_slow_immune: property('property_slow_immune'),
+    property_spell_amplify_percentage: property('property_spell_amplify_percentage'),
+    property_spell_lifesteal: property('property_spell_lifesteal'),
+    property_stats_agility_bonus: property('property_stats_agility_bonus'),
+    property_stats_intellect_bonus: property('property_stats_intellect_bonus'),
+    property_stats_strength_bonus: property('property_stats_strength_bonus'),
+    property_status_resistance_stacking: property('property_status_resistance_stacking'),
+  };
+});
+
+import type { PlayerProperty } from '../../api/player';
+import { PropertyController } from './property_controller';
+
+describe('PropertyController hero-level refresh', () => {
+  it('does not rebuild the same capped property for consecutive level-up events', () => {
+    (
+      globalThis as unknown as { GameRules: { Option: { enablePlayerAttribute: boolean } } }
+    ).GameRules = { Option: { enablePlayerAttribute: true } };
+    (globalThis as unknown as { LoadKeyValues: jest.Mock }).LoadKeyValues = jest.fn(() => ({}));
+    (globalThis as unknown as { print: jest.Mock }).print = jest.fn();
+
+    new PropertyController();
+
+    let heroLevel = 14;
+    const modifier = { GetName: jest.fn(() => 'property_cast_range_bonus_stacking') };
+    const hero = {
+      GetEntityIndex: jest.fn(() => 901),
+      GetLevel: jest.fn(() => heroLevel),
+      HasModifier: jest.fn(() => false),
+      IsAlive: jest.fn(() => true),
+      RemoveModifierByName: jest.fn(),
+      AddNewModifier: jest.fn(() => modifier),
+    } as unknown as CDOTA_BaseNPC_Hero;
+    const property = {
+      name: 'property_cast_range_bonus_stacking',
+      level: 8,
+    } as PlayerProperty;
+
+    PropertyController.LevelupHeroProperty(hero, property);
+    expect((hero as unknown as { AddNewModifier: jest.Mock }).AddNewModifier).toHaveBeenCalledTimes(
+      1,
+    );
+
+    heroLevel = 15;
+    expect(PropertyController.RefreshHeroPropertyOnLevelUp(hero, property)).toBe(false);
+
+    heroLevel = 16;
+    expect(PropertyController.RefreshHeroPropertyOnLevelUp(hero, property)).toBe(true);
+    expect((hero as unknown as { AddNewModifier: jest.Mock }).AddNewModifier).toHaveBeenCalledTimes(
+      2,
+    );
+
+    heroLevel = 25;
+    expect(PropertyController.RefreshHeroPropertyOnLevelUp(hero, property)).toBe(false);
+    expect((hero as unknown as { AddNewModifier: jest.Mock }).AddNewModifier).toHaveBeenCalledTimes(
+      2,
+    );
+  });
+});

--- a/src/vscripts/modules/property/property_controller.ts
+++ b/src/vscripts/modules/property/property_controller.ts
@@ -1,4 +1,5 @@
 import { type PlayerProperty } from '../../api/player';
+import { DEATH_PROPHET_POSSESSION_TARGET_MODIFIER } from '../../abilities/ts_abilities/death-prophet-ai-possession-constants';
 import {
   property_aoe_bonus_constant_stacking,
   property_attack_range_bonus,
@@ -29,6 +30,41 @@ import {
 import { reloadable } from '../../utils/tstl-utils';
 import { PlayerHelper } from '../helper/player-helper';
 
+/** 临时载体使用的单 modifier 属性快照，避免批量创建/移除玩家属性 modifier。 */
+export interface TemporaryHeroPropertyValues {
+  cooldownPercentage: number;
+  castRangeBonus: number;
+  aoeBonus: number;
+  spellAmplifyPercentage: number;
+  statusResistance: number;
+  evasion: number;
+  magicalResistance: number;
+  incomingDamagePercentage: number;
+  attackRangeBonus: number;
+  physicalArmor: number;
+  preattackDamage: number;
+  attackSpeed: number;
+  strength: number;
+  agility: number;
+  intellect: number;
+  healthRegenPercentage: number;
+  manaRegenPercentage: number;
+  lifesteal: number;
+  spellLifesteal: number;
+  moveSpeed: number;
+  bonusVision: number;
+  ignoreMoveSpeedLimit: 0 | 1;
+  cannotMiss: 0 | 1;
+  slowImmune: 0 | 1;
+  flying: 0 | 1;
+}
+
+interface PlayerModifierKeyValues {
+  item_player_modifiers?: {
+    Modifiers?: Record<string, { Properties?: Record<string, string> }>;
+  };
+}
+
 @reloadable
 export class PropertyController {
   /**
@@ -43,7 +79,16 @@ export class PropertyController {
    * value: data-driven modifier name
    */
   private static propertyDataDrivenModifierMap = new Map<string, string>();
+  private static propertyDataDrivenPropertyKeyMap = new Map<string, string>();
+  private static playerModifierKeyValues?: PlayerModifierKeyValues;
   private static PLAYER_MODIFER_DATA_DRIVEN_ITEM: CDOTA_Item_DataDriven;
+  /**
+   * 记录英雄上一次实际应用的属性档位。
+   *
+   * 英雄一次获得大量经验时，Dota 会连续派发多个升级事件。过去每个事件都会把全部
+   * 玩家属性 modifier 删除后重建，夺舍结束处决目标时尤其容易造成明显卡顿。
+   */
+  private static appliedPropertyLevels = new Map<string, number>();
 
   private static bnusSkillPointsAdded = new Map<number, number>();
 
@@ -54,6 +99,9 @@ export class PropertyController {
 
   constructor() {
     print('PropertyController init');
+    PropertyController.playerModifierKeyValues = LoadKeyValues(
+      'scripts/npc/npc_items_modifier.txt',
+    ) as PlayerModifierKeyValues | undefined;
     // lua modifier
     PropertyController.propertyLuaModiferMap.set(property_cast_range_bonus_stacking.name, 25);
     PropertyController.propertyLuaModiferMap.set(property_spell_amplify_percentage.name, 5);
@@ -122,6 +170,51 @@ export class PropertyController {
       property_flying.name,
       'modifier_player_property_flying',
     );
+
+    PropertyController.propertyDataDrivenPropertyKeyMap.set(
+      property_cooldown_percentage.name,
+      'MODIFIER_PROPERTY_COOLDOWN_PERCENTAGE',
+    );
+    PropertyController.propertyDataDrivenPropertyKeyMap.set(
+      property_movespeed_bonus_constant.name,
+      'MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT',
+    );
+    PropertyController.propertyDataDrivenPropertyKeyMap.set(
+      property_bonus_vision.name,
+      'MODIFIER_PROPERTY_BONUS_DAY_VISION',
+    );
+    PropertyController.propertyDataDrivenPropertyKeyMap.set(
+      property_evasion_constant.name,
+      'MODIFIER_PROPERTY_EVASION_CONSTANT',
+    );
+    PropertyController.propertyDataDrivenPropertyKeyMap.set(
+      property_magical_resistance_bonus.name,
+      'MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS',
+    );
+    PropertyController.propertyDataDrivenPropertyKeyMap.set(
+      property_physical_armor_bonus.name,
+      'MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS',
+    );
+    PropertyController.propertyDataDrivenPropertyKeyMap.set(
+      property_preattack_bonus_damage.name,
+      'MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE',
+    );
+    PropertyController.propertyDataDrivenPropertyKeyMap.set(
+      property_attackspeed_bonus_constant.name,
+      'MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT',
+    );
+    PropertyController.propertyDataDrivenPropertyKeyMap.set(
+      property_stats_strength_bonus.name,
+      'MODIFIER_PROPERTY_STATS_STRENGTH_BONUS',
+    );
+    PropertyController.propertyDataDrivenPropertyKeyMap.set(
+      property_stats_agility_bonus.name,
+      'MODIFIER_PROPERTY_STATS_AGILITY_BONUS',
+    );
+    PropertyController.propertyDataDrivenPropertyKeyMap.set(
+      property_stats_intellect_bonus.name,
+      'MODIFIER_PROPERTY_STATS_INTELLECT_BONUS',
+    );
   }
 
   /**
@@ -152,6 +245,8 @@ export class PropertyController {
     if (!hero) {
       return;
     }
+
+    PropertyController.ClearAppliedPropertyLevels(hero);
 
     // 移除Lua modifier
     for (const key of PropertyController.propertyLuaModiferMap.keys()) {
@@ -190,6 +285,24 @@ export class PropertyController {
     PropertyController.LevelupHeroProperty(hero, property);
   }
 
+  /**
+   * 英雄升级专用入口：档位没有变化时不重复删除/创建 modifier。
+   * 属性主动加点、重置和英雄出生仍走 LevelupHeroProperty，保证可以强制刷新。
+   */
+  public static RefreshHeroPropertyOnLevelUp(
+    hero: CDOTA_BaseNPC_Hero,
+    property: PlayerProperty,
+  ): boolean {
+    if (hero.HasModifier(DEATH_PROPHET_POSSESSION_TARGET_MODIFIER)) return false;
+
+    const activeLevel = PropertyController.GetPropertyActiveLevel(hero, property);
+    const cacheKey = PropertyController.GetAppliedPropertyLevelKey(hero, property.name);
+    if (PropertyController.appliedPropertyLevels.get(cacheKey) === activeLevel) return false;
+
+    PropertyController.LevelupHeroProperty(hero, property);
+    return true;
+  }
+
   // 根据英雄等级和加点点数，计算当前应该生效的属性等级
   private static GetPropertyActiveLevel(hero: CDOTA_BaseNPC_Hero, property: PlayerProperty) {
     if (PropertyController.limitPropertyNames.includes(property.name)) {
@@ -201,14 +314,25 @@ export class PropertyController {
 
   // 升级单条属性
   public static LevelupHeroProperty(hero: CDOTA_BaseNPC_Hero, property: PlayerProperty) {
-    // 移速属性作为例外,即使禁用玩家属性也生效
-    const isMoveSpeedProperty = property.name === 'property_movespeed_bonus_constant';
-
-    if (!GameRules.Option.enablePlayerAttribute && !isMoveSpeedProperty) {
+    // 夺舍目标的玩家成长由单一可见状态提供快照。其临时 PlayerID 不能触发正式属性 modifier，
+    // 否则附身期间升级后会把死亡先知的永久属性留到目标复活。
+    if (hero.HasModifier(DEATH_PROPHET_POSSESSION_TARGET_MODIFIER)) {
       return;
     }
+
     const name = property.name;
     const activeLevel = PropertyController.GetPropertyActiveLevel(hero, property);
+
+    // 先记录当前档位。即使当前数值为 0 或功能被关闭，连续升级事件也不应重复扫描它；
+    // 主动加点/重置仍会无条件调用本方法并覆盖缓存。
+    PropertyController.appliedPropertyLevels.set(
+      PropertyController.GetAppliedPropertyLevelKey(hero, name),
+      activeLevel,
+    );
+
+    // 移速属性作为例外,即使禁用玩家属性也生效
+    const isMoveSpeedProperty = property.name === 'property_movespeed_bonus_constant';
+    if (!GameRules.Option.enablePlayerAttribute && !isMoveSpeedProperty) return;
 
     // 设置额外技能点
     if (name === 'property_skill_points_bonus') {
@@ -250,6 +374,196 @@ export class PropertyController {
         );
       }
     }
+  }
+
+  private static GetAppliedPropertyLevelKey(
+    hero: CDOTA_BaseNPC_Hero,
+    propertyName: string,
+  ): string {
+    return `${hero.GetEntityIndex()}:${propertyName}`;
+  }
+
+  private static ClearAppliedPropertyLevels(hero: CDOTA_BaseNPC_Hero): void {
+    const prefix = `${hero.GetEntityIndex()}:`;
+    for (const key of PropertyController.appliedPropertyLevels.keys()) {
+      if (key.startsWith(prefix)) PropertyController.appliedPropertyLevels.delete(key);
+    }
+  }
+
+  /**
+   * 把指定玩家的局外成长折叠成一份纯数值快照。
+   * 夺舍状态直接声明这些属性，不创建/扫描/移除玩家属性 modifier，也不会覆盖目标原有成长。
+   */
+  public static BuildTemporaryHeroPropertyValues(
+    hero: CDOTA_BaseNPC_Hero,
+    properties: PlayerProperty[],
+  ): TemporaryHeroPropertyValues {
+    const values: TemporaryHeroPropertyValues = {
+      cooldownPercentage: 0,
+      castRangeBonus: 0,
+      aoeBonus: 0,
+      spellAmplifyPercentage: 0,
+      statusResistance: 0,
+      evasion: 0,
+      magicalResistance: 0,
+      incomingDamagePercentage: 0,
+      attackRangeBonus: 0,
+      physicalArmor: 0,
+      preattackDamage: 0,
+      attackSpeed: 0,
+      strength: 0,
+      agility: 0,
+      intellect: 0,
+      healthRegenPercentage: 0,
+      manaRegenPercentage: 0,
+      lifesteal: 0,
+      spellLifesteal: 0,
+      moveSpeed: 0,
+      bonusVision: 0,
+      ignoreMoveSpeedLimit: 0,
+      cannotMiss: 0,
+      slowImmune: 0,
+      flying: 0,
+    };
+
+    for (const property of properties) {
+      const isMoveSpeedProperty = property.name === property_movespeed_bonus_constant.name;
+      if (!GameRules.Option.enablePlayerAttribute && !isMoveSpeedProperty) continue;
+      if (property.name === 'property_skill_points_bonus') continue;
+
+      const activeLevel = PropertyController.GetPropertyActiveLevel(hero, property);
+      if (activeLevel <= 0) continue;
+
+      switch (property.name) {
+        case property_cooldown_percentage.name:
+          values.cooldownPercentage = PropertyController.GetDataDrivenPropertyValue(
+            property.name,
+            activeLevel,
+          );
+          break;
+        case property_cast_range_bonus_stacking.name:
+          values.castRangeBonus = 25 * activeLevel;
+          break;
+        case property_aoe_bonus_constant_stacking.name:
+          values.aoeBonus = 15 * activeLevel;
+          break;
+        case property_spell_amplify_percentage.name:
+          values.spellAmplifyPercentage = 5 * activeLevel;
+          break;
+        case property_status_resistance_stacking.name:
+          values.statusResistance = 4 * activeLevel;
+          break;
+        case property_evasion_constant.name:
+          values.evasion = PropertyController.GetDataDrivenPropertyValue(
+            property.name,
+            activeLevel,
+          );
+          break;
+        case property_magical_resistance_bonus.name:
+          values.magicalResistance = PropertyController.GetDataDrivenPropertyValue(
+            property.name,
+            activeLevel,
+          );
+          break;
+        case property_incoming_damage_percentage.name:
+          values.incomingDamagePercentage = -4 * activeLevel;
+          break;
+        case property_attack_range_bonus.name:
+          values.attackRangeBonus = 25 * activeLevel;
+          break;
+        case property_physical_armor_bonus.name:
+          values.physicalArmor = PropertyController.GetDataDrivenPropertyValue(
+            property.name,
+            activeLevel,
+          );
+          break;
+        case property_preattack_bonus_damage.name:
+          values.preattackDamage = PropertyController.GetDataDrivenPropertyValue(
+            property.name,
+            activeLevel,
+          );
+          break;
+        case property_attackspeed_bonus_constant.name:
+          values.attackSpeed = PropertyController.GetDataDrivenPropertyValue(
+            property.name,
+            activeLevel,
+          );
+          break;
+        case property_stats_strength_bonus.name:
+          values.strength = PropertyController.GetDataDrivenPropertyValue(
+            property.name,
+            activeLevel,
+          );
+          break;
+        case property_stats_agility_bonus.name:
+          values.agility = PropertyController.GetDataDrivenPropertyValue(
+            property.name,
+            activeLevel,
+          );
+          break;
+        case property_stats_intellect_bonus.name:
+          values.intellect = PropertyController.GetDataDrivenPropertyValue(
+            property.name,
+            activeLevel,
+          );
+          break;
+        case property_health_regen_percentage.name:
+          values.healthRegenPercentage = 0.3 * activeLevel;
+          break;
+        case property_mana_regen_total_percentage.name:
+          values.manaRegenPercentage = 0.3 * activeLevel;
+          break;
+        case property_lifesteal.name:
+          values.lifesteal = 10 * activeLevel;
+          break;
+        case property_spell_lifesteal.name:
+          values.spellLifesteal = 8 * activeLevel;
+          break;
+        case property_movespeed_bonus_constant.name:
+          values.moveSpeed = PropertyController.GetDataDrivenPropertyValue(
+            property.name,
+            activeLevel,
+          );
+          break;
+        case property_bonus_vision.name:
+          values.bonusVision = PropertyController.GetDataDrivenPropertyValue(
+            property.name,
+            activeLevel,
+          );
+          break;
+        case property_ignore_movespeed_limit.name:
+          values.ignoreMoveSpeedLimit = 1;
+          break;
+        case property_cannot_miss.name:
+          values.cannotMiss =
+            activeLevel >= PropertyController.SINGLE_DATA_DRIVEN_PROPERTY_MIN_LEVEL ? 1 : 0;
+          break;
+        case property_slow_immune.name:
+          values.slowImmune = 1;
+          break;
+        case property_flying.name:
+          values.flying =
+            activeLevel >= PropertyController.SINGLE_DATA_DRIVEN_PROPERTY_MIN_LEVEL ? 1 : 0;
+          break;
+      }
+    }
+
+    return values;
+  }
+
+  /** 从现有玩家属性 KV 的实际档位读取数值，避免为夺舍维护第二套成长常量。 */
+  private static GetDataDrivenPropertyValue(propertyName: string, activeLevel: number): number {
+    const modifierPrefix = PropertyController.propertyDataDrivenModifierMap.get(propertyName);
+    const propertyKey = PropertyController.propertyDataDrivenPropertyKeyMap.get(propertyName);
+    if (!modifierPrefix || !propertyKey) return 0;
+
+    const modifierName = modifierPrefix.endsWith('_level_')
+      ? `${modifierPrefix}${activeLevel}`
+      : modifierPrefix;
+    const rawValue =
+      PropertyController.playerModifierKeyValues?.item_player_modifiers?.Modifiers?.[modifierName]
+        ?.Properties?.[propertyKey];
+    return Number(rawValue ?? 0);
   }
 
   private static SetBonusSkillPoints(


### PR DESCRIPTION
## Summary

- Replace awakened Exorcism with temporary player control of an enemy AI hero while preserving the target's abilities and items.
- Attribute damage, damage taken, kills, and the possession-ending kill to Death Prophet, with level 25 kill extensions and lifecycle-safe restoration.
- Add awakened-only talent and Scepter compensation, status/Ping duration, vision, selection, hotkey synchronization, selected-ability inheritance, and property cleanup.
- Keep unawakened Exorcism and its original talent behavior unchanged.

## Testing

- User verified the awakening behavior in Dota Tools with the configured local test addon and player database.
- `npm run build:vscripts`
- `npm run build:panorama`
- Targeted Jest: 3 suites, 30 tests passed
- Targeted ESLint and Prettier checks
- `git diff --check origin/develop...HEAD`

## Checklist

- [x] I have tested the changes works well.

No Release Note or version change is included in this PR.
