### PR TITLE
Add mobile Nyx Assassin Burrow awakening

### DIFF
--- a/.claude/skills/awaken-ability/SKILL.md
+++ b/.claude/skills/awaken-ability/SKILL.md
@@ -109,7 +109,10 @@ description: 为英雄创作「觉醒技能」时使用——通过觉醒石（i
 
 - **图标** → 引用 Dota2 原版技能名则不放 png；自定义图标才复制同名 png 到 `game/resource/flash3/images/spellicons/<name>.png`。`AbilityTextureName` 也可直接填**至宝/变体 texture 路径**（如 `necrolyte/apostle_of_decay_icons/necrolyte_heartstopper_aura`、`drow_ranger/immortal/drow_ranger_wave_of_silence`、`zuus_static_field_alt1`），引擎直接引用，同样无需放 png。
 
-- **本地化** → 在两个 addon 文件的 `Awaken Abilities 觉醒技能` 模块补条目（中英同步）。标题格式见下。
+- **本地化** → 新觉醒条目固定排在旧觉醒之上：
+  - `addon_schinese.txt` / `addon_english.txt`：放在 `Awaken Abilities 觉醒技能` 模块的**顶部**，中英同步。
+  - `addon_russian.txt`：放在 `Creep / Tower` 区块末尾的 `Awaken Abilities 觉醒技能` 模块，位于 `// Сундук с сокровищами`（藏宝箱）之前。
+  - 觉醒条目的开头注释统一使用中文 `// 英雄 xxx觉醒`。标题格式见下。
 
 ### 3) 标题本地化格式（统一）
 

--- a/.claude/skills/release-note/SKILL.md
+++ b/.claude/skills/release-note/SKILL.md
@@ -170,6 +170,7 @@ grep "npc_dota_hero_pugna:n" docs/reference/7.41/abilities_english.txt
 ### 从 PR 提取信息
 
 - 优先从描述中的更新列表提取；无列表则从 commits 推断 3–5 条
+- 生成聚合 release PR 的大版本块时，已在其保留的小版本块或已发布小版本中出现的改动不重复写入；大版本块只保留本轮待发布内容。
 - 注释同步、KV 对照、纯文档变更若无玩法影响不写入
 - 多英雄技能同步归纳为一条玩家向 bullet
 - 数值改动用定性表述，除非用户指定

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -3591,6 +3591,13 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken"				"<font color='#d000ff'>Demon's Reach Awakened</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken_Description"		"While Atrophy Aura grants bonus attack damage, attacks deal <font color='#FFFFFF'><b>100%%</b></font> cleave damage, with cleave distance increasing for each point of bonus damage. Current cleave distance: <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font>."
 
+		// 司夜刺客 钻地觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"					"<font color='#d000ff'>Burrow Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"Nyx Assassin can move freely at his normal movement speed while Burrowed, while retaining all other Burrow effects."
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_SummaryDescription"	"Allows Nyx Assassin to move normally while Burrowed without losing its other effects."
+		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"				"<font color='#d000ff'>Burrow Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"Nyx Assassin can move freely at his normal movement speed while Burrowed, while retaining all other Burrow effects."
+
 		// Slark Essence Erosion - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>Essence Erosion Awakened</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"When Slark kills an enemy hero, he permanently steals %permanent_steal_pct%%% of the total attributes his Essence Shift has taken from that hero.<br>An enemy hero's base attributes never fall below <font color='#FFFFFF'><b>1</b></font>."

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -565,6 +565,10 @@
 		"DOTA_Tooltip_ability_fountain_armor_aura_Description"				"Provides %bonus_armor% armor to nearby allies."
 		"DOTA_Tooltip_ability_fountain_magical_armor_aura"				"Fountain Magical Resistance Aura"
 		"DOTA_Tooltip_ability_fountain_magical_armor_aura_Description"			"Provides %bonus_magical_armor%%% magical resistance to nearby allies."
+
+
+		// 藏宝箱
+		"npc_treasure_chest"											"Treasure Chest"
 		///////////////////////////////////////////////////
 		//
 		//            itembuilds
@@ -1259,6 +1263,54 @@
 		//
 		///////////////////////////////////////////////////
 // 					Awaken Abilities 觉醒技能
+
+		// 司夜刺客 钻地觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"					"<font color='#d000ff'>Burrow Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"Nyx Assassin can move freely at his normal movement speed while Burrowed, while retaining all other Burrow effects."
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_SummaryDescription"	"Allows Nyx Assassin to move normally while Burrowed without losing its other effects."
+		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"				"<font color='#d000ff'>Burrow Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"Nyx Assassin can move freely at his normal movement speed while Burrowed, while retaining all other Burrow effects."
+
+		// 巫妖 寒灾轮回觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade"		"<font color='#d000ff'>Frost Calamity Cycle</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Description"		"Increases Chain Frost's projectile speed and bounce range, and extends the duration of its slow and Frostbound.<br><br>Hits on a hero or Roshan deal bonus magical damage equal to %intelligence_damage_multiplier%x Intelligence and apply a stack of Frost Calamity lasting %mark_duration% seconds, detonating automatically at %mark_max_stacks% stacks; casting Frost Blast on a marked enemy also detonates it early. Detonation deals magical damage in a %detonation_radius% radius equal to %nova_detonation_multiplier_per_stack%x Intelligence per stack consumed and <font color='#2DD5E4'>Stuns</font> enemies for %freeze_duration% seconds.<br><br>If Ice Spire is already learned, hitting the only enemy hero nearby with Chain Frost casts Ice Spire at that hero automatically."
+		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Note0"		"Illusions do not count as real heroes. Roshan is treated as a regular unit."
+		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Note1"		"Frost Calamity marks only stack on real heroes and Roshan. Roshan takes the detonation damage but is not frozen."
+		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Note2"		"Frost Blast can detonate Frost Calamity early, dealing damage based on its current stacks."
+		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade"		"<font color='#d000ff'>Frost Calamity Cycle</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_Description"		"Increases Chain Frost's projectile speed and bounce range, and extends the duration of its slow and Frostbound.<br><br>Hits on a hero or Roshan deal bonus magical damage equal to <font color='#FFFFFF'><b>0.75x</b></font> Intelligence and apply a stack of Frost Calamity lasting <font color='#FFFFFF'><b>8</b></font> seconds, detonating automatically at <font color='#FFFFFF'><b>3</b></font> stacks; casting Frost Blast on a marked enemy also detonates it early. Detonation deals magical damage in a <font color='#FFFFFF'><b>350</b></font> radius equal to <font color='#FFFFFF'><b>0.75x</b></font> Intelligence per stack consumed and <font color='#2DD5E4'>Stuns</font> enemies for <font color='#FFFFFF'><b>0.6</b></font> seconds.<br><br>If Ice Spire is already learned, hitting the only enemy hero nearby with Chain Frost casts Ice Spire at that hero automatically."
+		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark"		"Frost Calamity"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark_Description"		"At 3 stacks, triggers a Frost Calamity detonation. Lich can also detonate it early with Frost Blast."
+
+		// 戴泽 薄葬觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade"					"<font color='#d000ff'>Shallow Grave Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade_Description"	"After casting Shallow Grave on yourself or an ally, the target gains the <font color='#FFCC66'>Black King Bar</font> effect for the duration of Shallow Grave."
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Shallow Grave Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"After casting Shallow Grave on yourself or an ally, the target gains the <font color='#FFCC66'>Black King Bar</font> effect for the duration of Shallow Grave."
+
+		// 孽主 恶魔之势觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken"					"<font color='#d000ff'>Demon's Reach Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_Description"		"Underlord's attacks cleave while he has bonus damage from Atrophy Aura. Cleave distance increases with each point of bonus damage."
+		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_SummaryDescription"	"Underlord's attacks cleave while he has bonus damage from Atrophy Aura."
+		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_cleave_damage_pct"		"%CLEAVE DAMAGE:"
+		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_cleave_distance_base"		"CLEAVE DISTANCE (BASE):"
+		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_cleave_distance_per_stack"	"CLEAVE DISTANCE (PER STACK):"
+		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken"				"<font color='#d000ff'>Demon's Reach Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken_Description"		"While Atrophy Aura grants bonus attack damage, attacks deal <font color='#FFFFFF'><b>100%%</b></font> cleave damage, with cleave distance increasing for each point of bonus damage. Current cleave distance: <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font>."
+
+		// 斯拉克 精华侵蚀觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>Essence Erosion Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"When Slark kills an enemy hero, he permanently steals %permanent_steal_pct%%% of the total attributes his Essence Shift has taken from that hero.<br>An enemy hero's base attributes never fall below <font color='#FFFFFF'><b>1</b></font>."
+		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_SummaryDescription"	"When Slark kills an enemy hero, he permanently steals part of the attributes his Essence Shift has taken from that hero."
+		"DOTA_Tooltip_modifier_special_bonus_unique_slark_permanent_essence_awaken"				"<font color='#d000ff'>Essence Erosion Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_slark_permanent_essence_awaken_Description"		"When Slark kills an enemy hero, he permanently steals <font color='#FFFFFF'><b>10%%</b></font> of the total attributes his Essence Shift has taken from that hero.<br>Permanently gained <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font> to all attributes."
+
+		// 亚巴顿 畅快淋漓觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken"					"<font color='#d000ff'>The Quickening Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken_Description"		"Whenever a unit dies within %radius% range of Abaddon, all his cooldowns are reduced. Non-hero deaths reduce them by %cooldown_reduction_creeps%s; hero deaths reduce them by %cooldown_reduction_heroes%s."
+		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken_SummaryDescription"		"Nearby deaths reduce the current cooldowns of all abilities and items."
+		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>The Quickening Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"Whenever a unit dies within <font color='#FFFFFF'><b>900</b></font> range, the current cooldowns of all Abaddon's abilities and items are reduced. Non-hero deaths reduce them by <font color='#FFFFFF'><b>0.2</b></font>s; hero deaths reduce them by <font color='#FFFFFF'><b>3</b></font>s."
 
 		// 兽王 野性之斧-觉醒
 		"DOTA_Tooltip_ability_beastmaster_wild_axes_awaken"							"<font color='#d000ff'>Wild Axes Awakened</font>"
