### PR TITLE
Add Spirit Breaker mass Charge awakening

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1260,6 +1260,14 @@
 		///////////////////////////////////////////////////
 // 					Awaken Abilities 觉醒技能
 
+		// 裂魂人 暗影冲刺觉醒
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken"					"<font color='#d000ff'>Mass Shadow Charge Awakened</font>"
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_Description"		"Charge of Darkness becomes a point-targeted area ability. Spirit Breaker charges the enemy nearest the center, while a temporary clone that continuously matches his current charge speed charges every other enemy. Spirit Breaker can use abilities and items normally while charging. Move, attack, or stop orders cancel only his own charge while the clones continue. All Greater Bash damage, stun, and knockback are applied by Spirit Breaker. When a knocked-back enemy hits another enemy, both take 100% Greater Bash damage and stun and may continue colliding with new enemies. Each target pair can collide only once per cast."
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_SummaryDescription"	"Target an area; Spirit Breaker and temporary clones charge every enemy within it."
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_echo_radius"			"%SELECTION RADIUS:"
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_movement_speed"			"%SHADOW CHARGE SPEED BONUS:"
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_collision_damage_pct"		"%COLLISION BASH DAMAGE:"
+
 		// 撼地者 余震觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade"						"<font color='#d000ff'>Aftershock Awakened</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade_Description"		"Each unit hit by Aftershock creates a small Aftershock at its position, dealing separate magical damage to nearby enemies. Multiple small Aftershocks can hit the same unit, but each batch stuns a unit only once. Small Aftershocks cannot trigger this effect again."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -668,6 +668,14 @@
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade"				"<font color='#d000ff'>Пробуждение Shallow Grave</font>"
 		"DOTA_Tooltip_modifier_special_bonus_unique_dazzle_upgrade_Description"	"После применения Shallow Grave на себя или союзника цель получает эффект <font color='#FFCC66'>Black King Bar</font> на время действия Shallow Grave."
 
+		// 裂魂人 暗影冲刺觉醒
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken"					"<font color='#d000ff'>Массовый теневой рывок: пробуждение</font>"
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_Description"		"Charge of Darkness становится направленной на область способностью. Spirit Breaker устремляется к ближайшему к центру врагу, а к каждому другому врагу — временная копия, постоянно повторяющая его текущую скорость рывка. Во время рывка Spirit Breaker может использовать способности и предметы. Приказ движения, атаки или остановки отменяет только его рывок, а копии продолжают движение. Весь урон, оглушение и отбрасывание Greater Bash исходят от Spirit Breaker. При столкновении отброшенного врага с другим оба снова получают 100% эффекта Greater Bash. Каждая пара целей сталкивается только один раз за применение."
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_SummaryDescription"	"Выберите область: Spirit Breaker и временные двойники атакуют всех врагов в ней."
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_echo_radius"			"%РАДИУС ВЫБОРА:"
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_movement_speed"			"%БОНУС СКОРОСТИ ТЕНИ:"
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_collision_damage_pct"		"%УРОН GREATER BASH ПРИ СТОЛКНОВЕНИИ:"
+
 		// 撼地者 余震觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade"						"<font color='#d000ff'>Афтершок: пробуждение</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade_Description"		"Каждая цель, задетая Афтершоком, создаёт малый Афтершок в своей точке, наносящий отдельный магический урон врагам поблизости. Несколько малых Афтершоков могут поразить одну цель, но в каждой серии оглушают её только один раз. Малые Афтершоки не создают новые малые Афтершоки."

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -1255,6 +1255,14 @@
 		///////////////////////////////////////////////////
 // 					Awaken Abilities 觉醒技能
 
+		// 裂魂人 暗影冲刺觉醒
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken"					"<font color='#d000ff'>群魂冲锋 觉醒</font>"
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_Description"		"暗影冲刺变为点地范围技能。选定区域中最靠近圆心的敌人由裂魂人本体冲锋，其余每个敌人由同步本体实时冲锋速度的临时分身冲锋。本体在冲锋期间可正常使用技能和装备。移动，攻击或停止指令只取消本体冲锋，分身仍会继续。所有重击伤害，眩晕和击退均由本体施加。被击退的敌人碰到其他敌人时，双方再次受到100%巨力重击伤害和眩晕，并可继续撞向其他敌人。同一对目标每次施法只触发一次碰撞。"
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_SummaryDescription"	"点选一个范围，本体与临时分身同时冲锋范围内的所有敌人。"
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_echo_radius"			"%选择范围："
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_movement_speed"			"%虚影冲锋速度加成："
+		"DOTA_Tooltip_ability_spirit_breaker_charge_of_darkness_awaken_collision_damage_pct"		"%碰撞重击伤害："
+
 		// 撼地者 余震觉醒
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade"						"<font color='#d000ff'>余震 觉醒</font>"
 		"DOTA_Tooltip_ability_special_bonus_unique_earthshaker_upgrade_Description"		"余震命中的每个单位都会在原地触发一次小余震，对附近敌人造成独立的魔法伤害。多个小余震可同时命中同一目标，每批小余震只会将同一目标眩晕一次。小余震不会再次触发此效果。"

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -5,6 +5,49 @@
 	// 英雄专属强化/替换技能，通过抽奖池获得
 	//=================================================================================================================
 
