### PR TITLE
Fix Green Butterfly self-cast and Viper blacklist typos

### DIFF
--- a/.claude/skills/bot-ability-usage/SKILL.md
+++ b/.claude/skills/bot-ability-usage/SKILL.md
@@ -165,7 +165,7 @@ export const SPECS: AbilitySpec[] = [
 - **不要在 spec 里手写 `range.lte`**：dispatcher 会用技能 KV 中的 `AbilityCastRange + GetCastRangeBonus` 自动填入。手写反而会覆盖默认值，导致超出施法距离也尝试施放。例外：spec 想要更小的搜索半径才显式覆盖。
 - **不要为 spec 加新的字段类型**：spec 字段只能是 `ability-spec.ts` 中已定义的；新需求先扩展 `cast-condition.ts` 与 dispatcher，再消费。
 - **不要往英雄文件 `UseAbilityXxx` 加新技能**：新技能一律走 spec。遇到已有手写规则时，将有效条件迁入 spec，并在确认行为等价后删除对应英雄覆盖，不能把英雄专属施法保留为长期第二执行层。
-- **toggle / autoCast 类技能**：通过 `condition.action.toggleOn / autoCastOn` 表达。这条路径目前只在老 `ActionAbility.doAction` 中实现，dispatcher 暂未串接 —— 遇到这类技能告知用户「该开关类目前需要走老链路或扩展 dispatcher」，不要自行硬塞。
+- **toggle / autoCast 类技能**：通过 `condition.action.toggleOn / toggleOff / autoCastOn` 表达。dispatcher 命中 action 条件后只切换到目标状态，不走正常施法派发；已经处于目标状态时返回 false，继续尝试后续规则。
 - **TSTL 对象 spread 陷阱**：见 CLAUDE.md「常见陷阱」末条；spec 文件本身用不到 spread，但若需要扩展 dispatcher / cast-condition，**绝对**不能写 `{ ...maybeUndefined }`。
 - **KV 数值字段术语**：Dota 2 现行 KV 中数值字段块名为 `AbilityValues`（旧版 `AbilitySpecial` 已废弃）。在注释、字段命名、文档中统一使用 `AbilityValue` 表述；引擎 API `GetSpecialValueFor(key)` 仍可调用，但变量名和注释应写 `abilityValue` / `rangeFromAbilityValue`，不用 `specialValue`。
 - **spec 文件头部注释不要复述 condition 里的字段/数值**：注释只写意图（"范围内有敌人即用"），不要带上 `range.lte` 等字段的具体值（"900 范围内"）。同一个数值出现两处，后续只改其中一处就会自相矛盾，且无法判断哪个是真相源。此规则同样适用于 ItemSpec（`ai/item/specs/`）文件。发现注释数值与代码不一致时，**不要默认注释代表设计意图、代码是笔误就去改代码**——应先查 git blame / 实机测试确认谁是真相源，再决定改代码还是改注释。

--- a/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
+++ b/game/scripts/vscripts/abilities/ability_blacklist_butterfly.lua
@@ -98,7 +98,7 @@ EXCLUDED_ABILITIES_ALLBUTTER = {
     ["queenofpain_blink"] = true,                  -- 痛苦女王 闪烁
     ["ember_spirit_activate_fire_remnant"] = true, -- 灰烬之灵 激活火焰残影
     ["earth_spirit_rolling_boulder"] = true,       -- 大地之灵 巨石翻滚
-    ["viper_nosedive"] = true,                     -- 冥界亚龙 俯冲
+    ["viper_nose_dive"] = true,                    -- 冥界亚龙 极恶俯冲
     ["winter_wyvern_cold_embrace"] = true,
     ["snapfire_firesnap_cookie"] = true,
     ["phantom_assassin_phantom_strike"] = true,
@@ -202,7 +202,7 @@ EXCLUDED_ABILITIES_ALLBUTTER = {
     -- 原因：这些技能有特殊的游戏机制，不适合随机触发
     -- ========================================
     ["ogre_magi_ignite"] = true,                -- 食人魔魔法师 引燃
-    ["viper_viper_strike"] = true,              -- 冥界亚龙 毒性攻击（大招）
+    ["viper_viper_strike"] = true,              -- 冥界亚龙 蝮蛇突袭
     ["death_prophet_carrion_swarm"] = true,     -- 死亡先知 腐尸群
     ["terrorblade_reflection"] = true,          -- 恐怖利刃 倒影
     ["goku_kaioken"] = true,                    -- 悟空 界王拳
@@ -212,7 +212,6 @@ EXCLUDED_ABILITIES_ALLBUTTER = {
     ["furion_teleportation"] = true,            -- 先知 传送
     ["dawnbreaker_solar_guardian"] = true,      -- 破晓辰星 太阳守护
     ["obsidian_destroyer_essence_flux"] = true, -- 黑鸟 精华变迁
-    ["viper_nethertoxin"] = true,               -- 冥界亚龙 剧毒攻击
     ["naga_siren_song_of_the_siren"] = true,    -- 娜迦海妖 海妖之歌
     ["tinker_keen_teleport"] = true,            -- 修补匠 传送
     ["lich_death_charge"] = true,               -- 巫妖 献身

--- a/game/scripts/vscripts/abilities/ability_trigger_on_spell_reflect.lua
+++ b/game/scripts/vscripts/abilities/ability_trigger_on_spell_reflect.lua
@@ -272,10 +272,6 @@ function modifier_trigger_on_spell_reflect:TriggerRandomAbility(original_attacke
                 cast_target = enemies[1]
                 target_position = cast_target:GetAbsOrigin()
                 --print("[SpellReflect] Found enemy:", cast_target:GetUnitName())
-            else
-                cast_target = parent
-                target_position = parent:GetAbsOrigin()
-                --print("[SpellReflect] No enemies found, casting on self position")
             end
         end
     else

--- a/game/scripts/vscripts/abilities/ogre_magi_multicast_lua.lua
+++ b/game/scripts/vscripts/abilities/ogre_magi_multicast_lua.lua
@@ -88,7 +88,6 @@ no_support_abilitys = {
 	enchantress_impetus = 1,      -- 魅惑魔女 推进
 	silencer_glaives_of_wisdom = 1, -- 沉默术士 智慧之刃
 	viper_poison_attack = 1,      -- 冥界亚龙 毒性攻击
-	viper_nethertoxin = 1,        -- 冥界亚龙 幽冥剧毒
 	troll_warlord_switch_stance = 1, -- 巨魔战将 切换姿态
 
 	-- 位移与形态切换
@@ -109,7 +108,7 @@ no_support_abilitys = {
 	zuus_heavenly_jump = 1,              -- 宙斯 神圣一跳
 	snapfire_firesnap_cookie = 1,        -- 电炎绝手 龙炎饼干
 	weaver_time_lapse = 1,               -- 编织者 时光倒流
-	viper_nosedive = 1,                  -- 冥界亚龙 俯冲
+	viper_nose_dive = 1,                 -- 冥界亚龙 极恶俯冲
 	tinker_keen_teleport = 1,            -- 修补匠 传送
 	abyssal_underlord_dark_rift = 1,     -- 孽主 黑暗之门
 	keeper_of_the_light_recall = 1,      -- 光之守卫 召回
@@ -134,7 +133,7 @@ no_support_abilitys = {
 	axe_culling_blade = 1,
 	techies_suicide = 1,                 -- 炸弹人 自爆
 	ogre_magi_ignite = 1,
-	viper_viper_strike = 1,
+	viper_viper_strike = 1,                           -- 冥界亚龙 蝮蛇突袭
 	death_prophet_carrion_swarm = 1,
 	obsidian_destroyer_arcane_orb = 1,
 	terrorblade_reflection = 1,                        -- 倒影


### PR DESCRIPTION
## Issue

No linked issue.

## Changes

- Prevent Green Butterfly from self-casting enemy-targeted abilities when no valid enemy exists.
- Correct Viper's Nosedive blacklist key in Butterfly Effect and Multicast.
- Allow Nethertoxin to be retriggered while keeping Viper Strike excluded.

## Checklist

- [ ] I have tested the changes works well.
- [ ] Verify Green Butterfly skips enemy-targeted casts when no valid enemy exists in Dota Tools.
- [ ] Verify Nethertoxin can retrigger and Nosedive remains excluded in Dota Tools.

## Release Note

```
[b]游戏性更新 v5.53a[/b]

- 修正蝴蝶效应的若干问题。
```

```
[b]Gameplay update v5.53a[/b]

- Fixed several Butterfly Effect issues.
```