@@ -3557,9 +3609,6 @@
 		"DOTA_Tooltip_ability_trigger_learned_skills_Note6"    "• Two-stage skills and cancel skills"
 		"DOTA_Tooltip_ability_trigger_learned_skills_Note7"    "• Elemental balls and fusion skills of Kael"
 
-		// 藏宝箱
-		"npc_treasure_chest"											"Treasure Chest"
-
 		// item_six_paths_reincarnation_gun
 		"DOTA_Tooltip_Ability_item_six_paths_reincarnation_gun"                                  "Six Paths Reincarnation Gun"
 		"DOTA_Tooltip_Ability_item_six_paths_reincarnation_gun_Description"                       "<h1>Active: Six Paths Rotation</h1>For %active_duration% seconds, each attack is independently converted into one of the following damage types:<br>- Physical damage<br>- Magical damage<br>- Pure damage<br>Critical strike damage is also converted. Split arrows and similar additional attacks roll their damage type separately. Converted damage is not affected by spell amplification.\n<h1>Passive: Samsara Scatter</h1>Each attack deals bonus damage to other enemies within %attack_radius% of the target equal to %attack_percent%%% of that attack's damage. The bonus damage is calculated after critical strikes, but before the target's armor, magic resistance, and other damage reductions.<br>Each proc randomly deals one of the following:<br>- Physical damage<br>- Magical damage<br>- Pure damage<br>Samsara Scatter bonus damage is not affected by spell amplification.<br>All shotgun effects share a %internal_cooldown% second attacker-wide internal cooldown, preventing simultaneous split arrows from producing many splash procs from a single attack.\n<h1>Passive: Mage Slayer</h1>Attacks reduce the target's ability and item damage by %mage_slayer_spell_damage_reduction%%% for %mage_slayer_duration% seconds. While affected, the target takes the following each second:<br>- %mage_slayer_damage_per_type% physical damage<br>- %mage_slayer_damage_per_type% magical damage<br>- %mage_slayer_damage_per_type% pure damage<br>The damage over time is not affected by spell amplification."
@@ -3572,52 +3621,5 @@
 		"DOTA_Tooltip_modifier_item_six_paths_reincarnation_gun_active_Description"              "Each attack is independently converted to physical, magical, or pure damage. Converted damage is not affected by spell amplification."
 		"DOTA_Tooltip_modifier_item_six_paths_reincarnation_gun_debuff"                          "Mage Slayer"
 		"DOTA_Tooltip_modifier_item_six_paths_reincarnation_gun_debuff_Description"              "Ability and item damage dealt is reduced by 30%, while taking physical, magical, and pure damage over time. The damage over time is not affected by spell amplification."
