### PR TITLE
Add Muerta Pierce the Veil awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1260,6 +1260,16 @@
 		///////////////////////////////////////////////////
 // 					Awaken Abilities 觉醒技能
 
+		// 琼英碧灵 越界觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken"					"<font color='#d000ff'>Pierce the Veil Awakened</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_Description"		"During Pierce the Veil, Muerta's attacks deal their normal damage to enemies protected by Black King Bar, and she gains Spell Lifesteal.<br>While Pierce the Veil is active, personally killing an enemy hero, or being near an enemy hero when they die, permanently grants one stack of Spell Amplification. Stacks have no limit and are not lost on death."
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_SummaryDescription"	"Pierce the Veil attacks damage enemies protected by Black King Bar normally and grant Spell Lifesteal. Hero kills and nearby hero deaths permanently accumulate Spell Amplification."
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_spell_lifesteal"		"%SPELL LIFESTEAL:"
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_spell_amp_per_kill"		"%SPELL AMPLIFICATION PER STACK:"
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_stack_collection_range"	"STACK COLLECTION RANGE:"
+		"DOTA_Tooltip_modifier_special_bonus_unique_muerta_pierce_the_veil_awaken"				"<font color='#d000ff'>Pierce the Veil Awakened</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_muerta_pierce_the_veil_awaken_Description"		"During Pierce the Veil, attacks deal their normal damage to enemies protected by Black King Bar and grant <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP2%%%</b></font> Spell Lifesteal.<br>Each stack permanently grants <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%%%</b></font> Spell Amplification. Stacks have no limit and are not lost on death. Current Spell Amplification: <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE%%%</b></font>."
+
 		// 撼地者 余震觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade"						"<font color='#d000ff'>Aftershock Awakened</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade_Description"		"Each unit hit by Aftershock creates a small Aftershock at its position, dealing separate magical damage to nearby enemies. Multiple small Aftershocks can hit the same unit, but each batch stuns a unit only once. Small Aftershocks cannot trigger this effect again."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -603,6 +603,16 @@
 		"DOTA_Tooltip_ability_ancient_apparition_freezing_aura_ad"				"ad rate： "
 		"DOTA_Tooltip_ability_ancient_apparition_freezing_aura_duration"		"Длительность： "
 
+		// 琼英碧灵 越界觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken"					"<font color='#d000ff'>Pierce the Veil · Пробуждение</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_Description"		"Во время действия Pierce the Veil атаки Muerta наносят обычный урон врагам под защитой Black King Bar, а сама Muerta получает магический вампиризм.<br>Пока Pierce the Veil действует, личное убийство вражеского героя или смерть вражеского героя рядом с Muerta навсегда дают один заряд усиления заклинаний. Число зарядов не ограничено, и они не теряются после смерти."
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_SummaryDescription"	"Pierce the Veil позволяет атакам нормально наносить урон врагам под защитой Black King Bar и даёт магический вампиризм. Убийства героев и смерти героев поблизости навсегда накапливают усиление заклинаний."
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_spell_lifesteal"		"%МАГИЧЕСКИЙ ВАМПИРИЗМ:"
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_spell_amp_per_kill"		"%УСИЛЕНИЕ ЗАКЛИНАНИЙ ЗА ЗАРЯД:"
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_stack_collection_range"	"РАДИУС ПОЛУЧЕНИЯ ЗАРЯДА:"
+		"DOTA_Tooltip_modifier_special_bonus_unique_muerta_pierce_the_veil_awaken"				"<font color='#d000ff'>Pierce the Veil · Пробуждение</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_muerta_pierce_the_veil_awaken_Description"		"Во время действия Pierce the Veil атаки наносят обычный урон врагам под защитой Black King Bar и дают <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP2%%%</b></font> магического вампиризма.<br>Каждый заряд навсегда даёт <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%%%</b></font> усиления заклинаний. Число зарядов не ограничено, и они не теряются после смерти. Текущее усиление заклинаний: <font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE%%%</b></font>."
+
 		// Skywrath Mage Staff of the Scion - Awakened
 		"DOTA_Tooltip_ability_special_bonus_unique_skywrath_upgrade"						"<font color='#d000ff'>Посох отпрыска · Пробуждение</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_skywrath_upgrade_Description"			"<font color='#d000ff'>Бонус пробуждения:</font> Skywrath Mage получает Staff of the Scion. Каждый раз, когда его способности наносят <font color='#05CAFF'>магический урон</font> вражескому герою, время восстановления всех его способностей сокращается на %cooldown_reduction% сек.<br><br><font color='#00CED1'>Автоприменение:</font> Если включено, Skywrath Mage автоматически применяет Ancient Seal, Concussive Shot, Mystic Flare и Arcane Bolt, когда вражеский герой находится в радиусе применения. Arcane Bolt также применяется по крипам, если героев поблизости нет."

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1255,6 +1255,16 @@
 		///////////////////////////////////////////////////
 // 					Awaken Abilities 觉醒技能
 
