### PR TITLE
Add generic fallback for unregistered bot abilities

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -448,6 +448,7 @@ grep "DOTA_Tooltip_ability_dragon_knight_dragon_blood" docs/reference/<version>/
 
 - 复用一个字符串事件，而不是新增自定义事件
 - 避免过度还原、过度分析
+- 布尔方法名用常见且直接的动词，避免抽象词和重复所属类或文件已经表达的语境，例如 `CanCast` 优于 `IsEligible` 或 `CanUseGenericFallback`
 - 多处需要相同逻辑（尤其是要求口径一致的计算）时提取共享函数，不要各自维护一份；调用方各自实现一遍容易在后续修改时只改一处、悄悄产生口径分歧
 
 ## 注释规约

--- a/game/scripts/npc/npc_abilities_custom_awaken.txt
+++ b/game/scripts/npc/npc_abilities_custom_awaken.txt
@@ -183,7 +183,7 @@
 			"min_throw_duration"
 			{
 				"value"					"0.4"
-				"special_bonus_unique_beastmaster_awaken"	"=0.3"
+				"special_bonus_unique_beastmaster_awaken"	"=0.4"
 			}
 			"max_throw_duration"
 			{

--- a/src/vscripts/abilities/ts_abilities/beastmaster_wild_axes_awaken.ts
+++ b/src/vscripts/abilities/ts_abilities/beastmaster_wild_axes_awaken.ts
@@ -62,8 +62,12 @@ export class BeastmasterWildAxesAwaken extends AutoCastAbility {
     const native = this.ensureNativeAbility();
     if (native === undefined) return;
 
-    native.SetActivated(true);
     this.GetCaster().SetCursorPosition(location);
     native.OnSpellStart();
+
+    const throwDuration = this.GetSpecialValueFor('min_throw_duration');
+    if (this.GetCooldownTimeRemaining() < throwDuration) {
+      this.StartCooldown(throwDuration);
+    }
   }
 }

--- a/src/vscripts/ai/ability/ability-dispatcher.ts
+++ b/src/vscripts/ai/ability/ability-dispatcher.ts
@@ -3,6 +3,7 @@ import { TryCastBySpec } from '../action/target-dispatch';
 import type { BotBaseAIModifier } from '../hero/bot-base';
 import { AbilityRegistry } from './ability-registry';
 import { TargetSide } from './ability-spec';