-		// 巫妖 寒灾轮回
-		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade"		"<font color='#d000ff'>Frost Calamity Cycle</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Description"		"Increases Chain Frost's projectile speed and bounce range, and extends the duration of its slow and Frostbound.<br><br>Hits on a hero or Roshan deal bonus magical damage equal to %intelligence_damage_multiplier%x Intelligence and apply a stack of Frost Calamity lasting %mark_duration% seconds, detonating automatically at %mark_max_stacks% stacks; casting Frost Blast on a marked enemy also detonates it early. Detonation deals magical damage in a %detonation_radius% radius equal to %nova_detonation_multiplier_per_stack%x Intelligence per stack consumed and <font color='#2DD5E4'>Stuns</font> enemies for %freeze_duration% seconds.<br><br>If Ice Spire is already learned, hitting the only enemy hero nearby with Chain Frost casts Ice Spire at that hero automatically."
-		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Note0"		"Illusions do not count as real heroes. Roshan is treated as a regular unit."
-		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Note1"		"Frost Calamity marks only stack on real heroes and Roshan. Roshan takes the detonation damage but is not frozen."
-		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Note2"		"Frost Blast can detonate Frost Calamity early, dealing damage based on its current stacks."
-		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade"		"<font color='#d000ff'>Frost Calamity Cycle</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_Description"		"Increases Chain Frost's projectile speed and bounce range, and extends the duration of its slow and Frostbound.<br><br>Hits on a hero or Roshan deal bonus magical damage equal to <font color='#FFFFFF'><b>0.75x</b></font> Intelligence and apply a stack of Frost Calamity lasting <font color='#FFFFFF'><b>8</b></font> seconds, detonating automatically at <font color='#FFFFFF'><b>3</b></font> stacks; casting Frost Blast on a marked enemy also detonates it early. Detonation deals magical damage in a <font color='#FFFFFF'><b>350</b></font> radius equal to <font color='#FFFFFF'><b>0.75x</b></font> Intelligence per stack consumed and <font color='#2DD5E4'>Stuns</font> enemies for <font color='#FFFFFF'><b>0.6</b></font> seconds.<br><br>If Ice Spire is already learned, hitting the only enemy hero nearby with Chain Frost casts Ice Spire at that hero automatically."
-		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark"		"Frost Calamity"
-		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark_Description"		"At 3 stacks, triggers a Frost Calamity detonation. Lich can also detonate it early with Frost Blast."
-		// 戴泽 薄葬觉醒
-		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade"					"<font color='#d000ff'>Shallow Grave Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade_Description"	"After casting Shallow Grave on yourself or an ally, the target gains the <font color='#FFCC66'>Black King Bar</font> effect for the duration of Shallow Grave."
-		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Shallow Grave Awakened</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"After casting Shallow Grave on yourself or an ally, the target gains the <font color='#FFCC66'>Black King Bar</font> effect for the duration of Shallow Grave."
-
-		// 孽主 恶魔之势觉醒
-		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken"					"<font color='#d000ff'>Demon's Reach Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_Description"		"Underlord's attacks cleave while he has bonus damage from Atrophy Aura. Cleave distance increases with each point of bonus damage."
-		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_SummaryDescription"	"Underlord's attacks cleave while he has bonus damage from Atrophy Aura."
-		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_cleave_damage_pct"		"%CLEAVE DAMAGE:"
-		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_cleave_distance_base"		"CLEAVE DISTANCE (BASE):"
-		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_cleave_distance_per_stack"	"CLEAVE DISTANCE (PER STACK):"
-		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken"				"<font color='#d000ff'>Demon's Reach Awakened</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken_Description"		"While Atrophy Aura grants bonus attack damage, attacks deal <font color='#FFFFFF'><b>100%%</b></font> cleave damage, with cleave distance increasing for each point of bonus damage. Current cleave distance: <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font>."
-
-		// 司夜刺客 钻地觉醒
-		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"					"<font color='#d000ff'>Burrow Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"Nyx Assassin can move freely at his normal movement speed while Burrowed, while retaining all other Burrow effects."
-		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_SummaryDescription"	"Allows Nyx Assassin to move normally while Burrowed without losing its other effects."
-		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"				"<font color='#d000ff'>Burrow Awakened</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"Nyx Assassin can move freely at his normal movement speed while Burrowed, while retaining all other Burrow effects."
-
-		// Slark Essence Erosion - Awakened
-		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>Essence Erosion Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"When Slark kills an enemy hero, he permanently steals %permanent_steal_pct%%% of the total attributes his Essence Shift has taken from that hero.<br>An enemy hero's base attributes never fall below <font color='#FFFFFF'><b>1</b></font>."
-		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_SummaryDescription"	"When Slark kills an enemy hero, he permanently steals part of the attributes his Essence Shift has taken from that hero."
-		"DOTA_Tooltip_modifier_special_bonus_unique_slark_permanent_essence_awaken"				"<font color='#d000ff'>Essence Erosion Awakened</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_slark_permanent_essence_awaken_Description"		"When Slark kills an enemy hero, he permanently steals <font color='#FFFFFF'><b>10%%</b></font> of the total attributes his Essence Shift has taken from that hero.<br>Permanently gained <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font> to all attributes."
-
-		// Abaddon The Quickening - Awakened
-		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken"					"<font color='#d000ff'>The Quickening Awakened</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken_Description"		"Whenever a unit dies within %radius% range of Abaddon, all his cooldowns are reduced. Non-hero deaths reduce them by %cooldown_reduction_creeps%s; hero deaths reduce them by %cooldown_reduction_heroes%s."
-		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken_SummaryDescription"		"Nearby deaths reduce the current cooldowns of all abilities and items."
-		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>The Quickening Awakened</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"Whenever a unit dies within <font color='#FFFFFF'><b>900</b></font> range, the current cooldowns of all Abaddon's abilities and items are reduced. Non-hero deaths reduce them by <font color='#FFFFFF'><b>0.2</b></font>s; hero deaths reduce them by <font color='#FFFFFF'><b>3</b></font>s."
-
 	}
 }

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -712,6 +712,13 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken"				"<font color='#d000ff'>Демонический размах · Пробуждение</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken_Description"				"Пока Atrophy Aura даёт дополнительный урон от атак, атаки наносят <font color='#FFFFFF'><b>100%%</b></font> прорубающего урона, а дальность прорубания увеличивается с каждой единицей дополнительного урона. Текущая дальность прорубания: <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font>."
 
+		// 司夜刺客 钻地觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"					"<font color='#d000ff'>Пробуждённое Закапывание</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"Nyx Assassin может свободно передвигаться с обычной скоростью в состоянии Burrow, сохраняя все остальные эффекты способности."
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_SummaryDescription"	"Позволяет Nyx Assassin нормально передвигаться в состоянии Burrow, не теряя остальные эффекты."
+		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"				"<font color='#d000ff'>Пробуждённое Закапывание</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"Nyx Assassin может свободно передвигаться с обычной скоростью в состоянии Burrow, сохраняя все остальные эффекты способности."
+
 		// Slark Essence Erosion - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>Разъедание сущности · Пробуждение</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"Когда Slark убивает вражеского героя, он навсегда забирает %permanent_steal_pct%%% от общего количества атрибутов, похищенных у этого героя его Essence Shift.<br>Базовые атрибуты вражеского героя не опускаются ниже <font color='#FFFFFF'><b>1</b></font>."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -455,6 +455,10 @@
 		"DOTA_Tooltip_ability_fountain_armor_aura_Description"				"Даёт %bonus_armor% брони ближайшим союзникам."
 		"DOTA_Tooltip_ability_fountain_magical_armor_aura"				"Магическая аура фонтана"
 		"DOTA_Tooltip_ability_fountain_magical_armor_aura_Description"			"Даёт %bonus_magical_armor%%% сопротивления магии ближайшим союзникам."
+
+
+		// 藏宝箱
+		"npc_treasure_chest"													"Сундук с сокровищами"
 		///////////////////////////////////////////////////
 		//
 		//            itembuilds
@@ -603,6 +607,14 @@
 		"DOTA_Tooltip_ability_ancient_apparition_freezing_aura_ad"				"ad rate： "
 		"DOTA_Tooltip_ability_ancient_apparition_freezing_aura_duration"		"Длительность： "
 
+
+		///////////////////////////////////////////////////
+		//
+		// 					Awaken Abilities 觉醒技能
+		//
+		///////////////////////////////////////////////////
+// 					Awaken Abilities 觉醒技能
+
 		// Skywrath Mage Staff of the Scion - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_skywrath_upgrade"						"<font color='#d000ff'>Посох отпрыска · Пробуждение</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_skywrath_upgrade_Description"			"<font color='#d000ff'>Бонус пробуждения:</font> Skywrath Mage получает Staff of the Scion. Каждый раз, когда его способности наносят <font color='#05CAFF'>магический урон</font> вражескому герою, время восстановления всех его способностей сокращается на %cooldown_reduction% сек.<br><br><font color='#00CED1'>Автоприменение:</font> Если включено, Skywrath Mage автоматически применяет Ancient Seal, Concussive Shot, Mystic Flare и Arcane Bolt, когда вражеский герой находится в радиусе применения. Arcane Bolt также применяется по крипам, если героев поблизости нет."