+		// 琼英碧灵 越界觉醒
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken"					"<font color='#d000ff'>越界 觉醒</font>"
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_Description"		"越界期间，琼英碧灵的攻击可以对开启黑皇杖的敌人正常造成伤害，并获得技能吸血。<br>在越界期间亲手击杀敌方英雄，或有敌方英雄在她身边阵亡时，永久获得一层技能增强。层数无上限，死亡不会损失。"
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_SummaryDescription"	"越界攻击可对开启黑皇杖的敌人正常造成伤害并提供技能吸血。英雄击杀与附近阵亡会永久累积技能增强。"
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_spell_lifesteal"		"%技能吸血："
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_spell_amp_per_kill"		"%每层技能增强："
+		"DOTA_Tooltip_ability_special_bonus_unique_muerta_pierce_the_veil_awaken_stack_collection_range"	"层数获取范围："
+		"DOTA_Tooltip_modifier_special_bonus_unique_muerta_pierce_the_veil_awaken"				"<font color='#d000ff'>越界 觉醒</font>"
+		"DOTA_Tooltip_modifier_special_bonus_unique_muerta_pierce_the_veil_awaken_Description"		"越界期间，攻击可以对开启黑皇杖的敌人正常造成伤害，并获得<font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP2%%%</b></font>技能吸血。<br>每层永久提供<font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_TOOLTIP%%%</b></font>技能增强。层数无上限且死亡不会损失。当前共获得<font color='#FFFFFF'><b>%dMODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE%%%</b></font>技能增强。"
+
 		// 撼地者 余震觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade"						"<font color='#d000ff'>余震 觉醒</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade_Description"		"余震命中的每个单位都会在原地触发一次小余震，对附近敌人造成独立的魔法伤害。多个小余震可同时命中同一目标，每批小余震只会将同一目标眩晕一次。小余震不会再次触发此效果。"

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -5,6 +5,25 @@
 	// 英雄专属强化/替换技能，通过抽奖池获得
 	//=================================================================================================================
 
