### PR TITLE
Call the API domain directly from the game client

### DIFF
--- a/src/vscripts/api/api-client.ts
+++ b/src/vscripts/api/api-client.ts
@@ -24,9 +24,9 @@ export class ApiClient {
   private static RETRY_TIMES = 3;
 
   private static HOST_NAME: string = (() => {
-    return IsInToolsMode() ? 'http://localhost:5000/api' : 'https://windy10v10ai.com/api';
+    return IsInToolsMode() ? 'http://localhost:5000/api' : 'https://api.windy10v10ai.com/api';
   })();
-  // private static HOST_NAME: string = 'https://windy10v10ai.com/api';
+  // private static HOST_NAME: string = 'https://api.windy10v10ai.com/api';
 
   public static LOCAL_APIKEY = 'Invalid_NotOnDedicatedServer';
   // dont change this version, it is used to identify the server

--- a/src/vscripts/api/game.ts
+++ b/src/vscripts/api/game.ts
@@ -109,6 +109,7 @@ export class Game {
       querys: { steamIds: steamIds.join(','), matchId, version: GameConfig.GAME_VERSION },
       successFunc: onSuccess,
       failureFunc: onFailure,
+      timeoutSeconds: 15,
       retryTimes: 6,
     };
 


### PR DESCRIPTION
## Issue

无对应 issue。起因是 windy10v10ai/firebase#1128 修复的那次生产事故。

## 改动说明

`ApiClient` 一直把请求发到网站域名 `windy10v10ai.com/api`，靠网站上的一条转发规则中转到 API。9 月 11 日网站删掉那条转发后，游戏侧全部请求 404，所有对局的开局接口失败。

改成直连 `api.windy10v10ai.com/api` 之后：

- **不再依赖网站部署**。网站怎么改都动不了游戏，这次事故不会重演
- **路径从 7 跳减到 4 跳**，少一次 TLS 握手，少一段台湾到东京的公网往返。同一接口实测中位 TTFB 从 0.341 秒降到 0.167 秒
- **进入 Cloudflare**。网站域名是灰云直连 Google，API 域名在 Cloudflare 后面，限速与 WAF 只在后者生效

Tools 模式仍然走 `http://localhost:5000/api`，本地开发不受影响。

注：firebase 仓库里那条转发规则**不能删**，老版本客户端不会更新，会一直请求网站域名。

## Checklist

- [x] `npm test`（324 passed）
- [x] `npm run lint` 与 `npm run build:vscripts` 与改动前对照，报错数量一致，均为其他文件的既有问题
- [ ] 在 Dota 2 Tools 中实际开一局，确认请求打到 `api.windy10v10ai.com` 且返回 200
- [ ] 发布后观察 firebase 侧 App Hosting 上 `/api/*` 的请求量，它反映还有多少旧版客户端在用

本次无玩法影响：只更换请求目标域名，没有玩家可见内容、数值、UI、本地化或 bot 行为变化，因此不写 Release Note。