@@ -636,17 +648,8 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_keeper_of_the_light_upgrade_focus"		"Фокус"
 		"DOTA_Tooltip_modifier_special_bonus_unique_keeper_of_the_light_upgrade_focus_Description"	"Урон Illuminate увеличен на <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%%%</b></font>."
 
-		// Сундук с сокровищами
-		"npc_treasure_chest"													"Сундук с сокровищами"
-		// Doom Awakened
-		"DOTA_Tooltip_ability_doom_bringer_doom_awakened"							"<font color='#d000ff'>Пробуждённый Doom</font>"
-		"DOTA_Tooltip_ability_doom_bringer_doom_awakened_Description"			"Накладывает проклятие, которое развеивает врага и не позволяет ему использовать способности или лечиться, при этом враг постепенно получает урон.\n\nТИП РАЗВЕИВАНИЯ: Простое развеивание\n\nС <font color='#92acf5'>Aghanim's Scepter</font> Doom также накладывает <font color='#DD621E'>Разрушение</font> и может применяться к владельцу или <font color='#FFFFFF'>союзному герою</font>, который будет непрерывно накладывать Doom на врагов в радиусе %scepter_aura_radius%, сам не получая Doom.\n\nПосле пробуждения способности нейтральных крипов, полученные с помощью <font color='#FFFFFF'>Devour</font>, автоматически повышаются до максимального уровня."
-		"DOTA_Tooltip_ability_doom_bringer_doom_awakened_duration"				"ДЛИТЕЛЬНОСТЬ:"
-		"DOTA_Tooltip_ability_doom_bringer_doom_awakened_scepter_duration"			"ДЛИТЕЛЬНОСТЬ ОБЛАСТИ DOOM:"
-		"DOTA_Tooltip_ability_doom_bringer_doom_awakened_damage"					"УРОН В СЕКУНДУ:"
-		"DOTA_Tooltip_modifier_doom_bringer_doom_awakened_carrier"				"Область Doom"
-		"DOTA_Tooltip_modifier_doom_bringer_doom_awakened_carrier_Description"	"Враги в радиусе %dMODIFIER_PROPERTY_TOOLTIP% непрерывно получают Doom."
-		// 巫妖 寒灾轮回
+
+		// 巫妖 寒灾轮回觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade"		"<font color='#d000ff'>Цикл ледяного бедствия</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Description"		"Увеличивает скорость снаряда и радиус отскока Chain Frost, а также продлевает длительность замедления и Frostbound.<br><br>Попадания по герою или Roshan наносят дополнительный магический урон в размере %intelligence_damage_multiplier%x интеллекта и накладывают 1 заряд Frost Calamity длительностью %mark_duration% сек, который взрывается самостоятельно при %mark_max_stacks% зарядах; применение Frost Blast на отмеченного врага также взрывает его досрочно. Взрыв наносит урон в радиусе %detonation_radius% в размере %nova_detonation_multiplier_per_stack%x интеллекта за каждый израсходованный заряд и <font color='#2DD5E4'>оглушает</font> врагов на %freeze_duration% сек.<br><br>Если Ice Spire уже изучена, попадание Chain Frost по единственному вражескому герою поблизости автоматически применяет Ice Spire в позиции этого героя."
 		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Note0"		"Иллюзии не считаются настоящими героями. Roshan считается обычным юнитом."
@@ -668,7 +671,14 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Пробуждение Shallow Grave</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"После применения Shallow Grave на себя или союзника цель получает эффект <font color='#FFCC66'>Black King Bar</font> на время действия Shallow Grave."
 
-		// 兽王 野性之斧-觉醒
+		// 司夜刺客 钻地觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"					"<font color='#d000ff'>Пробуждённое Закапывание</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"Nyx Assassin может свободно передвигаться с обычной скоростью в состоянии Burrow, сохраняя все остальные эффекты способности."
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_SummaryDescription"	"Позволяет Nyx Assassin нормально передвигаться в состоянии Burrow, не теряя остальные эффекты."
+		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"				"<font color='#d000ff'>Пробуждённое Закапывание</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"Nyx Assassin может свободно передвигаться с обычной скоростью в состоянии Burrow, сохраняя все остальные эффекты способности."
+
+		// 兽王 野性之斧觉醒
 		"DOTA_Tooltip_ability_beastmaster_wild_axes_awaken"							"<font color='#d000ff'>Wild Axes: пробуждение</font>"
 		"DOTA_Tooltip_ability_beastmaster_wild_axes_awaken_Description"				"Герой швыряет топоры, которые прорубают деревья и противников на своём пути и возвращаются обратно. Каждый топор задевает одного врага лишь единожды и увеличивает урон, получаемый от героя и его существ. Длительность эффекта зависит от сопротивления эффектам.<br><br><font color='#00CED1'>АВТОПРИМЕНЕНИЕ:</font> При включении топоры автоматически летят в самого дальнего вражеского героя, если в радиусе применения есть вражеские единицы.<br><font color='#d000ff'>ПРОБУЖДЕНИЕ:</font> Урон топоров увеличен, длительность усиления получаемого урона повышена, топоры почти мгновенно вылетают и возвращаются, а Drums of Slom получает увеличенные урон, лечение и число ударов барабана от Primal Roar."
 		"DOTA_Tooltip_ability_beastmaster_wild_axes_awaken_axe_damage"				"УРОН ТОПОРА:"
@@ -684,7 +694,7 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_earthshaker_upgrade"					"<font color='#d000ff'>Афтершок: пробуждение</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_earthshaker_upgrade_Description"		"Афтершок создаёт малый Афтершок в каждой точке попадания, наносящий <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%%%</b></font> урона Афтершока как <font color='#05CAFF'>магический урон</font> в радиусе <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP2%%%</b></font> от исходного. Оглушение длится вдвое меньше. Урон малых Афтершоков может накладываться, но в каждой серии цель оглушается только один раз. Малые Афтершоки не создают новые малые Афтершоки."
 
-		// Elder Titan Astral Spirit - Awakened
+		// 上古巨神 灵体游魂觉醒
 		"DOTA_Tooltip_ability_elder_titan_ancestral_spirit_awaken"						"<font color='#d000ff'>Астральный дух: пробуждение</font>"
 		"DOTA_Tooltip_ability_elder_titan_ancestral_spirit_awaken_SummaryDescription"		"Автоприменение: автоматически посылает духа к самому дальнему вражескому герою и автоматически возвращает его."
 		"DOTA_Tooltip_ability_elder_titan_ancestral_spirit_awaken_Description"		"Elder Titan призывает своего астрального духа, который наносит урон любым юнитам на своём пути. Когда дух воссоединяется с Titan, он даёт бонус к урону и скорости передвижения за каждый задетый юнит.\n\nАстральный дух обладает способностями Echo Stomp, Return Spirit и Natural Order.<br><br><font color='#d000ff'>Бонус пробуждения:</font> Сокращённое время восстановления.<br><font color='#00CED1'>Автоприменение:</font> Как только способность готова к использованию и поблизости есть вражеский герой, автоматически посылает духа к самому дальнему вражескому герою, а затем автоматически возвращает его, как только возврат становится доступен, без ручного управления. Пока способность активна, вручную призванный дух также возвращается автоматически."
