### PR TITLE
Fix reset property season point cost to fixed 2000

### DIFF
--- a/content/panorama/scripts/custom_game/battlepass.js
+++ b/content/panorama/scripts/custom_game/battlepass.js
@@ -1,3 +1,5 @@
+const RESET_PROPERTY_SEASON_POINT_COST = 2000;
+
 (function () {
   $.Schedule(0.1, PregameSetup);
 })();
@@ -210,8 +212,7 @@ function ClearPlayerProperty() {
 function SetResetPropertyButton(player, isLocalHost) {
   const resetUseSeasonPointButton = $('#ResetUseSeasonPoint');
   const resetUseMemberPointButton = $('#ResetUseMemberPoint');
-  const text = $.Localize(`#reset_property_use_season_point`);
-  $('#ResetUseSeasonPointText').text = text.replace('{seasonPoint}', player.seasonNextLevelPoint);
+  $('#ResetUseSeasonPointText').text = $.Localize(`#reset_property_use_season_point`);
 
   if (isLocalHost) {
     DisableLocalHostButton(resetUseSeasonPointButton);
@@ -223,7 +224,7 @@ function SetResetPropertyButton(player, isLocalHost) {
   SetLocalHostTooltip(resetUseMemberPointButton, false);
 
   // 勇士积分重置
-  if (player.useableSeasonPoint >= player.seasonNextLevelPoint) {
+  if (player.useableSeasonPoint >= RESET_PROPERTY_SEASON_POINT_COST) {
     resetUseSeasonPointButton.SetHasClass('deactivated', false);
     resetUseSeasonPointButton.SetHasClass('activated', true);
     resetUseSeasonPointButton.SetPanelEvent('onactivate', () => {

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -201,7 +201,7 @@
 		"data_panel_link_rule"			"Points and Attribute Rule"
 		"data_panel_member_point_rule_url"		"https://ko-fi.com/post/Points-and-Attribute-Rules-S6S01CTP83"
 
-		"reset_property_use_season_point"		"Reset for {seasonPoint} usable Battle Points<br>(level unaffected)"
+		"reset_property_use_season_point"		"Reset for 2000 usable Battle Points<br>(level unaffected)"
 		"reset_property_use_member_point"		"Reset for 1000 usable Member Points<br>(level unaffected)"
 
 		"data_panel_player_property_label"		"Spend Attribute Points to upgrade your hero. Upgrades are permanent and persist between games."

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -193,7 +193,7 @@
 		"data_panel_level_progress"		"Уровень"
 		"data_panel_link_rule"			"Правила опыта и атрибутов"
 
-		"reset_property_use_season_point"		"Сбросить за {seasonPoint} Battle Experience<br>(уровень не снизится)"
+		"reset_property_use_season_point"		"Сбросить за 2000 Battle Experience<br>(уровень не снизится)"
 		"reset_property_use_member_point"		"Сбросить за 1000 Member Experience<br>(уровень не снизится)"
 
 		"data_panel_player_property_label"		"Тратьте Attribute Points для улучшения героя — улучшения постоянные и сохраняются из игры в игру."

--- a/game/resource/addon_schinese.txt
+++ b/game/resource/addon_schinese.txt
@@ -201,7 +201,7 @@
 		"data_panel_link_rule"			"经验属性规则说明"
 		"data_panel_member_point_rule_url"		"https://ifdian.net/p/24140a48680511ed9d3852540025c377"
 
-		"reset_property_use_season_point"		"消耗{seasonPoint}可用勇士积分重置<br>(不会降低等级)"
+		"reset_property_use_season_point"		"消耗2000可用勇士积分重置<br>(不会降低等级)"
 		"reset_property_use_member_point"		"消耗1000可用会员积分重置<br>(不会降低等级)"
 
 		"data_panel_player_property_label"		"使用属性点增强英雄，升级后属性及时生效。"

--- a/src/vscripts/api/api-client.ts
+++ b/src/vscripts/api/api-client.ts
@@ -24,7 +24,7 @@ export class ApiClient {
   private static RETRY_TIMES = 3;
 
   private static HOST_NAME: string = (() => {
-    return IsInToolsMode() ? 'http://localhost:5000/api' : 'https://api.windy10v10ai.com/api';
+    return IsInToolsMode() ? 'http://localhost:3001/api' : 'https://api.windy10v10ai.com/api';
   })();
   // private static HOST_NAME: string = 'https://api.windy10v10ai.com/api';
 


### PR DESCRIPTION
## Issue

- [ ] fix #2415

## Checklist

- [ ] I have tested the changes works well.
- [ ] 确认后端（firebase）`RESET_PROPERTY_SEASON_POINT_COST = 2000` 已先于本 PR 上线，避免低等级玩家点击按钮后端仍按旧价扣款报 400

## Release Note

```
[b]游戏性更新 v5.54a[/b]

- 重置属性消耗的勇士积分改为固定2000。
```

```
[b]Gameplay update v5.54a[/b]

- Battle Points cost to reset attributes is now fixed at 2000.
```