+	// 琼英碧灵 越界觉醒
+	"special_bonus_unique_muerta_pierce_the_veil_awaken"
+	{
+		"BaseClass"					"ability_lua"
+		"ScriptFile"					"abilities/ts_abilities/special_bonus_unique_muerta_pierce_the_veil_awaken"
+		"AbilityBehavior"			"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_SKIP_FOR_KEYBINDS"
+		"SpellImmunityType"			"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityTextureName"		"muerta_pierce_the_veil"
+		"IsOnCastBar"				"0"
+		"MaxLevel"					"1"
+
+		"AbilityValues"
+		{
+			"spell_lifesteal"			"30"
+			"spell_amp_per_kill"			"2"
+			"stack_collection_range"		"925"
+		}
+	}
+
 	// 撼地者 余震觉醒
 	"special_bonus_unique_earthshaker_upgrade"
 	{

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,11 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_muerta',
+    abilityName: 'special_bonus_unique_muerta_pierce_the_veil_awaken',
+    freeTrial: true,
+  },
+  {
     heroName: 'npc_dota_hero_earthshaker',
     abilityName: 'special_bonus_unique_earthshaker_upgrade',
     freeTrial: true,
@@ -47,7 +52,6 @@ const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boo
   {
     heroName: 'npc_dota_hero_elder_titan',
     abilityName: 'elder_titan_ancestral_spirit_awaken',
-    freeTrial: true,
   },
   {
     heroName: 'npc_dota_hero_techies',

--- a/src/vscripts/abilities/ts_abilities/special_bonus_unique_muerta_pierce_the_veil_awaken.ts
+++ b/src/vscripts/abilities/ts_abilities/special_bonus_unique_muerta_pierce_the_veil_awaken.ts
@@ -1,0 +1,316 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+
+const PIERCE_THE_VEIL_BUFF = 'modifier_muerta_pierce_the_veil_buff';
+const PIERCE_THE_VEIL_ABILITY = 'muerta_pierce_the_veil';
+const DEBUFF_IMMUNITY_BUFF = 'modifier_black_king_bar_immune';
+const BEAST_SHIELD_ACTIVE_BUFF = 'modifier_item_beast_shield_active';
+const PIERCE_THE_VEIL_ICON = 'muerta_pierce_the_veil';
+const DEBUFF_IMMUNITY_RESISTANCE_SPECIALS: Record<string, string> = {
+  item_black_king_bar: 'spell_reduce',
+  item_black_king_bar_2: 'spell_reduce',
+  item_beast_shield: 'magic_resist',
+};
+const FULL_MAGIC_RESISTANCE_THRESHOLD = 0.999;
+let damageFilterRegistered = false;
+let replayingDebuffImmunityDamage = false;
+
+function getDebuffImmunityResistanceFromAbility(
+  ability: CDOTABaseAbility | undefined,
+): number | undefined {
+  if (!ability || ability.IsNull()) return undefined;
+
+  const specialName = DEBUFF_IMMUNITY_RESISTANCE_SPECIALS[ability.GetAbilityName()];
+  if (!specialName) return undefined;
+  return ability.GetSpecialValueFor(specialName);
+}
+
+function getActiveDebuffImmunityResistance(target: CDOTA_BaseNPC): number | undefined {
+  const immunityModifiers = target.FindAllModifiersByName(DEBUFF_IMMUNITY_BUFF);
+  if (immunityModifiers.length === 0) return undefined;
+
+  let effectiveResistance: number | undefined;
+  for (const modifier of immunityModifiers) {
+    const resistance = getDebuffImmunityResistanceFromAbility(modifier.GetAbility());
+    if (resistance !== undefined) {
+      effectiveResistance = Math.max(effectiveResistance ?? resistance, resistance);
+    }
+  }
+
+  // 同名减益免疫 modifier 刷新时不保证保留生效来源，因此用独立主动 modifier 补充解析。
+  const beastShieldActive = target.FindModifierByName(BEAST_SHIELD_ACTIVE_BUFF);
+  if (beastShieldActive && !beastShieldActive.IsNull()) {
+    const resistance = getDebuffImmunityResistanceFromAbility(beastShieldActive.GetAbility());
+    if (resistance !== undefined) {
+      effectiveResistance = Math.max(effectiveResistance ?? resistance, resistance);
+    }
+  }
+
+  return effectiveResistance;
+}
+
+function hasActiveMuertaAwaken(attacker: CDOTA_BaseNPC): boolean {
+  const modifier = attacker.FindModifierByName(
+    modifier_special_bonus_unique_muerta_pierce_the_veil_awaken.name,
+  );
+  if (!modifier || modifier.IsNull()) return false;
+
+  const ability = modifier.GetAbility();
+  return !!ability && !ability.IsNull() && ability.GetLevel() > 0 && ability.IsActivated();
+}
+
+function isPierceTheVeilMagicAttack(event: DamageFilterEvent): boolean {
+  if (event.damagetype_const !== DamageTypes.MAGICAL) return false;
+
+  const inflictorIndex = event.entindex_inflictor_const;
+  if (inflictorIndex === undefined || inflictorIndex <= 0) return true;
+
+  const inflictor = EntIndexToHScript(inflictorIndex) as CDOTABaseAbility | undefined;
+  return isPierceTheVeilInflictor(inflictor);
+}
+
+function isPierceTheVeilInflictor(inflictor: CDOTABaseAbility | undefined): boolean {
+  return (
+    !inflictor || (!inflictor.IsNull() && inflictor.GetAbilityName() === PIERCE_THE_VEIL_ABILITY)
+  );
+}
+
+function filterMuertaPierceTheVeilDamage(event: DamageFilterEvent): boolean {
+  if (replayingDebuffImmunityDamage) return true;
+
+  if (!isPierceTheVeilMagicAttack(event)) return true;
+
+  const attacker = EntIndexToHScript(event.entindex_attacker_const) as CDOTA_BaseNPC | undefined;
+  const victim = EntIndexToHScript(event.entindex_victim_const) as CDOTA_BaseNPC | undefined;
+  if (
+    !attacker ||
+    attacker.IsNull() ||
+    attacker.IsIllusion() ||
+    !victim ||
+    victim.IsNull() ||
+    victim.GetTeamNumber() === attacker.GetTeamNumber() ||
+    !hasActiveMuertaAwaken(attacker) ||
+    !attacker.HasModifier(PIERCE_THE_VEIL_BUFF)
+  ) {
+    return true;
+  }
+
+  const immunityResistance = getActiveDebuffImmunityResistance(victim);
+  if (immunityResistance === undefined || immunityResistance <= 0) return true;
+
+  // 满魔抗无法通过除法反算，因此交由攻击落地事件重放；其余只抵消识别到的免疫来源。
+  const resistance = Math.min(immunityResistance / 100, 1);
+  if (resistance >= FULL_MAGIC_RESISTANCE_THRESHOLD) return false;
+
+  event.damage /= Math.max(1 - resistance, 0.001);
+  return true;
+}
+
+function registerMuertaDamageFilter(): void {
+  if (damageFilterRegistered) return;
+
+  const gameMode = GameRules.GetGameModeEntity();
+  gameMode.SetDamageFilter((event) => filterMuertaPierceTheVeilDamage(event), gameMode);
+  damageFilterRegistered = true;
+}
+
+@registerAbility('special_bonus_unique_muerta_pierce_the_veil_awaken')
+export class SpecialBonusUniqueMuertaPierceTheVeilAwaken extends BaseAbility {
+  GetIntrinsicModifierName(): string {
+    return modifier_special_bonus_unique_muerta_pierce_the_veil_awaken.name;
+  }
+}
+
+/** 琼英碧灵“越界”觉醒控制器。 */
+@registerModifier('abilities/ts_abilities/special_bonus_unique_muerta_pierce_the_veil_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_special_bonus_unique_muerta_pierce_the_veil_awaken extends BaseModifier {
+  private spellLifesteal = 30;
+  private spellAmpPerKill = 2;
+  private stackCollectionRange = 925;
+
+  OnCreated(): void {
+    this.refreshValues();
+    if (IsServer()) registerMuertaDamageFilter();
+  }
+
+  OnRefresh(): void {
+    this.refreshValues();
+  }
+
+  IsHidden(): boolean {
+    return false;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  IsBuff(): boolean {
+    return true;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  AllowIllusionDuplicate(): boolean {
+    return false;
+  }
+
+  GetTexture(): string {
+    return PIERCE_THE_VEIL_ICON;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [
+      ModifierFunction.ON_DEATH,
+      ModifierFunction.ON_TAKEDAMAGE,
+      ModifierFunction.ON_ATTACK_LANDED,
+      ModifierFunction.SPELL_AMPLIFY_PERCENTAGE,
+      ModifierFunction.TOOLTIP,
+      ModifierFunction.TOOLTIP2,
+    ];
+  }
+
+  GetModifierSpellAmplify_Percentage(): number {
+    return this.GetStackCount() * this.spellAmpPerKill;
+  }
+
+  OnAttackLanded(event: ModifierAttackEvent): void {
+    if (!IsServer() || !this.isFullyImmuneDebuffAttack(event)) return;
+
+    const parent = this.GetParent();
+    const ability = this.GetAbility();
+    const target = event.target;
+    if (!ability || ability.IsNull()) return;
+
+    const attackDamage = Math.max(event.original_damage, 0);
+    if (attackDamage <= 0) return;
+
+    // 满魔抗路径需绕过魔抗并预乘正常抗性，避免重复触发攻击或攻击方增幅。
+    const normalMagicMultiplier = 1 - this.getMagicResistanceWithoutBkb(target);
+    const replacementDamage = attackDamage * Math.max(normalMagicMultiplier, 0);
+    if (replacementDamage <= 0) return;
+
+    replayingDebuffImmunityDamage = true;
+    try {
+      ApplyDamage({
+        victim: target,
+        attacker: parent,
+        damage: replacementDamage,
+        damage_type: DamageTypes.MAGICAL,
+        damage_flags:
+          DamageFlag.IGNORES_MAGIC_ARMOR +
+          DamageFlag.NO_SPELL_AMPLIFICATION +
+          DamageFlag.MAGIC_AUTO_ATTACK +
+          DamageFlag.NO_REFLECTION,
+        ability,
+      });
+    } finally {
+      replayingDebuffImmunityDamage = false;
+    }
+  }
+
+  OnTakeDamage(event: ModifierInstanceEvent): void {
+    if (!IsServer() || !this.isAwakenActive()) return;
+
+    const parent = this.GetParent();
+    if (parent.IsIllusion() || !parent.HasModifier(PIERCE_THE_VEIL_BUFF)) return;
+
+    TsSpellLifeSteal(event, this.spellLifesteal, parent, true);
+  }
+
+  OnDeath(event: ModifierInstanceEvent): void {
+    if (!IsServer() || !this.isAwakenActive()) return;
+
+    const parent = this.GetParent();
+    const victim = event.unit;
+    if (
+      parent.IsIllusion() ||
+      !parent.HasModifier(PIERCE_THE_VEIL_BUFF) ||
+      !victim ||
+      victim.IsNull() ||
+      !victim.IsRealHero() ||
+      victim.IsIllusion() ||
+      victim.IsReincarnating() ||
+      victim.GetTeamNumber() === parent.GetTeamNumber()
+    ) {
+      return;
+    }
+
+    const personallyKilled = event.attacker === parent;
+    const diedNearby =
+      victim.GetAbsOrigin().__sub(parent.GetAbsOrigin()).Length2D() <= this.stackCollectionRange;
+    if (!personallyKilled && !diedNearby) return;
+
+    this.SetStackCount(this.GetStackCount() + 1);
+  }
+
+  OnTooltip(): number {
+    return this.spellAmpPerKill;
+  }
+
+  OnTooltip2(): number {
+    return this.spellLifesteal;
+  }
+
+  private refreshValues(): void {
+    const ability = this.GetAbility();
+    if (!ability || ability.IsNull()) return;
+
+    this.spellLifesteal = ability.GetSpecialValueFor('spell_lifesteal');
+    this.spellAmpPerKill = ability.GetSpecialValueFor('spell_amp_per_kill');
+    this.stackCollectionRange = ability.GetSpecialValueFor('stack_collection_range');
+  }
+
+  private isAwakenActive(): boolean {
+    const ability = this.GetAbility();
+    return !!ability && !ability.IsNull() && ability.GetLevel() > 0 && ability.IsActivated();
+  }
+
+  private isFullyImmuneDebuffAttack(event: ModifierAttackEvent): boolean {
+    if (!this.isAwakenActive() || event.attacker !== this.GetParent()) return false;
+
+    const parent = this.GetParent();
+    const target = event.target;
+    if (!target || target.IsNull()) return false;
+
+    const immunityResistance = getActiveDebuffImmunityResistance(target);
+    return (
+      !parent.IsIllusion() &&
+      parent.HasModifier(PIERCE_THE_VEIL_BUFF) &&
+      isPierceTheVeilInflictor(event.inflictor) &&
+      target.GetTeamNumber() !== parent.GetTeamNumber() &&
+      immunityResistance !== undefined &&
+      immunityResistance / 100 >= FULL_MAGIC_RESISTANCE_THRESHOLD
+    );
+  }
+
+  private getMagicResistanceWithoutBkb(target: CDOTA_BaseNPC): number {
+    const totalResistance = this.normalizeResistance(
+      target.Script_GetMagicalArmorValue(this.GetAbility() ?? {}),
+    );
+
+    // 穿透来源能排除满免疫时直接采用；饱和值不可逆，只能回退到基础魔抗。
+    if (totalResistance < FULL_MAGIC_RESISTANCE_THRESHOLD) {
+      return this.clampResistance(totalResistance);
+    }
+    return this.clampResistance(target.GetBaseMagicalResistanceValue() / 100);
+  }
+
+  private normalizeResistance(value: number): number {
+    return Math.abs(value) > 1.5 ? value / 100 : value;
+  }
+
+  private clampResistance(value: number): number {
+    return Math.max(-1, Math.min(value, FULL_MAGIC_RESISTANCE_THRESHOLD));
+  }
+}
+
+// DamageFilter 是全局入口。模块重载时也重新注册，不能只依赖已有 intrinsic modifier 的 OnCreated。
+if (IsServer()) registerMuertaDamageFilter();

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,12 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 琼英碧灵 觉醒
+  {
+    heroName: 'npc_dota_hero_muerta',
+    newAbility: 'special_bonus_unique_muerta_pierce_the_veil_awaken',
+    newLevel: 1,
+  },
   // 撼地者 觉醒
   {
     heroName: 'npc_dota_hero_earthshaker',
@@ -263,13 +269,13 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  * 新觉醒发布时加入，下次发版由 awaken-ability skill 流程确认移出。
  */
 export const FREE_TRIAL_HEROES: string[] = [
+  'npc_dota_hero_muerta', // 琼英碧灵
   'npc_dota_hero_earthshaker', // 撼地者
   'npc_dota_hero_abyssal_underlord', // 孽主
   'npc_dota_hero_slark', // 斯拉克
   'npc_dota_hero_abaddon', // 亚巴顿
   'npc_dota_hero_skywrath_mage', // 天怒法师
   'npc_dota_hero_dazzle', // 戴泽
-  'npc_dota_hero_elder_titan', // 上古巨神
 ];
 
 /** 可觉醒英雄名去重列表（随机抽选的英雄池真源） */

--- a/src/vscripts/utils/lifesteal.ts
+++ b/src/vscripts/utils/lifesteal.ts
@@ -18,9 +18,14 @@ function canLifestealFromTarget(target: CDOTA_BaseNPC, isAttack: boolean): boole
 /** 判断伤害是否可以触发吸血效果
  * @param damageEvent 伤害事件
  * @param isAttack 是否是攻击
+ * @param allowMagicAutoAttack 是否允许带 MAGIC_AUTO_ATTACK 标记的魔法普攻触发技能吸血
  * @returns 是否可以触发吸血效果
  */
-function canLifestealFromDamage(damageEvent: ModifierInstanceEvent, isAttack: boolean): boolean {
+function canLifestealFromDamage(
+  damageEvent: ModifierInstanceEvent,
+  isAttack: boolean,
+  allowMagicAutoAttack = false,
+): boolean {
   // 反弹的伤害不触发
   if ((damageEvent.damage_flags & DamageFlag.REFLECTION) === DamageFlag.REFLECTION) return false;
   // 移除生命值而不是造成直接伤害的技能不触发
@@ -32,10 +37,13 @@ function canLifestealFromDamage(damageEvent: ModifierInstanceEvent, isAttack: bo
   )
     return false;
   if (!isAttack) {
-    // 技能吸血时，NO_SPELL_AMPLIFICATION
+    // 明确允许时，魔法普攻即使不吃技能增强也仍按技能吸血结算。
+    const isMagicAutoAttack =
+      (damageEvent.damage_flags & DamageFlag.MAGIC_AUTO_ATTACK) === DamageFlag.MAGIC_AUTO_ATTACK;
     if (
       (damageEvent.damage_flags & DamageFlag.NO_SPELL_AMPLIFICATION) ===
-      DamageFlag.NO_SPELL_AMPLIFICATION
+        DamageFlag.NO_SPELL_AMPLIFICATION &&
+      !(allowMagicAutoAttack && isMagicAutoAttack)
     )
       return false;
   }
@@ -116,6 +124,7 @@ function handleSpellLifesteal(
   event: ModifierInstanceEvent,
   lifeStealPercent: number,
   owner: CDOTA_BaseNPC,
+  allowMagicAutoAttack = false,
 ): void {
   // 判定attacker是否是owner
   const attacker = event.attacker;
@@ -133,7 +142,7 @@ function handleSpellLifesteal(
   const target = event.unit;
   if (target.GetTeam() === owner.GetTeam()) return;
 
-  if (!canLifestealFromDamage(event, false)) return;
+  if (!canLifestealFromDamage(event, false, allowMagicAutoAttack)) return;
 
   if (!canLifestealFromTarget(target, false)) return;
 
@@ -152,6 +161,7 @@ declare global {
     event: ModifierInstanceEvent,
     lifeStealPercent: number,
     owner: CDOTA_BaseNPC,
+    allowMagicAutoAttack?: boolean,
   ): void;
 }
 
@@ -168,8 +178,9 @@ _G.TsSpellLifeSteal = (
   event: ModifierInstanceEvent,
   lifeStealPercent: number,
   owner: CDOTA_BaseNPC,
+  allowMagicAutoAttack = false,
 ) => {
-  handleSpellLifesteal(event, lifeStealPercent, owner);
+  handleSpellLifesteal(event, lifeStealPercent, owner, allowMagicAutoAttack);
 };
 
 export {};


### PR DESCRIPTION
## Issue

No linked issue.

## Checklist

- [x] I have tested the changes works well.

## Summary

- Add a Muerta Pierce the Veil awakening while preserving the native ultimate identity and icon.
- Restore permanent Spell Amplification stacks from hero kills or nearby hero deaths and grant Spell Lifesteal during Pierce the Veil.
- Let Pierce the Veil attacks deal normal damage through Black King Bar, Upgraded Black King Bar, and Beast Shield debuff immunity.
- Add the awakening to the profile UI and three-language localization, rotate Muerta into the free trial, and rotate Elder Titan out.

## Testing

- `npm run build:vscripts`
- `npm run build:panorama`
- `npm run lint`
- `npx jest src/vscripts/modules/awaken/awaken-replacer.test.ts src/vscripts/modules/awaken/awaken-random.test.ts --runInBand`
- User-tested in Dota Tools, including normal Pierce the Veil damage against Black King Bar, Upgraded Black King Bar, and Beast Shield.