@@ -697,13 +707,13 @@
 		"DOTA_Tooltip_ability_elder_titan_ancestral_spirit_awaken_damage_creeps"		"БОНУС УРОНА (НЕ-ГЕРОИ):"
 		"DOTA_Tooltip_ability_elder_titan_ancestral_spirit_awaken_damage_heroes"		"БОНУС УРОНА (ГЕРОИ):"
 		"DOTA_Tooltip_ability_elder_titan_ancestral_spirit_awaken_scepter_description"	"Elder Titan получает неуязвимость к дебаффам и %immunity_resist%%% сопротивления магии на %scepter_magic_immune_per_hero% сек. за каждого задетого вражеского героя, когда дух возвращается."
-		// Undying Flesh Decay - Awakened
+		// 尸王 血肉腐朽觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_undying_upgrade"					"<font color='#d000ff'>Гниение плоти: пробуждение</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_undying_upgrade_Description"	"Пока действует Голем из плоти, каждая обычная атака Undying при попадании применяет Гниение с центром на поражённом враге, но не чаще одного раза в %trigger_cooldown% сек. Это применение не расходует ману и не влияет на перезарядку Гниения.<br>Иллюзии и отключение пассивных способностей не активируют эффект.<br>Производные атаки без задержки между атаками не активируют эффект."
 		"DOTA_Tooltip_modifier_special_bonus_unique_undying_upgrade"			"<font color='#d000ff'>Гниение плоти: пробуждение</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_undying_upgrade_Description"	"Пока действует Голем из плоти, каждая обычная атака Undying при попадании применяет Гниение с центром на поражённом враге, но не чаще одного раза в <font color='#FFFFFF'><b>0.6</b></font> сек. Это применение не расходует ману и не влияет на перезарядку Гниения.<br>Иллюзии и отключение пассивных способностей не активируют эффект.<br>Производные атаки без задержки между атаками не активируют эффект."
 
-		// 术士 地狱火献祭-觉醒
+		// 术士 地狱火献祭觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_warlock_upgrade"					"<font color='#D000FF'>Адское пламя: пробуждение</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_warlock_upgrade_Description"	"Увеличивает урон в секунду от Постоянного пламени Адского пламени на сумму текущих восстановления здоровья и маны Чернокнижника, умноженную на %regen_to_damage_pct%%%."
 		"DOTA_Tooltip_modifier_special_bonus_unique_warlock_upgrade"			"<font color='#D000FF'>Адское пламя: пробуждение</font>"
@@ -719,26 +729,27 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken"				"<font color='#d000ff'>Демонический размах · Пробуждение</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken_Description"				"Пока Atrophy Aura даёт дополнительный урон от атак, атаки наносят <font color='#FFFFFF'><b>100%%</b></font> прорубающего урона, а дальность прорубания увеличивается с каждой единицей дополнительного урона. Текущая дальность прорубания: <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font>."
 
-		// 司夜刺客 钻地觉醒
-		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"					"<font color='#d000ff'>Пробуждённое Закапывание</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"Nyx Assassin может свободно передвигаться с обычной скоростью в состоянии Burrow, сохраняя все остальные эффекты способности."
-		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_SummaryDescription"	"Позволяет Nyx Assassin нормально передвигаться в состоянии Burrow, не теряя остальные эффекты."
-		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"				"<font color='#d000ff'>Пробуждённое Закапывание</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"Nyx Assassin может свободно передвигаться с обычной скоростью в состоянии Burrow, сохраняя все остальные эффекты способности."
-
-		// Slark Essence Erosion - Awakened
+		// 斯拉克 精华侵蚀觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>Разъедание сущности · Пробуждение</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"Когда Slark убивает вражеского героя, он навсегда забирает %permanent_steal_pct%%% от общего количества атрибутов, похищенных у этого героя его Essence Shift.<br>Базовые атрибуты вражеского героя не опускаются ниже <font color='#FFFFFF'><b>1</b></font>."
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_SummaryDescription"	"Когда Slark убивает вражеского героя, он навсегда забирает часть атрибутов, похищенных у этого героя его Essence Shift."
 		"DOTA_Tooltip_modifier_special_bonus_unique_slark_permanent_essence_awaken"				"<font color='#d000ff'>Разъедание сущности · Пробуждение</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_slark_permanent_essence_awaken_Description"		"Когда Slark убивает вражеского героя, он навсегда забирает <font color='#FFFFFF'><b>10%%</b></font> от общего количества атрибутов, похищенных у этого героя его Essence Shift.<br>Навсегда получено <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font> ко всем атрибутам."
 
-		// Abaddon The Quickening - Awakened
+		// 亚巴顿 畅快淋漓觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken"					"<font color='#d000ff'>Ускорение · Пробуждение</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken_Description"		"Когда юнит умирает в радиусе %radius% от Abaddon, всё его время перезарядки сокращается. Смерть не-героя сокращает его на %cooldown_reduction_creeps% сек., а смерть героя — на %cooldown_reduction_heroes% сек."
 		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken_SummaryDescription"		"Смерти поблизости сокращают текущее время перезарядки всех способностей и предметов."
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>Ускорение · Пробуждение</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"Когда юнит погибает в радиусе <font color='#FFFFFF'><b>900</b></font> от Abaddon, текущее время перезарядки всех его способностей и предметов сокращается. Смерть не-героя сокращает его на <font color='#FFFFFF'><b>0.2</b></font> сек., а смерть героя — на <font color='#FFFFFF'><b>3</b></font> сек."
 
+		// Doom Awakened
+		"DOTA_Tooltip_ability_doom_bringer_doom_awakened"							"<font color='#d000ff'>Пробуждённый Doom</font>"
+		"DOTA_Tooltip_ability_doom_bringer_doom_awakened_Description"			"Накладывает проклятие, которое развеивает врага и не позволяет ему использовать способности или лечиться, при этом враг постепенно получает урон.\n\nТИП РАЗВЕИВАНИЯ: Простое развеивание\n\nС <font color='#92acf5'>Aghanim's Scepter</font> Doom также накладывает <font color='#DD621E'>Разрушение</font> и может применяться к владельцу или <font color='#FFFFFF'>союзному герою</font>, который будет непрерывно накладывать Doom на врагов в радиусе %scepter_aura_radius%, сам не получая Doom.\n\nПосле пробуждения способности нейтральных крипов, полученные с помощью <font color='#FFFFFF'>Devour</font>, автоматически повышаются до максимального уровня."
+		"DOTA_Tooltip_ability_doom_bringer_doom_awakened_duration"				"ДЛИТЕЛЬНОСТЬ:"
+		"DOTA_Tooltip_ability_doom_bringer_doom_awakened_scepter_duration"			"ДЛИТЕЛЬНОСТЬ ОБЛАСТИ DOOM:"
+		"DOTA_Tooltip_ability_doom_bringer_doom_awakened_damage"					"УРОН В СЕКУНДУ:"
+		"DOTA_Tooltip_modifier_doom_bringer_doom_awakened_carrier"				"Область Doom"
+		"DOTA_Tooltip_modifier_doom_bringer_doom_awakened_carrier_Description"	"Враги в радиусе %dMODIFIER_PROPERTY_TOOLTIP% непрерывно получают Doom."
 	}
 }

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -3600,6 +3600,13 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken"				"<font color='#d000ff'>恶魔之势 觉醒</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken_Description"		"拥有衰退光环的攻击力加成时，攻击造成<font color='#FFFFFF'><b>100%%</b></font>分裂伤害，分裂距离随当前加成攻击力提高。当前分裂距离：<font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font>。"
 