+import { GenericAbilityFallback } from './generic-ability-fallback';
 
 /**
  * 统一的 bot 技能 AI 入口。
@@ -49,18 +50,21 @@ export class AbilityDispatcher {
       }
 
       const specs = AbilityRegistry.get(ability.GetName());
-      if (!specs) {
+      if (specs) {
+        for (const spec of specs) {
+          const condition =
+            spec.targetSide === TargetSide.EnemyCreep
+              ? DeepMerge(CREEP_DEFAULT_CONDITION, spec.condition)
+              : spec.condition;
+          if (TryCastBySpec(ai, ability, spec.targetSide, condition)) {
+            return true;
+          }
+        }
         continue;
       }
 
-      for (const spec of specs) {
-        const condition =
-          spec.targetSide === TargetSide.EnemyCreep
-            ? DeepMerge(CREEP_DEFAULT_CONDITION, spec.condition)
-            : spec.condition;
-        if (TryCastBySpec(ai, ability, spec.targetSide, condition)) {
-          return true;
-        }
+      if (GenericAbilityFallback.TryCast(ai, ability)) {
+        return true;
       }
     }
 

--- a/src/vscripts/ai/ability/generic-ability-fallback.ts
+++ b/src/vscripts/ai/ability/generic-ability-fallback.ts
@@ -1,0 +1,90 @@
+import { GetAbilityBehaviorBits } from '../action/cast-condition';
+import { TryCastBySpec } from '../action/target-dispatch';
+import type { BotBaseAIModifier } from '../hero/bot-base';
+import { TargetSide } from './ability-spec';
+
+/** 为未登记技能提供只面向敌方英雄的最低施法能力。 */
+export class GenericAbilityFallback {
+  static TryCast(ai: BotBaseAIModifier, ability: CDOTABaseAbility): boolean {
+    if (!this.CanCast(ability)) {
+      return false;
+    }
+
+    if (!TryCastBySpec(ai, ability, TargetSide.EnemyHero, undefined)) {
+      return false;
+    }
+
+    print(`[AI] GenericAbility ${ability.GetName()}`);
+    return true;
+  }
+
+  private static CanCast(ability: CDOTABaseAbility): boolean {
+    if (ability.GetLevel() < 2 || !ability.IsFullyCastable() || ability.IsHidden()) {
+      return false;
+    }
+    if (ability.GetAbilityType() === AbilityTypes.ULTIMATE) {
+      return false;
+    }
+
+    const behavior = GetAbilityBehaviorBits(ability);
+    if (this.HasUnsupportedBehavior(behavior)) {
+      return false;
+    }
+    if (this.HasBehavior(behavior, AbilityBehavior.UNIT_TARGET)) {
+      return this.CanTargetEnemyHero(ability);
+    }
+    if (this.HasBehavior(behavior, AbilityBehavior.POINT)) {
+      return this.CanUseEnemyHeroPosition(ability);
+    }
+    return false;
+  }
+
+  private static HasUnsupportedBehavior(behavior: number): boolean {
+    return (
+      this.HasBehavior(behavior, AbilityBehavior.NO_TARGET) ||
+      this.HasBehavior(behavior, AbilityBehavior.CHANNELLED) ||
+      this.HasBehavior(behavior, AbilityBehavior.TOGGLE) ||
+      this.HasBehavior(behavior, AbilityBehavior.AUTOCAST) ||
+      this.HasBehavior(behavior, AbilityBehavior.ATTACK) ||
+      this.HasBehavior(behavior, AbilityBehavior.VECTOR_TARGETING) ||
+      this.HasBehavior(behavior, AbilityBehavior.OPTIONAL_UNIT_TARGET) ||
+      this.HasBehavior(behavior, AbilityBehavior.OPTIONAL_POINT) ||
+      this.HasBehavior(behavior, AbilityBehavior.OPTIONAL_NO_TARGET) ||
+      this.HasBehavior(behavior, AbilityBehavior.ITEM) ||
+      this.HasBehavior(behavior, AbilityBehavior.PASSIVE) ||
+      this.HasBehavior(behavior, AbilityBehavior.HIDDEN) ||
+      this.HasBehavior(behavior, AbilityBehavior.NOT_LEARNABLE)
+    );
+  }
+
+  private static CanTargetEnemyHero(ability: CDOTABaseAbility): boolean {
+    const targetTeam = ability.GetAbilityTargetTeam();
+    if (targetTeam !== UnitTargetTeam.ENEMY && targetTeam !== UnitTargetTeam.BOTH) {
+      return false;
+    }
+
+    return this.HasHeroTargetType(ability.GetAbilityTargetType());
+  }
+
+  private static CanUseEnemyHeroPosition(ability: CDOTABaseAbility): boolean {
+    const targetTeam = ability.GetAbilityTargetTeam();
+    if (
+      targetTeam !== UnitTargetTeam.ENEMY &&
+      targetTeam !== UnitTargetTeam.BOTH &&
+      targetTeam !== UnitTargetTeam.NONE
+    ) {
+      return false;
+    }
+
+    const targetType = ability.GetAbilityTargetType();
+    return targetType === UnitTargetType.NONE || this.HasHeroTargetType(targetType);
+  }
+
+  private static HasHeroTargetType(targetType: DOTA_UNIT_TARGET_TYPE): boolean {
+    return (targetType & UnitTargetType.HERO) !== 0 && (targetType & UnitTargetType.CUSTOM) === 0;
+  }
+
+  private static HasBehavior(behavior: number, flag: AbilityBehavior): boolean {
+    return (behavior & flag) === flag;
+  }
+}

--- a/src/vscripts/ai/action/cast-condition.ts
+++ b/src/vscripts/ai/action/cast-condition.ts
@@ -404,7 +404,7 @@ function isNumberRange(item: object): boolean {
  * 自定义 Lua 技能（BaseClass 为 ability_lua）的 behavior 由引擎以 64 位 userdata 返回，
  * 位运算函数只收 number，直接参与按位与会在运行时抛错。
  */
-function GetAbilityBehaviorBits(ability: CDOTABaseAbility): number {
+export function GetAbilityBehaviorBits(ability: CDOTABaseAbility): number {
   const raw = ability.GetBehavior();
   if (type(raw) === 'number') {
     return raw as number;


### PR DESCRIPTION
## Checklist

- [x] `npm run lint`
- [x] `npm run build:vscripts`
- [x] `npm test -- --runInBand`
- [x] 在 Dota Tools 确认已登记技能只按 spec 释放，不会降级为通用施法
- [x] 在 Dota Tools 确认未登记的单位目标、点目标与混合目标技能使用正确的施法方式
- [x] 在 Dota Tools 确认 1 级、Ultimate、无目标、toggle 与 autocast 技能不会进入通用兜底