+	// 裂魂人 暗影冲刺觉醒
+	"spirit_breaker_charge_of_darkness_awaken"
+	{
+		"BaseClass"					"ability_lua"
+		"ScriptFile"				"abilities/ts_abilities/spirit_breaker_charge_of_darkness_awaken"
+		"AbilityType"				"DOTA_ABILITY_TYPE_BASIC"
+		"AbilityBehavior"			"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"		"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"		"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"	"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"		"DAMAGE_TYPE_MAGICAL"
+		"SpellImmunityType"			"SPELL_IMMUNITY_ENEMIES_YES"
+		"SpellDispellableType"		"SPELL_DISPELLABLE_NO"
+		"AbilityTextureName"			"spirit_breaker_charge_of_darkness"
+		"AbilityCastAnimation"		"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCastRange"			"99999"
+		"AbilityCastPoint"			"0.3"
+		"AbilityCooldown"			"22 19 16 13 10"
+		"AbilityManaCost"			"90 100 110 120 130"
+		"MaxLevel"					"5"
+
+		"precache"
+		{
+			"particle"		"particles/units/heroes/hero_spirit_breaker/spirit_breaker_charge.vpcf"
+			"particle"		"particles/units/heroes/hero_spirit_breaker/spirit_breaker_greater_bash.vpcf"
+		}
+
+		"AbilityValues"
+		{
+			"echo_radius"
+			{
+				"value"						"300"
+				"affected_by_aoe_increase"	"1"
+			}
+			"movement_speed"				"275 325 375 425 475"
+			"collision_damage_pct"
+			{
+				"value"					"100"
+				"display_type"			"kMagicalDamagePercentage"
+			}
+		}
+	}
+
 	// 撼地者 余震觉醒
 	"special_bonus_unique_earthshaker_upgrade"
 	{

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -3868,9 +3868,10 @@
 		"MaxLevel"						"5"
 		"AbilityValues"
 		{
+				"chance_pct"			"20"	// 17
 				"damage"
 				{
-					"value"	"25 30 35 40 45"	// 25 30 35 40
+					"value"	"30 40 50 65 80"	// 25 30 35 40
 				}
 				"duration"				"0.9 1.1 1.3 1.5 1.7"	// 0.9 1.1 1.3 1.5
 				"knockback_distance"	"143 152 158 162 165"	// 143 152 158 162

--- a/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
+++ b/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
@@ -86,6 +86,7 @@ EXCLUDED_ABILITIES_ALLBUTTER = {
     ["void_spirit_dissimilate"] = true,            -- 虚无之灵 异化
     ["puck_illusory_orb"] = true,                  -- 帕克 幻象法球
     ["spirit_breaker_charge_of_darkness"] = true,  -- 裂魂人 暗影冲刺
+    ["spirit_breaker_charge_of_darkness_awaken"] = true, -- 裂魂人 暗影冲刺 觉醒
     ["rattletrap_hookshot"] = true,                -- 发条技师 发射钩爪
     ["huskar_life_break"] = true,                  -- 哈斯卡 牺牲
     ["pangolier_swashbuckle"] = true,              -- 石鳞剑士 虚张声势

--- a/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
+++ b/src/panorama/react/hud_main/pages/profile/tabs/AwakenTab.tsx
@@ -15,6 +15,11 @@ import { AwakenUnlockConfirmDialog } from './AwakenUnlockConfirmDialog';
 // freeTrial 与 vscripts awaken-config 的 FREE_TRIAL_HEROES 对应，同样需手动同步
 const AWAKEN_ABILITIES: { heroName: string; abilityName: string; freeTrial?: boolean }[] = [
   {
+    heroName: 'npc_dota_hero_spirit_breaker',
+    abilityName: 'spirit_breaker_charge_of_darkness_awaken',
+    freeTrial: true,
+  },
+  {
     heroName: 'npc_dota_hero_earthshaker',
     abilityName: 'special_bonus_unique_earthshaker_upgrade',
     freeTrial: true,

--- a/src/vscripts/abilities/ts_abilities/spirit_breaker_charge_of_darkness_awaken.ts
+++ b/src/vscripts/abilities/ts_abilities/spirit_breaker_charge_of_darkness_awaken.ts
@@ -1,0 +1,707 @@
+import {
+  BaseAbility,
+  BaseModifier,
+  registerAbility,
+  registerModifier,
+} from '../../utils/dota_ts_adapter';
+
+const SPIRIT_BREAKER_HERO = 'npc_dota_hero_spirit_breaker';
+const GREATER_BASH = 'spirit_breaker_greater_bash';
+const CHARGE_PARTICLE = 'particles/units/heroes/hero_spirit_breaker/spirit_breaker_charge.vpcf';
+const GREATER_BASH_PARTICLE =
+  'particles/units/heroes/hero_spirit_breaker/spirit_breaker_greater_bash.vpcf';
+
+const THINK_INTERVAL = 0.03;
+const COLLISION_SCAN_INTERVAL = 0.06;
+const MAX_CAST_LIFETIME = 30;
+const IMPACT_DISTANCE = 72;
+const BODY_STOP_DISTANCE = 96;
+const MOTION_START_GRACE = 0.15;
+const DEFAULT_HERO_HITBOX = 185;
+const DEFAULT_CREEP_HITBOX = 100;
+
+interface ChargeRunner {
+  targetIndex: EntityIndex;
+  unitIndex: EntityIndex;
+  isCaster: boolean;
+  chargeParticle: ParticleID;
+}
+
+interface KnockbackMotion {
+  targetIndex: EntityIndex;
+  lastPosition: Vector;
+  fallbackDirection: Vector;
+  createdAt: number;
+  sawMovement: boolean;
+}
+
+interface ActiveKnockbackMotion {
+  target: CDOTA_BaseNPC;
+  position: Vector;
+  direction: Vector;
+}
+
+interface ChargeCastState {
+  id: number;
+  caster: CDOTA_BaseNPC_Hero;
+  chargeSpeed: number;
+  runners: Map<EntityIndex, ChargeRunner>;
+  motions: Map<EntityIndex, KnockbackMotion>;
+  collidedPairs: Set<string>;
+  heroCollisionRadius: number;
+  creepCollisionRadius: number;
+  nextCollisionScanAt: number;
+  expiresAt: number;
+}
+
+/** 群魂冲锋：本体与同步其状态的虚影分别冲锋选定范围内的敌人。 */
+@registerAbility('spirit_breaker_charge_of_darkness_awaken')
+export class SpiritBreakerChargeOfDarknessAwaken extends BaseAbility {
+  private nextCastId = 1;
+  private activeCasts = new Map<number, ChargeCastState>();
+
+  GetIntrinsicModifierName(): string {
+    return modifier_spirit_breaker_charge_of_darkness_awaken.name;
+  }
+
+  GetAOERadius(): number {
+    return this.GetSpecialValueFor('echo_radius');
+  }
+
+  OnSpellStart(): void {
+    if (!IsServer()) return;
+
+    const caster = this.GetCaster() as CDOTA_BaseNPC_Hero;
+    if (!this.IsValidCaster(caster)) return;
+
+    const center = this.GetCursorPosition();
+    const radius = this.GetSpecialValueFor('echo_radius');
+    const targets = FindUnitsInRadius(
+      caster.GetTeamNumber(),
+      center,
+      undefined,
+      radius,
+      UnitTargetTeam.ENEMY,
+      UnitTargetType.HERO | UnitTargetType.BASIC,
+      UnitTargetFlags.FOW_VISIBLE | UnitTargetFlags.NO_INVIS | UnitTargetFlags.MAGIC_IMMUNE_ENEMIES,
+      FindOrder.CLOSEST,
+      false,
+    ).filter((target) => !target.IsNull() && target.IsAlive());
+
+    if (targets.length <= 0) return;
+
+    const now = GameRules.GetGameTime();
+    const castId = this.nextCastId;
+    this.nextCastId += 1;
+    const chargeSpeed = this.GetCurrentChargeSpeed(caster);
+    const heroCollisionRadius = this.GetConfiguredCollisionRadius(true);
+    const creepCollisionRadius = this.GetConfiguredCollisionRadius(false);
+    const state: ChargeCastState = {
+      id: castId,
+      caster,
+      chargeSpeed,
+      runners: new Map<EntityIndex, ChargeRunner>(),
+      motions: new Map<EntityIndex, KnockbackMotion>(),
+      collidedPairs: new Set<string>(),
+      heroCollisionRadius,
+      creepCollisionRadius,
+      nextCollisionScanAt: now,
+      expiresAt: now + MAX_CAST_LIFETIME,
+    };
+    // FindOrder.CLOSEST 以施法圆心排序：最接近圆心者由本体冲锋，其余目标由分身冲锋。
+    const primaryTarget = targets[0];
+    const bodyRunner = this.CreateBodyRunner(caster, primaryTarget);
+    state.runners.set(bodyRunner.targetIndex, bodyRunner);
+
+    for (let index = 1; index < targets.length; index += 1) {
+      const runner = this.CreateShadowRunner(caster, targets[index]);
+      if (!runner) continue;
+      state.runners.set(runner.targetIndex, runner);
+    }
+
+    this.activeCasts.set(castId, state);
+    Timers.CreateTimer(0, () => this.TickCast(castId));
+  }
+
+  private IsValidCaster(caster: CDOTA_BaseNPC_Hero): boolean {
+    return (
+      !caster.IsNull() &&
+      caster.IsRealHero() &&
+      !caster.IsIllusion() &&
+      caster.GetUnitName() === SPIRIT_BREAKER_HERO
+    );
+  }
+
+  private CreateBodyRunner(caster: CDOTA_BaseNPC_Hero, target: CDOTA_BaseNPC): ChargeRunner {
+    caster.AddNewModifier(
+      caster,
+      this,
+      modifier_spirit_breaker_charge_of_darkness_awaken_body.name,
+      { duration: MAX_CAST_LIFETIME },
+    );
+    caster.StartGesture(GameActivity.DOTA_RUN);
+    return this.CreateRunner(caster, target, true);
+  }
+
+  private CreateShadowRunner(
+    caster: CDOTA_BaseNPC_Hero,
+    target: CDOTA_BaseNPC,
+  ): ChargeRunner | undefined {
+    const shadows = CreateIllusions(
+      caster,
+      caster,
+      {
+        outgoing_damage: 0,
+        incoming_damage: 0,
+      },
+      1,
+      0,
+      false,
+      false,
+    );
+    const shadow = shadows[0];
+    if (!shadow || shadow.IsNull()) return undefined;
+
+    const casterOrigin = caster.GetAbsOrigin();
+    shadow.SetAbsOrigin(Vector(casterOrigin.x, casterOrigin.y, casterOrigin.z));
+    this.StripShadowGameplayInstances(shadow);
+    shadow.SetDayTimeVisionRange(0);
+    shadow.SetNightTimeVisionRange(0);
+    shadow.AddNewModifier(
+      caster,
+      this,
+      modifier_spirit_breaker_charge_of_darkness_awaken_shadow.name,
+      { duration: MAX_CAST_LIFETIME },
+    );
+    shadow.StartGesture(GameActivity.DOTA_RUN);
+    return this.CreateRunner(shadow, target, false);
+  }
+
+  private StripShadowGameplayInstances(shadow: CDOTA_BaseNPC_Hero): void {
+    for (let index = 23; index >= 0; index -= 1) {
+      const ability = shadow.GetAbilityByIndex(index);
+      if (ability && !ability.IsNull()) shadow.RemoveAbility(ability.GetAbilityName());
+    }
+
+    const itemSlots = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 23, 24, 26];
+    for (const slot of itemSlots) {
+      const item = shadow.GetItemInSlot(slot);
+      if (!item || item.IsNull()) continue;
+      shadow.RemoveItem(item);
+      UTIL_Remove(item);
+    }
+  }
+
+  private CreateRunner(
+    unit: CDOTA_BaseNPC,
+    target: CDOTA_BaseNPC,
+    isCaster: boolean,
+  ): ChargeRunner {
+    const direction = this.DirectionFromTo(unit.GetAbsOrigin(), target.GetAbsOrigin());
+    unit.SetForwardVector(direction);
+    const particle = ParticleManager.CreateParticle(
+      CHARGE_PARTICLE,
+      ParticleAttachment.ABSORIGIN_FOLLOW,
+      unit,
+    );
+    return {
+      targetIndex: target.GetEntityIndex(),
+      unitIndex: unit.GetEntityIndex(),
+      isCaster,
+      chargeParticle: particle,
+    };
+  }
+
+  private TickCast(castId: number): number | undefined {
+    const state = this.activeCasts.get(castId);
+    if (!state) return undefined;
+
+    if (this.IsNull() || state.caster.IsNull() || GameRules.GetGameTime() >= state.expiresAt) {
+      this.DestroyCast(state);
+      return undefined;
+    }
+
+    this.TickRunners(state);
+    this.TickKnockbackMotions(state);
+    if (state.runners.size <= 0 && state.motions.size <= 0) {
+      this.DestroyCast(state);
+      return undefined;
+    }
+    return THINK_INTERVAL;
+  }
+
+  private TickRunners(state: ChargeCastState): void {
+    const completed: EntityIndex[] = [];
+    const currentChargeSpeed = this.GetCurrentChargeSpeed(state.caster);
+    state.chargeSpeed = currentChargeSpeed;
+
+    for (const [targetIndex, runner] of state.runners) {
+      const target = EntIndexToHScript(targetIndex) as CDOTA_BaseNPC | undefined;
+      const runnerUnit = EntIndexToHScript(runner.unitIndex) as CDOTA_BaseNPC | undefined;
+      if (
+        !target ||
+        target.IsNull() ||
+        !target.IsAlive() ||
+        !runnerUnit ||
+        runnerUnit.IsNull() ||
+        !runnerUnit.IsAlive()
+      ) {
+        this.DestroyRunner(runner);
+        completed.push(targetIndex);
+        continue;
+      }
+
+      const runnerPosition = runnerUnit.GetAbsOrigin();
+      const targetPosition = target.GetAbsOrigin();
+      const direction = this.DirectionFromTo(runnerPosition, targetPosition);
+      const distance = this.Distance2D(runnerPosition, targetPosition);
+      const step = currentChargeSpeed * THINK_INTERVAL;
+      runnerUnit.SetForwardVector(direction);
+
+      if (distance <= Math.max(IMPACT_DISTANCE, step)) {
+        if (runner.isCaster) {
+          const stopDistance = Math.min(BODY_STOP_DISTANCE, distance);
+          runnerUnit.SetAbsOrigin(
+            Vector(
+              targetPosition.x - direction.x * stopDistance,
+              targetPosition.y - direction.y * stopDistance,
+              targetPosition.z,
+            ),
+          );
+        }
+        this.DestroyRunner(runner);
+        completed.push(targetIndex);
+        this.ResolveRunnerImpact(state, target, direction);
+        continue;
+      }
+
+      runnerUnit.SetAbsOrigin(
+        Vector(
+          runnerPosition.x + direction.x * step,
+          runnerPosition.y + direction.y * step,
+          targetPosition.z,
+        ),
+      );
+    }
+
+    for (const targetIndex of completed) state.runners.delete(targetIndex);
+  }
+
+  private DestroyRunner(runner: ChargeRunner): void {
+    ParticleManager.DestroyParticle(runner.chargeParticle, false);
+    ParticleManager.ReleaseParticleIndex(runner.chargeParticle);
+
+    const runnerUnit = EntIndexToHScript(runner.unitIndex) as CDOTA_BaseNPC | undefined;
+    if (!runnerUnit || runnerUnit.IsNull()) return;
+
+    if (runner.isCaster) {
+      runnerUnit.FadeGesture(GameActivity.DOTA_RUN);
+      runnerUnit.RemoveModifierByName(modifier_spirit_breaker_charge_of_darkness_awaken_body.name);
+      FindClearSpaceForUnit(runnerUnit, runnerUnit.GetAbsOrigin(), true);
+    } else {
+      runnerUnit.FadeGesture(GameActivity.DOTA_RUN);
+      UTIL_Remove(runnerUnit);
+    }
+  }
+
+  CancelBodyCharge(caster: CDOTA_BaseNPC): void {
+    if (!IsServer()) return;
+
+    const casterIndex = caster.GetEntityIndex();
+    for (const state of this.activeCasts.values()) {
+      for (const [targetIndex, runner] of state.runners) {
+        if (!runner.isCaster || runner.unitIndex !== casterIndex) continue;
+
+        this.DestroyRunner(runner);
+        state.runners.delete(targetIndex);
+        break;
+      }
+    }
+  }
+
+  private ResolveRunnerImpact(
+    state: ChargeCastState,
+    target: CDOTA_BaseNPC,
+    direction: Vector,
+  ): void {
+    if (!this.ApplyGreaterBash(state, target, true, direction, 100)) return;
+
+    this.AddKnockbackMotion(state, target, direction);
+  }
+
+  private AddKnockbackMotion(
+    state: ChargeCastState,
+    target: CDOTA_BaseNPC,
+    fallbackDirection: Vector,
+  ): void {
+    const targetIndex = target.GetEntityIndex();
+    const existing = state.motions.get(targetIndex);
+    if (existing) {
+      existing.fallbackDirection = fallbackDirection;
+      return;
+    }
+
+    const origin = target.GetAbsOrigin();
+    state.motions.set(targetIndex, {
+      targetIndex,
+      lastPosition: Vector(origin.x, origin.y, origin.z),
+      fallbackDirection,
+      createdAt: GameRules.GetGameTime(),
+      sawMovement: false,
+    });
+  }
+
+  private TickKnockbackMotions(state: ChargeCastState): void {
+    const finished: EntityIndex[] = [];
+    const activeMotions: ActiveKnockbackMotion[] = [];
+    const now = GameRules.GetGameTime();
+
+    for (const [targetIndex, motion] of state.motions) {
+      const movingTarget = EntIndexToHScript(targetIndex) as CDOTA_BaseNPC | undefined;
+      if (!movingTarget || movingTarget.IsNull() || !movingTarget.IsAlive()) {
+        finished.push(targetIndex);
+        continue;
+      }
+
+      const currentPosition = movingTarget.GetAbsOrigin();
+      const isMoving =
+        movingTarget.HasModifier('modifier_knockback') ||
+        movingTarget.IsCurrentlyHorizontalMotionControlled();
+      if (!isMoving) {
+        motion.lastPosition = Vector(currentPosition.x, currentPosition.y, currentPosition.z);
+        if (motion.sawMovement || now - motion.createdAt >= MOTION_START_GRACE) {
+          finished.push(targetIndex);
+        }
+        continue;
+      }
+
+      motion.sawMovement = true;
+      const movement = Vector(
+        currentPosition.x - motion.lastPosition.x,
+        currentPosition.y - motion.lastPosition.y,
+        0,
+      );
+      const direction = movement.Length2D() > 0 ? movement.Normalized() : motion.fallbackDirection;
+      motion.lastPosition = Vector(currentPosition.x, currentPosition.y, currentPosition.z);
+      activeMotions.push({ target: movingTarget, position: currentPosition, direction });
+    }
+
+    for (const targetIndex of finished) state.motions.delete(targetIndex);
+    if (activeMotions.length <= 0 || now < state.nextCollisionScanAt) return;
+
+    state.nextCollisionScanAt = now + COLLISION_SCAN_INTERVAL;
+    const nearby = this.FindCollisionCandidates(state, activeMotions);
+    for (const motion of activeMotions) {
+      this.ResolveNearbyCollisions(state, motion.target, motion.position, motion.direction, nearby);
+    }
+  }
+
+  private FindCollisionCandidates(
+    state: ChargeCastState,
+    motions: ActiveKnockbackMotion[],
+  ): CDOTA_BaseNPC[] {
+    let minX = motions[0].position.x;
+    let maxX = minX;
+    let minY = motions[0].position.y;
+    let maxY = minY;
+    for (let index = 1; index < motions.length; index += 1) {
+      const position = motions[index].position;
+      minX = Math.min(minX, position.x);
+      maxX = Math.max(maxX, position.x);
+      minY = Math.min(minY, position.y);
+      maxY = Math.max(maxY, position.y);
+    }
+
+    const center = Vector((minX + maxX) / 2, (minY + maxY) / 2, motions[0].position.z);
+    const maxHitbox = Math.max(state.heroCollisionRadius, state.creepCollisionRadius);
+    let radius = maxHitbox;
+    for (const motion of motions) {
+      radius = Math.max(radius, this.Distance2D(center, motion.position) + maxHitbox);
+    }
+
+    return FindUnitsInRadius(
+      state.caster.GetTeamNumber(),
+      center,
+      undefined,
+      radius,
+      UnitTargetTeam.ENEMY,
+      UnitTargetType.HERO | UnitTargetType.BASIC,
+      UnitTargetFlags.MAGIC_IMMUNE_ENEMIES,
+      FindOrder.ANY,
+      false,
+    );
+  }
+
+  private ResolveNearbyCollisions(
+    state: ChargeCastState,
+    movingTarget: CDOTA_BaseNPC,
+    currentPosition: Vector,
+    direction: Vector,
+    nearby: CDOTA_BaseNPC[],
+  ): void {
+    for (const other of nearby) {
+      if (other === movingTarget || other.IsNull() || !other.IsAlive()) continue;
+
+      const movingIndex = movingTarget.GetEntityIndex();
+      const otherIndex = other.GetEntityIndex();
+      const pairKey = this.PairKey(movingIndex, otherIndex);
+      if (state.collidedPairs.has(pairKey)) continue;
+      const collisionRadius = other.IsHero()
+        ? state.heroCollisionRadius
+        : state.creepCollisionRadius;
+      if (this.Distance2D(currentPosition, other.GetAbsOrigin()) > collisionRadius) {
+        continue;
+      }
+
+      state.collidedPairs.add(pairKey);
+      const collisionDamagePct = this.GetSpecialValueFor('collision_damage_pct');
+      this.ApplyGreaterBash(state, movingTarget, false, direction, collisionDamagePct);
+      if (this.ApplyGreaterBash(state, other, true, direction, collisionDamagePct)) {
+        this.AddKnockbackMotion(state, other, direction);
+      }
+    }
+  }
+
+  private GetConfiguredCollisionRadius(hero: boolean): number {
+    const greaterBash = this.GetGreaterBash();
+    const fallback = hero ? DEFAULT_HERO_HITBOX : DEFAULT_CREEP_HITBOX;
+    if (!greaterBash) return fallback;
+
+    const configured = greaterBash.GetSpecialValueFor(
+      hero ? 'cascading_bashes_hero_hitbox' : 'cascading_bashes_creep_hitbox',
+    );
+    return configured > 0 ? configured : fallback;
+  }
+
+  private PairKey(first: EntityIndex, second: EntityIndex): string {
+    return first < second ? `${first}:${second}` : `${second}:${first}`;
+  }
+
+  private ApplyGreaterBash(
+    state: ChargeCastState,
+    target: CDOTA_BaseNPC,
+    applyKnockback: boolean,
+    direction: Vector,
+    effectPct: number,
+  ): boolean {
+    if (target.IsNull() || !target.IsAlive()) return false;
+
+    const greaterBash = this.GetGreaterBash();
+    if (!greaterBash) return false;
+
+    const bashDamagePct = greaterBash.GetSpecialValueFor('damage');
+    const damage = (state.chargeSpeed * bashDamagePct * effectPct) / 10000;
+    ApplyDamage({
+      victim: target,
+      attacker: state.caster,
+      damage,
+      damage_type: greaterBash.GetAbilityDamageType(),
+      ability: greaterBash,
+    });
+
+    const stunDuration =
+      greaterBash.GetSpecialValueFor('duration') * (1 - target.GetStatusResistance());
+    if (stunDuration > 0) {
+      target.AddNewModifier(state.caster, greaterBash, 'modifier_stunned', {
+        duration: stunDuration,
+      });
+    }
+
+    const particle = ParticleManager.CreateParticle(
+      GREATER_BASH_PARTICLE,
+      ParticleAttachment.ABSORIGIN_FOLLOW,
+      target,
+    );
+    ParticleManager.ReleaseParticleIndex(particle);
+    target.EmitSound('Hero_Spirit_Breaker.GreaterBash');
+
+    if (!applyKnockback || target.IsCurrentlyHorizontalMotionControlled()) return true;
+
+    const targetOrigin = target.GetAbsOrigin();
+    const center = Vector(
+      targetOrigin.x - direction.x * 100,
+      targetOrigin.y - direction.y * 100,
+      targetOrigin.z,
+    );
+    const knockbackDuration = greaterBash.GetSpecialValueFor('knockback_duration');
+    target.AddNewModifier(state.caster, greaterBash, 'modifier_knockback', {
+      should_stun: 0,
+      knockback_duration: knockbackDuration,
+      duration: knockbackDuration,
+      knockback_distance: greaterBash.GetSpecialValueFor('knockback_distance'),
+      knockback_height: greaterBash.GetSpecialValueFor('knockback_height'),
+      center_x: center.x,
+      center_y: center.y,
+      center_z: center.z,
+    });
+    return true;
+  }
+
+  private GetGreaterBash(): CDOTABaseAbility | undefined {
+    const greaterBash = this.GetCaster().FindAbilityByName(GREATER_BASH);
+    return greaterBash && !greaterBash.IsNull() && greaterBash.GetLevel() > 0
+      ? greaterBash
+      : undefined;
+  }
+
+  private GetCurrentChargeSpeed(caster: CDOTA_BaseNPC_Hero): number {
+    return Math.max(caster.GetIdealSpeedNoSlows() + this.GetSpecialValueFor('movement_speed'), 1);
+  }
+
+  private DirectionFromTo(from: Vector, to: Vector): Vector {
+    const delta = Vector(to.x - from.x, to.y - from.y, 0);
+    return delta.Length2D() > 0 ? delta.Normalized() : Vector(1, 0, 0);
+  }
+
+  private Distance2D(first: Vector, second: Vector): number {
+    const x = second.x - first.x;
+    const y = second.y - first.y;
+    return Math.sqrt(x * x + y * y);
+  }
+
+  private DestroyCast(state: ChargeCastState): void {
+    for (const runner of state.runners.values()) this.DestroyRunner(runner);
+    state.runners.clear();
+    state.motions.clear();
+    this.activeCasts.delete(state.id);
+  }
+}
+
+@registerModifier('abilities/ts_abilities/spirit_breaker_charge_of_darkness_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_spirit_breaker_charge_of_darkness_awaken extends BaseModifier {
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  RemoveOnDeath(): boolean {
+    return false;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [
+      ModifierFunction.OVERRIDE_ABILITY_SPECIAL,
+      ModifierFunction.OVERRIDE_ABILITY_SPECIAL_VALUE,
+    ];
+  }
+
+  GetModifierOverrideAbilitySpecial(event: ModifierOverrideAbilitySpecialEvent): 0 | 1 {
+    if (!IsServer()) return 0;
+    return event.ability.GetAbilityName() === GREATER_BASH &&
+      event.ability_special_value === 'cascading_bashes_damage_multiplier'
+      ? 1
+      : 0;
+  }
+
+  GetModifierOverrideAbilitySpecialValue(event: ModifierOverrideAbilitySpecialEvent): number {
+    if (
+      event.ability.GetAbilityName() !== GREATER_BASH ||
+      event.ability_special_value !== 'cascading_bashes_damage_multiplier'
+    ) {
+      return event.ability.GetLevelSpecialValueNoOverride(
+        event.ability_special_value,
+        event.ability_special_level,
+      );
+    }
+    return this.GetAbility()?.GetSpecialValueFor('collision_damage_pct') ?? 100;
+  }
+}
+
+@registerModifier('abilities/ts_abilities/spirit_breaker_charge_of_darkness_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_spirit_breaker_charge_of_darkness_awaken_body extends BaseModifier {
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [ModifierFunction.ON_ORDER];
+  }
+
+  OnOrder(event: ModifierUnitEvent): void {
+    if (!IsServer() || event.unit !== this.GetParent()) return;
+
+    switch (event.order_type) {
+      case UnitOrder.MOVE_TO_POSITION:
+      case UnitOrder.MOVE_TO_TARGET:
+      case UnitOrder.MOVE_TO_DIRECTION:
+      case UnitOrder.MOVE_RELATIVE:
+      case UnitOrder.ATTACK_MOVE:
+      case UnitOrder.ATTACK_TARGET:
+      case UnitOrder.HOLD_POSITION:
+      case UnitOrder.STOP:
+      case UnitOrder.PATROL:
+      case UnitOrder.PICKUP_ITEM:
+      case UnitOrder.PICKUP_RUNE:
+        break;
+      default:
+        return;
+    }
+
+    const ability = this.GetAbility() as SpiritBreakerChargeOfDarknessAwaken | undefined;
+    ability?.CancelBodyCharge(event.unit);
+  }
+
+  CheckState(): Partial<Record<ModifierState, boolean>> {
+    return {
+      [ModifierState.NO_UNIT_COLLISION]: true,
+      [ModifierState.FLYING_FOR_PATHING_PURPOSES_ONLY]: true,
+    };
+  }
+}
+
+@registerModifier('abilities/ts_abilities/spirit_breaker_charge_of_darkness_awaken')
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class modifier_spirit_breaker_charge_of_darkness_awaken_shadow extends BaseModifier {
+  IsHidden(): boolean {
+    return true;
+  }
+
+  IsPurgable(): boolean {
+    return false;
+  }
+
+  CheckState(): Partial<Record<ModifierState, boolean>> {
+    return {
+      [ModifierState.INVULNERABLE]: true,
+      [ModifierState.UNSELECTABLE]: true,
+      [ModifierState.NO_HEALTH_BAR]: true,
+      [ModifierState.NO_UNIT_COLLISION]: true,
+      [ModifierState.COMMAND_RESTRICTED]: true,
+      [ModifierState.DISARMED]: true,
+      [ModifierState.SILENCED]: true,
+      [ModifierState.MUTED]: true,
+      [ModifierState.NOT_ON_MINIMAP]: true,
+      [ModifierState.NOT_ON_MINIMAP_FOR_ENEMIES]: true,
+      [ModifierState.FLYING_FOR_PATHING_PURPOSES_ONLY]: true,
+    };
+  }
+
+  DeclareFunctions(): ModifierFunction[] {
+    return [
+      ModifierFunction.ABSOLUTE_NO_DAMAGE_MAGICAL,
+      ModifierFunction.ABSOLUTE_NO_DAMAGE_PHYSICAL,
+      ModifierFunction.ABSOLUTE_NO_DAMAGE_PURE,
+    ];
+  }
+
+  GetAbsoluteNoDamageMagical(): 0 | 1 {
+    return 1;
+  }
+
+  GetAbsoluteNoDamagePhysical(): 0 | 1 {
+    return 1;
+  }
+
+  GetAbsoluteNoDamagePure(): 0 | 1 {
+    return 1;
+  }
+}

--- a/src/vscripts/modules/awaken/awaken-config.ts
+++ b/src/vscripts/modules/awaken/awaken-config.ts
@@ -18,6 +18,13 @@ export interface AbilityReplacement {
 }
 
 export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
+  // 裂魂人 觉醒
+  {
+    heroName: 'npc_dota_hero_spirit_breaker',
+    targetAbility: 'spirit_breaker_charge_of_darkness',
+    newAbility: 'spirit_breaker_charge_of_darkness_awaken',
+    newLevel: 0,
+  },
   // 撼地者 觉醒
   {
     heroName: 'npc_dota_hero_earthshaker',
@@ -263,6 +270,7 @@ export const ABILITY_REPLACEMENTS: AbilityReplacement[] = [
  * 新觉醒发布时加入，下次发版由 awaken-ability skill 流程确认移出。
  */
 export const FREE_TRIAL_HEROES: string[] = [
+  'npc_dota_hero_spirit_breaker', // 裂魂人
   'npc_dota_hero_earthshaker', // 撼地者
   'npc_dota_hero_abyssal_underlord', // 孽主
   'npc_dota_hero_slark', // 斯拉克


### PR DESCRIPTION
## Issue

No linked issue.

## Summary

- Add a point-targeted area awakening for Spirit Breaker's Charge of Darkness, with the real hero charging one target and temporary visual clones charging every other target.
- Keep clone speed synchronized with the real hero while allowing abilities and items during the charge; movement, attack, and stop orders cancel only the real hero's charge.
- Apply Greater Bash on every charge impact and chain full-damage Bash effects when knocked enemies collide, with per-cast pair deduplication and batched collision scans.
- Increase Greater Bash proc chance to 20% and movement-speed damage scaling to 30/40/50/65/80%.

## Checklist

- [x] User verified the area targeting, visible clones, synchronized speed, charge controls, and collision behavior in Dota Tools.
- [x] `npm run build:vscripts`, `npm run build:panorama`, and `npm run lint` pass on the latest `origin/develop`.
- [ ] Recheck the final Butterfly exclusion name in Dota Tools.