+		// 司夜刺客 钻地觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"					"<font color='#d000ff'>钻地 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"钻地状态下可以保持正常移动速度并自由移动，同时保留钻地的其他效果。"
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_SummaryDescription"	"钻地状态下可以正常移动，同时保留其他钻地效果。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"				"<font color='#d000ff'>钻地 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"钻地状态下可以保持正常移动速度并自由移动，同时保留钻地的其他效果。"
+
 		// 斯拉克 精华侵蚀觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>精华侵蚀 觉醒</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"斯拉克击杀敌人时，将能量转移偷取属性总量的%permanent_steal_pct%%%永久偷走该英雄的全属性。<br>敌方英雄的基础属性最低保留<font color='#FFFFFF'><b>1</b></font>点。"

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -566,6 +566,10 @@
 		"DOTA_Tooltip_ability_fountain_armor_aura_Description"					"增加附近友军%bonus_armor%点护甲。"
 		"DOTA_Tooltip_ability_fountain_magical_armor_aura"					"泉水魔抗光环"
 		"DOTA_Tooltip_ability_fountain_magical_armor_aura_Description"				"增加附近友军%bonus_magical_armor%%%魔法抗性。"
+
+
+		// 藏宝箱
+		"npc_treasure_chest"															"藏宝箱"
 		///////////////////////////////////////////////////
 		//
 		//			itembuilds
@@ -1254,6 +1258,54 @@
 		//
 		///////////////////////////////////////////////////
 // 					Awaken Abilities 觉醒技能
+
+		// 司夜刺客 钻地觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"					"<font color='#d000ff'>钻地 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"钻地状态下可以保持正常移动速度并自由移动，同时保留钻地的其他效果。"
+		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_SummaryDescription"	"钻地状态下可以正常移动，同时保留其他钻地效果。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"				"<font color='#d000ff'>钻地 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"钻地状态下可以保持正常移动速度并自由移动，同时保留钻地的其他效果。"
+
+		// 巫妖 寒灾轮回觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade"		"<font color='#d000ff'>寒灾轮回</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Description"		"提升连环霜冻的弹道速度与跳跃范围，并延长减速和霜缚的持续时间。<br><br>命中英雄或肉山时额外造成相当于智力%intelligence_damage_multiplier%倍的魔法伤害，并叠加1层寒灾印记，持续%mark_duration%秒，叠满%mark_max_stacks%层后自动引爆；也可对已叠加印记的敌人施放寒霜爆发提前引爆。引爆会在%detonation_radius%范围内造成相当于智力%nova_detonation_multiplier_per_stack%倍乘以当前印记层数的魔法伤害，并<font color='#2DD5E4'>眩晕</font>敌人%freeze_duration%秒。<br><br>若已学会寒冰尖柱，连环霜冻命中附近唯一的敌方英雄时会自动在其位置施放寒冰尖柱。"
+		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Note0"		"幻象不计入真实英雄；肉山按普通单位处理。"
+		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Note1"		"寒灾印记仅对真实英雄和肉山叠加；肉山会受到爆炸伤害，但不会被眩晕。"
+		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Note2"		"寒霜爆发可提前引爆寒灾印记，并按当前层数结算伤害。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade"		"<font color='#d000ff'>寒灾轮回</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_Description"		"提升连环霜冻的弹道速度与跳跃范围，并延长减速和霜缚的持续时间。<br><br>命中英雄或肉山时额外造成相当于智力<font color='#FFFFFF'><b>0.75</b></font>倍的魔法伤害，并叠加1层寒灾印记，持续<font color='#FFFFFF'><b>8</b></font>秒，叠满<font color='#FFFFFF'><b>3</b></font>层后自动引爆；也可对已叠加印记的敌人施放寒霜爆发提前引爆。引爆会在<font color='#FFFFFF'><b>350</b></font>范围内造成相当于智力<font color='#FFFFFF'><b>0.75</b></font>倍乘以当前印记层数的魔法伤害，并<font color='#2DD5E4'>眩晕</font>敌人<font color='#FFFFFF'><b>0.6</b></font>秒。<br><br>若已学会寒冰尖柱，连环霜冻命中附近唯一的敌方英雄时会自动在其位置施放寒冰尖柱。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark"		"寒灾印记"
+		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark_Description"		"达到3层时触发寒灾冰爆；巫妖也可使用寒霜爆发提前引爆。"
+
+		// 戴泽 薄葬觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade"					"<font color='#d000ff'>薄葬 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade_Description"	"对自己或队友施放薄葬后，目标在薄葬持续期间获得<font color='#FFCC66'>黑皇杖</font>效果。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>薄葬 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"对自己或队友施放薄葬后，目标在薄葬持续期间获得<font color='#FFCC66'>黑皇杖</font>效果。"
+
+		// 孽主 恶魔之势觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken"					"<font color='#d000ff'>恶魔之势 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_Description"		"孽主在拥有衰退光环的攻击力加成时，攻击具有分裂效果。分裂距离随当前加成攻击力提高。"
+		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_SummaryDescription"	"孽主在拥有衰退光环的攻击力加成时，攻击具有分裂效果。"
+		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_cleave_damage_pct"		"%分裂伤害："
+		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_cleave_distance_base"		"分裂距离（基础）："
+		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_cleave_distance_per_stack"	"分裂距离（每点叠加攻击力）："
+		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken"				"<font color='#d000ff'>恶魔之势 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken_Description"		"拥有衰退光环的攻击力加成时，攻击造成<font color='#FFFFFF'><b>100%%</b></font>分裂伤害，分裂距离随当前加成攻击力提高。当前分裂距离：<font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font>。"
+
+		// 斯拉克 精华侵蚀觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>精华侵蚀 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"斯拉克击杀敌人时，将能量转移偷取属性总量的%permanent_steal_pct%%%永久偷走该英雄的全属性。<br>敌方英雄的基础属性最低保留<font color='#FFFFFF'><b>1</b></font>点。"
+		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_SummaryDescription"	"斯拉克击杀敌人时，将能量转移偷取属性总量的一部分永久偷走该英雄的全属性。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_slark_permanent_essence_awaken"				"<font color='#d000ff'>精华侵蚀 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_slark_permanent_essence_awaken_Description"		"斯拉克击杀敌人时，将能量转移偷取属性总量的<font color='#FFFFFF'><b>10%%</b></font>永久偷走该英雄的全属性。<br>已永久获得 <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font> 点全属性。"
+
+		// 亚巴顿 畅快淋漓觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken"					"<font color='#d000ff'>畅快淋漓 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken_Description"		"亚巴顿附近%radius%范围内有单位阵亡时，他的所有冷却时间都会减少。非英雄单位阵亡减少%cooldown_reduction_creeps%秒，英雄阵亡减少%cooldown_reduction_heroes%秒。"
+		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken_SummaryDescription"		"附近单位阵亡时，减少所有技能和物品的当前冷却。"
+		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>畅快淋漓 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"附近 <font color='#FFFFFF'><b>900</b></font> 范围内有单位阵亡时，亚巴顿所有技能和物品的当前冷却都会减少。非英雄单位阵亡减少 <font color='#FFFFFF'><b>0.2</b></font> 秒，英雄阵亡减少 <font color='#FFFFFF'><b>3</b></font> 秒。"
 
 		// 兽王 野性之斧-觉醒
 		"DOTA_Tooltip_ability_beastmaster_wild_axes_awaken"							"<font color='#d000ff'>野性之斧 觉醒</font>"
@@ -3566,9 +3618,6 @@
 		"dota_hud_error_swift_glove_no_roshan"											"无法对肉山使用"
 		"dota_hud_error_swift_glove_no_building"										"无法对建筑使用"
 
-		// 藏宝箱
-		"npc_treasure_chest"															"藏宝箱"
-
 		// item_six_paths_reincarnation_gun 六道轮回枪
 		"DOTA_Tooltip_Ability_item_six_paths_reincarnation_gun"                                  "六道轮回枪"
 		"DOTA_Tooltip_Ability_item_six_paths_reincarnation_gun_Description"                      "<h1>主动：六道轮转</h1>持续%active_duration%秒。期间每次攻击都会独立随机转化为以下一种伤害类型：<br>- 物理伤害<br>- 魔法伤害<br>- 纯粹伤害<br>暴击伤害也会被转化。分裂箭及类似的额外攻击会分别随机伤害类型。转换伤害不受技能增强影响。\n<h1>被动：六道霰弹</h1>每次攻击时，对目标周围%attack_radius%范围内的其他敌人造成相当于本次攻击伤害%attack_percent%%%的额外伤害。额外伤害根据暴击后的攻击伤害计算，并在目标护甲、魔法抗性等减伤生效前确定数值。<br>每次触发随机造成以下一种伤害：<br>- 物理伤害<br>- 魔法伤害<br>- 纯粹伤害<br>六道霰弹造成的额外伤害不受技能增强影响。<br>多支分裂箭同时命中时，所有霰弹效果共享%internal_cooldown%秒全局内部冷却，单次攻击不会瞬间重复触发大量范围伤害。\n<h1>被动：法师克星</h1>攻击使目标造成的技能和物品伤害降低%mage_slayer_spell_damage_reduction%%%，持续%mage_slayer_duration%秒。效果期间，目标每秒受到：<br>- %mage_slayer_damage_per_type%点物理伤害<br>- %mage_slayer_damage_per_type%点魔法伤害<br>- %mage_slayer_damage_per_type%点纯粹伤害<br>持续伤害不受技能增强影响。"
@@ -3581,52 +3630,5 @@
 		"DOTA_Tooltip_modifier_item_six_paths_reincarnation_gun_active_Description"              "每次攻击独立随机转化为物理、魔法或纯粹伤害。转换伤害不受技能增强影响。"
 		"DOTA_Tooltip_modifier_item_six_paths_reincarnation_gun_debuff"                          "法师克星"
 		"DOTA_Tooltip_modifier_item_six_paths_reincarnation_gun_debuff_Description"              "造成的技能和物品伤害降低30%，并持续受到物理、魔法和纯粹伤害。持续伤害不受技能增强影响。"
-		// 巫妖 寒灾轮回
-		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade"		"<font color='#d000ff'>寒灾轮回</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Description"		"提升连环霜冻的弹道速度与跳跃范围，并延长减速和霜缚的持续时间。<br><br>命中英雄或肉山时额外造成相当于智力%intelligence_damage_multiplier%倍的魔法伤害，并叠加1层寒灾印记，持续%mark_duration%秒，叠满%mark_max_stacks%层后自动引爆；也可对已叠加印记的敌人施放寒霜爆发提前引爆。引爆会在%detonation_radius%范围内造成相当于智力%nova_detonation_multiplier_per_stack%倍乘以当前印记层数的魔法伤害，并<font color='#2DD5E4'>眩晕</font>敌人%freeze_duration%秒。<br><br>若已学会寒冰尖柱，连环霜冻命中附近唯一的敌方英雄时会自动在其位置施放寒冰尖柱。"
-		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Note0"		"幻象不计入真实英雄；肉山按普通单位处理。"
-		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Note1"		"寒灾印记仅对真实英雄和肉山叠加；肉山会受到爆炸伤害，但不会被眩晕。"
-		"DOTA_Tooltip_ability_special_bonus_unique_lich_upgrade_Note2"		"寒霜爆发可提前引爆寒灾印记，并按当前层数结算伤害。"
-		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade"		"<font color='#d000ff'>寒灾轮回</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_Description"		"提升连环霜冻的弹道速度与跳跃范围，并延长减速和霜缚的持续时间。<br><br>命中英雄或肉山时额外造成相当于智力<font color='#FFFFFF'><b>0.75</b></font>倍的魔法伤害，并叠加1层寒灾印记，持续<font color='#FFFFFF'><b>8</b></font>秒，叠满<font color='#FFFFFF'><b>3</b></font>层后自动引爆；也可对已叠加印记的敌人施放寒霜爆发提前引爆。引爆会在<font color='#FFFFFF'><b>350</b></font>范围内造成相当于智力<font color='#FFFFFF'><b>0.75</b></font>倍乘以当前印记层数的魔法伤害，并<font color='#2DD5E4'>眩晕</font>敌人<font color='#FFFFFF'><b>0.6</b></font>秒。<br><br>若已学会寒冰尖柱，连环霜冻命中附近唯一的敌方英雄时会自动在其位置施放寒冰尖柱。"
-		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark"		"寒灾印记"
-		"DOTA_Tooltip_modifier_special_bonus_unique_lich_upgrade_mark_Description"		"达到3层时触发寒灾冰爆；巫妖也可使用寒霜爆发提前引爆。"
-		// 戴泽 薄葬觉醒
-		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade"					"<font color='#d000ff'>薄葬 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_dazzle_upgrade_Description"	"对自己或队友施放薄葬后，目标在薄葬持续期间获得<font color='#FFCC66'>黑皇杖</font>效果。"
-		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>薄葬 觉醒</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"对自己或队友施放薄葬后，目标在薄葬持续期间获得<font color='#FFCC66'>黑皇杖</font>效果。"
-
-		// 孽主 恶魔之势觉醒
-		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken"					"<font color='#d000ff'>恶魔之势 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_Description"		"孽主在拥有衰退光环的攻击力加成时，攻击具有分裂效果。分裂距离随当前加成攻击力提高。"
-		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_SummaryDescription"	"孽主在拥有衰退光环的攻击力加成时，攻击具有分裂效果。"
-		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_cleave_damage_pct"		"%分裂伤害："
-		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_cleave_distance_base"		"分裂距离（基础）："
-		"DOTA_Tooltip_ability_special_bonus_unique_underlord_demons_reach_awaken_cleave_distance_per_stack"	"分裂距离（每点叠加攻击力）："
-		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken"				"<font color='#d000ff'>恶魔之势 觉醒</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_underlord_demons_reach_awaken_Description"		"拥有衰退光环的攻击力加成时，攻击造成<font color='#FFFFFF'><b>100%%</b></font>分裂伤害，分裂距离随当前加成攻击力提高。当前分裂距离：<font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font>。"
-
-		// 司夜刺客 钻地觉醒
-		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"					"<font color='#d000ff'>钻地 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"钻地状态下可以保持正常移动速度并自由移动，同时保留钻地的其他效果。"
-		"DOTA_Tooltip_ability_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_SummaryDescription"	"钻地状态下可以正常移动，同时保留其他钻地效果。"
-		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken"				"<font color='#d000ff'>钻地 觉醒</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken_Description"		"钻地状态下可以保持正常移动速度并自由移动，同时保留钻地的其他效果。"
-
-		// 斯拉克 精华侵蚀觉醒
-		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken"					"<font color='#d000ff'>精华侵蚀 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_Description"		"斯拉克击杀敌人时，将能量转移偷取属性总量的%permanent_steal_pct%%%永久偷走该英雄的全属性。<br>敌方英雄的基础属性最低保留<font color='#FFFFFF'><b>1</b></font>点。"
-		"DOTA_Tooltip_ability_special_bonus_unique_slark_permanent_essence_awaken_SummaryDescription"	"斯拉克击杀敌人时，将能量转移偷取属性总量的一部分永久偷走该英雄的全属性。"
-		"DOTA_Tooltip_modifier_special_bonus_unique_slark_permanent_essence_awaken"				"<font color='#d000ff'>精华侵蚀 觉醒</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_slark_permanent_essence_awaken_Description"		"斯拉克击杀敌人时，将能量转移偷取属性总量的<font color='#FFFFFF'><b>10%%</b></font>永久偷走该英雄的全属性。<br>已永久获得 <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%</b></font> 点全属性。"
-
-		// 亚巴顿 畅快淋漓觉醒
-		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken"					"<font color='#d000ff'>畅快淋漓 觉醒</font>"
-		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken_Description"		"亚巴顿附近%radius%范围内有单位阵亡时，他的所有冷却时间都会减少。非英雄单位阵亡减少%cooldown_reduction_creeps%秒，英雄阵亡减少%cooldown_reduction_heroes%秒。"
-		"DOTA_Tooltip_ability_special_bonus_unique_abaddon_quickening_awaken_SummaryDescription"		"附近单位阵亡时，减少所有技能和物品的当前冷却。"
-		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken"				"<font color='#d000ff'>畅快淋漓 觉醒</font>"
-		"DOTA_Tooltip_modifier_special_bonus_unique_abaddon_quickening_awaken_Description"		"附近 <font color='#FFFFFF'><b>900</b></font> 范围内有单位阵亡时，亚巴顿所有技能和物品的当前冷却都会减少。非英雄单位阵亡减少 <font color='#FFFFFF'><b>0.2</b></font> 秒，英雄阵亡减少 <font color='#FFFFFF'><b>3</b></font> 秒。"
-
 	}
 }

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -25,6 +25,17 @@
 		}
 	}
 
+	// 司夜刺客 钻地觉醒
+	"special_bonus_unique_nyx_assassin_mobile_burrow_awaken"
+	{
+		"BaseClass"					"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/special_bonus_unique_nyx_assassin_mobile_burrow_awaken"
+		"AbilityBehavior"			"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_SKIP_FOR_KEYBINDS"
+		"AbilityTextureName"		"nyx_assassin_burrow"
+		"IsOnCastBar"				"0"
+		"MaxLevel"					"1"
+	}
+
 	// 斯拉克 精华侵蚀觉醒
 	"special_bonus_unique_slark_permanent_essence_awaken"
 	{

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,11 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_nyx_assassin',
+    abilityName: 'special_bonus_unique_nyx_assassin_mobile_burrow_awaken',
+    freeTrial: true,
+  },
+  {
     heroName: 'npc_dota_hero_earthshaker',
     abilityName: 'special_bonus_unique_earthshaker_upgrade',
     freeTrial: true,

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -52,12 +52,10 @@ const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boo
   {
     heroName: 'npc_dota_hero_dazzle',
     abilityName: 'special_bonus_unique_dazzle_upgrade',
-    freeTrial: true,
   },
   {
     heroName: 'npc_dota_hero_elder_titan',
     abilityName: 'elder_titan_ancestral_spirit_awaken',
-    freeTrial: true,
   },
   {
     heroName: 'npc_dota_hero_techies',

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_nyx_assassin_mobile_burrow_awaken.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_nyx_assassin_mobile_burrow_awaken.ts
@@ -1,0 +1,49 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+
+const BURROW_MODIFIER = 'modifier_nyx_assassin_burrow';
+const BURROW_ICON = 'nyx_assassin_burrow';
+
+@registerAbility('special_bonus_unique_nyx_assassin_mobile_burrow_awaken')
+export class SpecialBonusUniqueNyxAssassinMobileBurrowAwaken extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken.name;
+  }
+}
+
+/** 司夜刺客 钻地觉醒：只解除钻地状态的定身，让原生 modifier 继续拥有其余效果。 */
+@registerModifier('abilities/ts_abilities/special_bonus_unique_nyx_assassin_mobile_burrow_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_nyx_assassin_mobile_burrow_awaken extends BaseModifier {
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return BURROW_ICON;
+  }
+
+  GetPriority(): modifierpriority {
+    return ModifierPriority.SUPER_ULTRA;
+  }
+
+  CheckState(): Partial<Record<ModifierState, boolean>> {
+    if (!this.GetParent().HasModifier(BURROW_MODIFIER)) return {};
+
+    return {
+      [ModifierState.ROOTED]: false,
+    };
+  }
+}

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,12 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 司夜刺客 觉醒
+  {
+    heroName: 'npc_dota_hero_nyx_assassin',
+    newAbility: 'special_bonus_unique_nyx_assassin_mobile_burrow_awaken',
+    newLevel: 1,
+  },
   // 撼地者 觉醒
   {
     heroName: 'npc_dota_hero_earthshaker',
@@ -263,6 +269,7 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  * 新觉醒发布时加入，下次发版由 awaken-ability skill 流程确认移出。
  */
 export const FREE_TRIAL_HEROES: string[] = [
+  'npc_dota_hero_nyx_assassin', // 司夜刺客
   'npc_dota_hero_earthshaker', // 撼地者
   'npc_dota_hero_abyssal_underlord', // 孽主
   'npc_dota_hero_slark', // 斯拉克

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -288,8 +288,6 @@ export const FREE_TRIAL_HEROES: string[] = [
   'npc_dota_hero_slark', // 斯拉克
   'npc_dota_hero_abaddon', // 亚巴顿
   'npc_dota_hero_skywrath_mage', // 天怒法师
-  'npc_dota_hero_dazzle', // 戴泽
-  'npc_dota_hero_elder_titan', // 上古巨神
 ];
 
 /** 可觉醒英雄名去重列表（随机抽选的英雄池真源） */


### PR DESCRIPTION
## Summary

- Add a Nyx Assassin Burrow awakening that allows normal movement while Burrowed.
- Keep the native Burrow modifier responsible for invisibility, attack restriction, damage reduction, regeneration, ability enhancements, particles, and sounds.
- Add the awakening configuration, profile card, ability KV, visible status modifier, and Simplified Chinese, English, and Russian localization.

## Checklist

- [x] User verified in Dota Tools that Nyx Assassin can move while Burrowed and all native Burrow effects remain active.
- [x] `npm run build:vscripts`
- [x] `npm run build:panorama`
- [x] `npx jest awaken-replacer --runInBand`
- [x] `npm run lint`
- [x] `git diff --check`
